### PR TITLE
perf(mister): zero-RPC browsing via direct database reads

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,7 +128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
 
 [[package]]
@@ -127,7 +139,7 @@ checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width 0.2.2",
+ "unicode-width",
 ]
 
 [[package]]
@@ -186,9 +198,9 @@ dependencies = [
 
 [[package]]
 name = "cxx"
-version = "1.0.194"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747d8437319e3a2f43d93b341c137927ca70c0f5dabeea7a005a73665e247c7e"
+checksum = "6fe442a792c7c736eea18b32a7f8a3b63cf8aafabda6760042dc2fdeda456291"
 dependencies = [
  "cc",
  "cxx-build",
@@ -201,9 +213,9 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.194"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0f4697d190a142477b16aef7da8a99bfdc41e7e8b1687583c0d23a79c7afc1e"
+checksum = "e3184a94384c663718698311a78a51ac00c484c10b4eeac06fb0a068c5f64fa2"
 dependencies = [
  "cc",
  "codespan-reporting 0.13.1",
@@ -211,20 +223,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "cxx-gen"
-version = "0.7.194"
+version = "0.7.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "035b6c61a944483e8a4b2ad4fb8b13830d63491bd004943716ad16d85dcc64bc"
+checksum = "fb0f24fd8cafa20f043e24372ca5d8273ab1fdce055ee977b989f82c1bcd89b5"
 dependencies = [
  "codespan-reporting 0.13.1",
  "indexmap",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -270,7 +282,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -294,39 +306,39 @@ dependencies = [
  "cxx-qt-gen",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.194"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0956799fa8678d4c50eed028f2de1c0552ae183c76e976cf7ca8c4e36a7c328"
+checksum = "0148d8fd1199329ddf1d157a5e134e51ceff37c6a7ddd38615c399d81cb05d8d"
 dependencies = [
  "clap",
  "codespan-reporting 0.13.1",
  "indexmap",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.194"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23384a836ab4f0ad98ace7e3955ad2de39de42378ab487dc28d3990392cb283a"
+checksum = "52850339faed2eaadd24e286dc1d8268cc6f8a7bd9524d713adc9099566b4c89"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.194"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6acc6b5822b9526adfb4fc377b67128fdd60aac757cc4a741a6278603f763cf"
+checksum = "2c77c856545d886c9bd5215409ebb63b925e262135248b50c79e5a5f194ee47c"
 dependencies = [
  "indexmap",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -393,6 +405,18 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -489,9 +513,27 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "http"
@@ -516,7 +558,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -587,6 +629,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -684,6 +737,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "powerfmt"
@@ -808,6 +867,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,7 +938,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -984,6 +1057,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,7 +1115,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1042,7 +1126,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1110,7 +1194,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1196,7 +1280,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1293,12 +1377,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
 name = "uuid"
 version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1314,6 +1392,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1368,7 +1452,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -1483,6 +1567,7 @@ dependencies = [
  "cxx-qt-lib",
  "libc",
  "qrcode",
+ "rusqlite",
  "semver",
  "tempfile",
  "time",
@@ -1541,7 +1626,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -35,6 +35,9 @@ insta           = { version = "1", features = ["yaml"] }
 tempfile        = "3"
 base64          = "0.22"
 semver          = "1"
+# Bundled so the MiSTer cross-build needs no system sqlite; used only by
+# the read-only media.db art lookup on device.
+rusqlite        = { version = "0.32", features = ["bundled"] }
 
 [workspace.lints.rust]
 unsafe_op_in_unsafe_fn        = "deny"

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -39,9 +39,6 @@ skip = [
     # cxx-qt-build pulls codespan-reporting 0.11 directly; its cxx-gen dep pulls 0.13.
     { crate = "codespan-reporting@0.11.1" },
     { crate = "codespan-reporting@0.13.1" },
-    # codespan-reporting 0.11 → unicode-width 0.1; codespan-reporting 0.13 → 0.2.
-    { crate = "unicode-width@0.1.14" },
-    { crate = "unicode-width@0.2.2" },
     # tempfile+uuid hold getrandom 0.4; rand 0.9 (via tungstenite) brings 0.3.
     # (0.3 is build-script-only in the linux/armv7 filtered graph so cargo-deny
     # doesn't surface it; listing it here would warn as unmatched.)

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -51,6 +51,9 @@ skip = [
     { crate = "thiserror@2.0.18" },
     { crate = "thiserror-impl@1.0.69" },
     { crate = "thiserror-impl@2.0.18" },
+    # rusqlite's hashlink tracks hashbrown one major behind indexmap
+    # (pulled by cxx-qt's build tooling); no rusqlite release aligns them.
+    { crate = "hashbrown@0.14.5" },
 ]
 
 [sources]

--- a/rust/deny.toml
+++ b/rust/deny.toml
@@ -54,6 +54,10 @@ skip = [
     # rusqlite's hashlink tracks hashbrown one major behind indexmap
     # (pulled by cxx-qt's build tooling); no rusqlite release aligns them.
     { crate = "hashbrown@0.14.5" },
+    # cxx/cxx-gen 1.0.195+ moved to syn 3 (RUSTSEC-2026-0202 forces the
+    # bump); serde_derive and the cxx-qt macros remain on syn 2.
+    { crate = "syn@2.0.118" },
+    { crate = "syn@3.0.3" },
 ]
 
 [sources]

--- a/rust/frontend/Cargo.toml
+++ b/rust/frontend/Cargo.toml
@@ -38,6 +38,7 @@ qrcode       = { workspace = true }
 toml         = { workspace = true }
 base64       = { workspace = true }
 semver       = { workspace = true }
+rusqlite     = { workspace = true }
 
 [dev-dependencies]
 tempfile     = { workspace = true }

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -11,6 +11,7 @@ mod media_favorites_db;
 mod media_history_db;
 mod media_image_cache;
 mod media_meta_cache;
+mod media_meta_db;
 mod mister_runtime;
 mod models;
 pub mod system_logos;

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -7,6 +7,7 @@ mod bind;
 pub mod image_overrides;
 mod media_art_db;
 mod media_browse_db;
+mod media_favorites_db;
 mod media_image_cache;
 mod media_meta_cache;
 mod mister_runtime;

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -8,6 +8,7 @@ pub mod image_overrides;
 mod media_art_db;
 mod media_browse_db;
 mod media_favorites_db;
+mod media_history_db;
 mod media_image_cache;
 mod media_meta_cache;
 mod mister_runtime;

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -5,6 +5,7 @@
 #[macro_use]
 mod bind;
 pub mod image_overrides;
+mod media_art_db;
 mod media_image_cache;
 mod media_meta_cache;
 mod mister_runtime;

--- a/rust/frontend/src/lib.rs
+++ b/rust/frontend/src/lib.rs
@@ -6,6 +6,7 @@
 mod bind;
 pub mod image_overrides;
 mod media_art_db;
+mod media_browse_db;
 mod media_image_cache;
 mod media_meta_cache;
 mod mister_runtime;

--- a/rust/frontend/src/media_art_db.rs
+++ b/rust/frontend/src/media_art_db.rs
@@ -119,7 +119,21 @@ fn open_checked(db_path: &Path) -> Result<Connection, String> {
         db_path,
         OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
     )
-    .map_err(|e| e.to_string())?;
+    .map_err(|e| {
+        // A WAL-mode database opened read-only needs the -shm/-wal
+        // sidecars to be accessible; SQLITE_READONLY_CANTINIT is the
+        // specific "cannot initialize WAL under these permissions"
+        // failure, worth naming so a permissions problem on the card
+        // is diagnosable from the log rather than a generic open error.
+        if let rusqlite::Error::SqliteFailure(ffi_err, _) = &e {
+            if ffi_err.extended_code == rusqlite::ffi::SQLITE_READONLY_CANTINIT {
+                return format!(
+                    "WAL sidecar files are not accessible read-only                      (SQLITE_READONLY_CANTINIT) — check permissions on                      the media database directory: {e}"
+                );
+            }
+        }
+        e.to_string()
+    })?;
     conn.busy_timeout(std::time::Duration::from_millis(200))
         .map_err(|e| e.to_string())?;
     let n: i64 = conn

--- a/rust/frontend/src/media_art_db.rs
+++ b/rust/frontend/src/media_art_db.rs
@@ -1,0 +1,494 @@
+// Zaparoo Frontend
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// Read-only artwork-path lookup against Core's media database. Core's
+// scrapers already resolve every gamelist/artwork match and store the
+// result as a plain file path in `MediaProperties` / `MediaTitleProperties`
+// (`docs/scraper.md`: "Path-backed properties persist their text path");
+// reading that answer back lets the frontend serve a cover with one
+// indexed SELECT plus one file read, skipping Core's `media.image`
+// pipeline (globally serialized through a size-1 semaphore) on the very
+// first view — the same architecture Console Mode uses via its own art
+// map.
+//
+// Boundaries, stated for the reader who wants to rip this out:
+// - Strictly read-only. The connection is opened with
+//   `SQLITE_OPEN_READ_ONLY`; this module never writes, checkpoints, or
+//   pragma-tunes Core's database.
+// - Blob-backed properties (`BlobDBID` set) are ignored here and left to
+//   the RPC path. As of Core v2.16 no production scraper writes image
+//   blobs (only tests do), so on a gamelist-scraped card this covers
+//   effectively everything.
+// - Schema drift: the query touches `Media`, `MediaProperties`,
+//   `MediaTitleProperties`, `Tags`. A guard at open verifies those
+//   tables exist and disables the layer loudly if Core ever renames
+//   them, leaving the RPC path as the sole source exactly as before
+//   this module existed.
+// - Concurrency: Core runs the database in WAL mode (readers do not
+//   block its writer and vice versa; Core ships
+//   `concurrent_read_during_tx_test.go` for exactly this shape). A
+//   short busy timeout plus drop-and-reopen on error keeps a mid-scrape
+//   lookup from wedging anything; on any failure the caller falls
+//   through to RPC.
+//
+// `ZAPAROO_FRONTEND_DB_ART=0` disables the layer at runtime for A/B
+// comparison.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+
+use rusqlite::{Connection, OpenFlags};
+use tracing::{debug, info, warn};
+
+use crate::media_image_cache::MediaKey;
+
+const MEDIA_DB_PATH: &str = "/media/fat/zaparoo/media.db";
+
+/// Cap on candidates returned per lookup: bounds the file-read retries
+/// the caller performs when leading candidates point at dead files.
+const MAX_ART_CANDIDATES: usize = 5;
+
+/// Property tags carrying artwork, in default preference order (mirrors
+/// `CORE_DEFAULT_IMAGE_TYPES` in the image cache: the order Core itself
+/// consults when no explicit type is requested).
+const DEFAULT_TYPE_ORDER: &[&str] = &[
+    "image",
+    "thumbnail",
+    "boxart",
+    "boxart3d",
+    "screenshot",
+    "wheel",
+    "titleshot",
+    "map",
+    "marquee",
+    "fanart",
+];
+
+/// A resolved artwork file for a media row.
+#[derive(Debug)]
+pub struct ArtHit {
+    pub path: PathBuf,
+    /// Bare type name (e.g. `"screenshot"`), matching the `type_tag`
+    /// convention of `media.image` responses.
+    pub type_tag: String,
+}
+
+struct ArtDb {
+    conn: Mutex<Option<Connection>>,
+    db_path: PathBuf,
+}
+
+static ART_DB: OnceLock<Option<ArtDb>> = OnceLock::new();
+
+fn art_db() -> Option<&'static ArtDb> {
+    ART_DB
+        .get_or_init(|| {
+            let disabled = std::env::var("ZAPAROO_FRONTEND_DB_ART")
+                .is_ok_and(|v| v == "0" || v.eq_ignore_ascii_case("off"));
+            if disabled {
+                info!("media_art_db: disabled via ZAPAROO_FRONTEND_DB_ART");
+                return None;
+            }
+            let db_path = PathBuf::from(MEDIA_DB_PATH);
+            if !db_path.is_file() {
+                return None;
+            }
+            match open_checked(&db_path) {
+                Ok(conn) => {
+                    info!(db = %db_path.display(), "media_art_db: direct art lookup active");
+                    Some(ArtDb {
+                        conn: Mutex::new(Some(conn)),
+                        db_path,
+                    })
+                }
+                Err(e) => {
+                    warn!("media_art_db: unavailable ({e}), covers use RPC only");
+                    None
+                }
+            }
+        })
+        .as_ref()
+}
+
+/// Open read-only and verify the tables this module queries actually
+/// exist, so a future Core schema change turns the layer off instead of
+/// producing wrong answers.
+fn open_checked(db_path: &Path) -> Result<Connection, String> {
+    let conn = Connection::open_with_flags(
+        db_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|e| e.to_string())?;
+    conn.busy_timeout(std::time::Duration::from_millis(200))
+        .map_err(|e| e.to_string())?;
+    let n: i64 = conn
+        .query_row(
+            "SELECT count(*) FROM sqlite_master WHERE type='table' AND name IN \
+             ('Media','MediaProperties','MediaTitleProperties','Tags')",
+            [],
+            |r| r.get(0),
+        )
+        .map_err(|e| e.to_string())?;
+    if n != 4 {
+        return Err(format!(
+            "expected 4 known tables, found {n} — Core schema changed, refusing to guess"
+        ));
+    }
+    Ok(conn)
+}
+
+/// Resolve artwork candidates for `key`, best first. Callers try each
+/// candidate's file in order — the database can reference files that no
+/// longer exist (an artwork directory reorganized after an early scrape
+/// leaves its old paths behind), so a single answer is not enough: the
+/// next candidate is often the live one. Returns an empty vec on any miss; errors also
+/// drop the cached connection so the next call reopens fresh (covers
+/// Core swapping the database file underneath us during recovery).
+pub fn resolve_art(key: &MediaKey, preferred_types: &[String]) -> Vec<ArtHit> {
+    let Some(db) = art_db() else {
+        return Vec::new();
+    };
+    #[allow(clippy::unwrap_used, reason = "mutex poisoning is unrecoverable")]
+    let mut guard = db.conn.lock().unwrap();
+    if guard.is_none() {
+        match open_checked(&db.db_path) {
+            Ok(c) => *guard = Some(c),
+            Err(e) => {
+                debug!("media_art_db: reopen failed ({e})");
+                return Vec::new();
+            }
+        }
+    }
+    #[allow(clippy::unwrap_used, reason = "populated just above")]
+    let conn = guard.as_ref().unwrap();
+    match resolve_with(conn, key, preferred_types) {
+        Ok(hits) => hits,
+        Err(e) => {
+            debug!(
+                system_id = %key.system_id,
+                path = %key.path,
+                "media_art_db: lookup error ({e}), dropping connection",
+            );
+            *guard = None;
+            Vec::new()
+        }
+    }
+}
+
+fn resolve_with(
+    conn: &Connection,
+    key: &MediaKey,
+    preferred_types: &[String],
+) -> Result<Vec<ArtHit>, rusqlite::Error> {
+    // Collect every Media row this key can identify: the keyed row
+    // first (by media_id when the key carries one), then any other row
+    // sharing the same file path. Core v2.16's arcade hardware
+    // classifications index one physical file under both `Arcade` and a
+    // classification system with artwork bound to only one of the rows — same file,
+    // same art, so a path twin is a legitimate source, and Core's own
+    // gamelist scraper has no folder mapping for the classification
+    // systems (a forced scrape processes 0 entries), leaving those rows
+    // permanently artless on the Core side.
+    let mut rows: Vec<(i64, Option<i64>)> = Vec::new();
+    if let Some(id) = key.media_id {
+        if let Some(row) = conn
+            .query_row(
+                "SELECT DBID, MediaTitleDBID FROM Media WHERE DBID = ?1",
+                [id],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .map(Some)
+            .or_else(ignore_no_rows)?
+        {
+            rows.push(row);
+        }
+    }
+    if !key.path.is_empty() {
+        let mut stmt =
+            conn.prepare_cached("SELECT DBID, MediaTitleDBID FROM Media WHERE Path = ?1 LIMIT 4")?;
+        let found = stmt.query_map([key.path.as_ref()], |r| Ok((r.get(0)?, r.get(1)?)))?;
+        for row in found {
+            let row: (i64, Option<i64>) = row?;
+            if !rows.contains(&row) {
+                rows.push(row);
+            }
+        }
+    }
+    if rows.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Gather ALL candidates across the identified rows, keeping the
+    // natural precedence as a stable tiebreak: keyed row before twins,
+    // media-level before title-level within a row. Then rank by type
+    // preference across the whole set — this mirrors media.image, which
+    // walks the requested types and finds the first level carrying one,
+    // so a preferred `screenshot` at title level beats a non-preferred
+    // `image` at media level.
+    let mut candidates: Vec<(String, String)> = Vec::new();
+    for (media_dbid, title_dbid) in rows {
+        candidates.extend(image_properties(
+            conn,
+            "SELECT t.Tag, p.Text FROM MediaProperties p \
+             JOIN Tags t ON t.DBID = p.TypeTagDBID \
+             WHERE p.MediaDBID = ?1 AND p.BlobDBID IS NULL \
+             AND t.Tag LIKE 'image-%' AND length(coalesce(p.Text,'')) > 0",
+            media_dbid,
+        )?);
+        if let Some(tid) = title_dbid {
+            candidates.extend(image_properties(
+                conn,
+                "SELECT t.Tag, p.Text FROM MediaTitleProperties p \
+                 JOIN Tags t ON t.DBID = p.TypeTagDBID \
+                 WHERE p.MediaTitleDBID = ?1 AND p.BlobDBID IS NULL \
+                 AND t.Tag LIKE 'image-%' AND length(coalesce(p.Text,'')) > 0",
+                tid,
+            )?);
+        }
+    }
+    if candidates.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // Preference rank: position in the caller's list, then the default
+    // order, then unknown-but-still-art types last. `sort_by_key` is
+    // stable, so equal ranks keep the row/level precedence from above.
+    let rank = |tag: &str| -> usize {
+        if let Some(i) = preferred_types.iter().position(|w| w == tag) {
+            return i;
+        }
+        if let Some(i) = DEFAULT_TYPE_ORDER.iter().position(|w| *w == tag) {
+            return preferred_types.len() + i;
+        }
+        preferred_types.len() + DEFAULT_TYPE_ORDER.len()
+    };
+    candidates.sort_by_key(|(tag, _)| rank(tag));
+    candidates.truncate(MAX_ART_CANDIDATES);
+    Ok(candidates
+        .into_iter()
+        .map(|(tag, text)| ArtHit {
+            path: absolute_art_path(&text),
+            type_tag: tag,
+        })
+        .collect())
+}
+
+/// Property paths are `/media/fat/`-absolute on scraped cards. A
+/// relative value would resolve
+/// against the frontend's working directory, which is never right, so
+/// root it at the card instead.
+fn absolute_art_path(text: &str) -> PathBuf {
+    let p = PathBuf::from(text);
+    if p.is_absolute() {
+        p
+    } else {
+        Path::new("/media/fat").join(p)
+    }
+}
+
+/// Fetch `(bare_type, text_path)` image property rows for one entity.
+fn image_properties(
+    conn: &Connection,
+    sql: &str,
+    dbid: i64,
+) -> Result<Vec<(String, String)>, rusqlite::Error> {
+    let mut stmt = conn.prepare_cached(sql)?;
+    let rows = stmt.query_map([dbid], |r| {
+        let tag: String = r.get(0)?;
+        let text: String = r.get(1)?;
+        Ok((tag, text))
+    })?;
+    let mut out = Vec::new();
+    for row in rows {
+        let (tag, text) = row?;
+        let bare = tag.strip_prefix("image-").unwrap_or(&tag).to_string();
+        out.push((bare, text));
+    }
+    Ok(out)
+}
+
+#[allow(clippy::unnecessary_wraps, reason = "or_else adapter shape")]
+fn ignore_no_rows<T>(e: rusqlite::Error) -> Result<Option<T>, rusqlite::Error> {
+    match e {
+        rusqlite::Error::QueryReturnedNoRows => Ok(None),
+        other => Err(other),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::expect_used,
+        clippy::unwrap_used,
+        reason = "tests should fail-fast on unexpected errors"
+    )]
+
+    use super::*;
+
+    fn test_db() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE Tags (DBID INTEGER PRIMARY KEY, Tag TEXT);
+             CREATE TABLE Media (DBID INTEGER PRIMARY KEY, MediaTitleDBID INTEGER, Path TEXT);
+             CREATE TABLE MediaProperties (
+                 DBID INTEGER PRIMARY KEY, MediaDBID INTEGER,
+                 TypeTagDBID INTEGER, Text TEXT, BlobDBID INTEGER);
+             CREATE TABLE MediaTitleProperties (
+                 DBID INTEGER PRIMARY KEY, MediaTitleDBID INTEGER,
+                 TypeTagDBID INTEGER, Text TEXT, BlobDBID INTEGER);
+             INSERT INTO Tags VALUES (1,'image-screenshot'),(2,'image-boxart'),(3,'genre');
+             INSERT INTO Media VALUES (10, 100, '/media/fat/games/X/game.bin');
+             INSERT INTO MediaProperties VALUES (1, 10, 1, '/art/shot.png', NULL);
+             INSERT INTO MediaProperties VALUES (2, 10, 3, 'Action', NULL);
+             INSERT INTO MediaTitleProperties VALUES (1, 100, 2, '/art/box.png', NULL);",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn key() -> MediaKey {
+        MediaKey::new("X", "/media/fat/games/X/game.bin")
+    }
+
+    #[test]
+    fn resolves_candidates_by_path_in_default_type_order() {
+        let conn = test_db();
+        let hits = resolve_with(&conn, &key(), &[]).unwrap();
+        // Default order ranks boxart (title level) above screenshot.
+        assert_eq!(hits[0].type_tag, "boxart");
+        assert_eq!(hits[1].type_tag, "screenshot");
+        assert_eq!(hits[1].path, PathBuf::from("/art/shot.png"));
+    }
+
+    #[test]
+    fn preferred_type_at_title_level_beats_other_type_at_media_level() {
+        // media.image walks the requested types in order and serves the
+        // first level carrying one, so a preferred boxart at title level
+        // outranks a non-preferred screenshot at media level.
+        let conn = test_db();
+        let hits = resolve_with(&conn, &key(), &["boxart".into()]).unwrap();
+        assert_eq!(hits[0].type_tag, "boxart");
+        assert_eq!(hits[0].path, PathBuf::from("/art/box.png"));
+        // The screenshot stays available as the retry candidate.
+        assert_eq!(hits[1].type_tag, "screenshot");
+    }
+
+    #[test]
+    fn dead_media_level_path_keeps_live_screenshot_as_next_candidate() {
+        // The dead-path shape: media-level `image` points at a file that
+        // was deleted, title-level `screenshot` is the live art.
+        // With a screenshot preference the live file ranks FIRST and the
+        // dead one is merely a later candidate.
+        let conn = test_db();
+        conn.execute("UPDATE Tags SET Tag = 'image-image' WHERE DBID = 1", [])
+            .unwrap();
+        conn.execute(
+            "UPDATE MediaProperties SET Text = '/art/deleted-dir/old.jpg' WHERE TypeTagDBID = 1",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "UPDATE Tags SET Tag = 'image-screenshot' WHERE DBID = 2",
+            [],
+        )
+        .unwrap();
+        let hits = resolve_with(&conn, &key(), &["screenshot".into()]).unwrap();
+        assert_eq!(hits[0].type_tag, "screenshot");
+        assert_eq!(hits[0].path, PathBuf::from("/art/box.png"));
+        assert_eq!(hits[1].path, PathBuf::from("/art/deleted-dir/old.jpg"));
+    }
+
+    #[test]
+    fn falls_back_to_title_level_when_media_has_none() {
+        let conn = test_db();
+        conn.execute("DELETE FROM MediaProperties WHERE TypeTagDBID = 1", [])
+            .unwrap();
+        let hits = resolve_with(&conn, &key(), &[]).unwrap();
+        assert_eq!(hits[0].path, PathBuf::from("/art/box.png"));
+        assert_eq!(hits[0].type_tag, "boxart");
+    }
+
+    #[test]
+    fn blob_backed_rows_are_ignored() {
+        let conn = test_db();
+        conn.execute(
+            "UPDATE MediaProperties SET BlobDBID = 7 WHERE TypeTagDBID = 1",
+            [],
+        )
+        .unwrap();
+        // Media-level art is now blob-backed -> skipped; falls to title.
+        let hits = resolve_with(&conn, &key(), &[]).unwrap();
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].type_tag, "boxart");
+    }
+
+    #[test]
+    fn unknown_media_returns_empty() {
+        let conn = test_db();
+        let k = MediaKey::new("X", "/nope");
+        assert!(resolve_with(&conn, &k, &[]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn artless_duplicate_row_borrows_from_path_twin() {
+        // Core v2.16 arcade classifications: same file indexed under a
+        // second system with no art bound. A key carrying the artless
+        // row's media_id must still resolve via the path twin.
+        let conn = test_db();
+        conn.execute(
+            "INSERT INTO Media VALUES (11, 200, '/media/fat/games/X/game.bin')",
+            [],
+        )
+        .unwrap();
+        let mut k = key();
+        k.media_id = Some(11);
+        let hits = resolve_with(&conn, &k, &["screenshot".into()]).unwrap();
+        assert!(!hits.is_empty(), "twin must supply candidates");
+        assert_eq!(hits[0].path, PathBuf::from("/art/shot.png"));
+    }
+
+    #[test]
+    fn keyed_row_art_ranks_before_equal_type_twin() {
+        // Same art type on both rows: stable ordering keeps the keyed
+        // row's own art first.
+        let conn = test_db();
+        conn.execute(
+            "INSERT INTO Media VALUES (11, 200, '/media/fat/games/X/game.bin')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO MediaProperties VALUES (9, 11, 1, '/art/own-shot.png', NULL)",
+            [],
+        )
+        .unwrap();
+        let mut k = key();
+        k.media_id = Some(11);
+        let hits = resolve_with(&conn, &k, &["screenshot".into()]).unwrap();
+        assert_eq!(hits[0].path, PathBuf::from("/art/own-shot.png"));
+    }
+
+    #[test]
+    fn relative_property_paths_root_at_the_card() {
+        assert_eq!(
+            absolute_art_path("games/X/media/screenshot/a.png"),
+            PathBuf::from("/media/fat/games/X/media/screenshot/a.png")
+        );
+        assert_eq!(
+            absolute_art_path("/media/fat/a.png"),
+            PathBuf::from("/media/fat/a.png")
+        );
+    }
+
+    #[test]
+    fn schema_guard_rejects_foreign_database() {
+        let dir = tempfile::tempdir().unwrap();
+        let p = dir.path().join("other.db");
+        Connection::open(&p)
+            .unwrap()
+            .execute_batch("CREATE TABLE unrelated (x);")
+            .unwrap();
+        assert!(open_checked(&p).is_err());
+    }
+}

--- a/rust/frontend/src/media_art_db.rs
+++ b/rust/frontend/src/media_art_db.rs
@@ -43,7 +43,7 @@ use tracing::{debug, info, warn};
 
 use crate::media_image_cache::MediaKey;
 
-const MEDIA_DB_PATH: &str = "/media/fat/zaparoo/media.db";
+pub(crate) const MEDIA_DB_PATH: &str = "/media/fat/zaparoo/media.db";
 
 /// Cap on candidates returned per lookup: bounds the file-read retries
 /// the caller performs when leading candidates point at dead files.
@@ -128,7 +128,9 @@ fn open_checked(db_path: &Path) -> Result<Connection, String> {
         if let rusqlite::Error::SqliteFailure(ffi_err, _) = &e {
             if ffi_err.extended_code == rusqlite::ffi::SQLITE_READONLY_CANTINIT {
                 return format!(
-                    "WAL sidecar files are not accessible read-only                      (SQLITE_READONLY_CANTINIT) — check permissions on                      the media database directory: {e}"
+                    "WAL sidecar files are not accessible read-only \
+                     (SQLITE_READONLY_CANTINIT) — check permissions on \
+                     the media database directory: {e}"
                 );
             }
         }

--- a/rust/frontend/src/media_browse_db.rs
+++ b/rust/frontend/src/media_browse_db.rs
@@ -142,8 +142,21 @@ fn open_checked(db_path: &Path) -> Result<Connection, String> {
 /// answer cannot be produced with full confidence — layer disabled, cache
 /// not serveable, path unknown — and the caller falls through to the RPC
 /// exactly as before this module existed.
-pub fn browse_folder(path: &str, systems: &[String]) -> Option<MediaBrowseResult> {
+///
+/// `cancelled` is polled at each query stage and periodically inside the
+/// row loop so a superseded browse (the user already navigated away)
+/// stops consuming its blocking worker and the database instead of
+/// running the full folder read to completion; a cancelled call returns
+/// `None`, which the caller's ticket check discards anyway.
+pub fn browse_folder(
+    path: &str,
+    systems: &[String],
+    cancelled: &(dyn Fn() -> bool + Sync),
+) -> Option<MediaBrowseResult> {
     let db = browse_db()?;
+    if cancelled() {
+        return None;
+    }
     let started = Instant::now();
     #[allow(clippy::unwrap_used, reason = "Mutex poisoning is unrecoverable")]
     let mut guard = db.conn.lock().unwrap();
@@ -160,8 +173,11 @@ pub fn browse_folder(path: &str, systems: &[String]) -> Option<MediaBrowseResult
         }
     }
     let conn = guard.as_ref()?;
-    match list_folder(conn, path, systems) {
+    match list_folder(conn, path, systems, cancelled) {
         Ok(result) => {
+            if cancelled() {
+                return None;
+            }
             if let Some(r) = &result {
                 debug!(
                     ?path,
@@ -222,6 +238,7 @@ fn list_folder(
     conn: &Connection,
     path: &str,
     systems: &[String],
+    cancelled: &(dyn Fn() -> bool + Sync),
 ) -> rusqlite::Result<Option<MediaBrowseResult>> {
     let cleaned = path.trim_end_matches('/');
     if cleaned.is_empty() {
@@ -257,8 +274,14 @@ fn list_folder(
     if let Some(pid) = parent_id {
         dir_entries(conn, pid, cleaned, systems, &mut entries)?;
     }
+    if cancelled() {
+        return Ok(None);
+    }
     let total_dirs = u32::try_from(entries.len()).unwrap_or(u32::MAX);
-    let total_files = file_entries(conn, &prefix, systems, &mut entries)?;
+    let total_files = file_entries(conn, &prefix, systems, &mut entries, cancelled)?;
+    if cancelled() {
+        return Ok(None);
+    }
 
     // A path the browse cache does not know, with no files either, is
     // one this module cannot vouch for (fresh folder mid-index, virtual
@@ -344,6 +367,7 @@ fn file_entries(
     prefix: &str,
     systems: &[String],
     entries: &mut Vec<BrowseEntry>,
+    cancelled: &(dyn Fn() -> bool + Sync),
 ) -> rusqlite::Result<u32> {
     let fav_ids = tag_ids(conn, "user", "favorite", false)?;
     let img_ids = tag_ids(conn, "property", "image-%", true)?;
@@ -408,6 +432,12 @@ fn file_entries(
     })?;
     let mut total_files = 0u32;
     for row in rows {
+        // Poll every 256 rows: often enough that a superseded read on a
+        // huge folder stops within milliseconds, rare enough to cost
+        // nothing on the happy path.
+        if total_files.is_multiple_of(256) && cancelled() {
+            return Ok(0);
+        }
         let (system_id, sort_name, file_path, dbid, favorite, has_cover) = row?;
         total_files = total_files.saturating_add(1);
         let name = if sort_name.is_empty() {
@@ -512,7 +542,7 @@ mod tests {
     #[test]
     fn dirs_precede_files_and_both_are_name_ordered() {
         let conn = test_db();
-        let result = list_folder(&conn, "/games/C64", &[])
+        let result = list_folder(&conn, "/games/C64", &[], &|| false)
             .expect("query ok")
             .expect("folder listed");
         let names: Vec<&str> = result.entries.iter().map(|e| e.name.as_str()).collect();
@@ -532,7 +562,7 @@ mod tests {
     #[test]
     fn favorite_tag_maps_to_user_favorite() {
         let conn = test_db();
-        let result = list_folder(&conn, "/games/C64", &[])
+        let result = list_folder(&conn, "/games/C64", &[], &|| false)
             .expect("query ok")
             .expect("folder listed");
         let beta = result
@@ -554,7 +584,7 @@ mod tests {
     #[test]
     fn has_cover_from_media_and_title_level_properties() {
         let conn = test_db();
-        let result = list_folder(&conn, "/games/C64", &[])
+        let result = list_folder(&conn, "/games/C64", &[], &|| false)
             .expect("query ok")
             .expect("folder listed");
         let by_name = |n: &str| {
@@ -574,7 +604,7 @@ mod tests {
     #[test]
     fn empty_sortname_falls_back_to_file_stem() {
         let conn = test_db();
-        let result = list_folder(&conn, "/games/C64", &[])
+        let result = list_folder(&conn, "/games/C64", &[], &|| false)
             .expect("query ok")
             .expect("folder listed");
         assert!(result.entries.iter().any(|e| e.name == "Old Game"));
@@ -583,7 +613,7 @@ mod tests {
     #[test]
     fn system_filter_excludes_other_systems() {
         let conn = test_db();
-        let result = list_folder(&conn, "/games/C64", &["C64".to_string()])
+        let result = list_folder(&conn, "/games/C64", &["C64".to_string()], &|| false)
             .expect("query ok")
             .expect("folder listed");
         assert!(result.entries.iter().all(|e| e.name != "NesFile"));
@@ -593,7 +623,7 @@ mod tests {
     #[test]
     fn missing_rows_are_excluded() {
         let conn = test_db();
-        let result = list_folder(&conn, "/games/C64", &[])
+        let result = list_folder(&conn, "/games/C64", &[], &|| false)
             .expect("query ok")
             .expect("folder listed");
         assert!(result.entries.iter().all(|e| e.name != "Missing"));
@@ -607,7 +637,7 @@ mod tests {
             [],
         )
         .expect("update version");
-        assert!(list_folder(&conn, "/games/C64", &[])
+        assert!(list_folder(&conn, "/games/C64", &[], &|| false)
             .expect("query ok")
             .is_none());
     }
@@ -615,7 +645,7 @@ mod tests {
     #[test]
     fn unknown_empty_path_defers_to_rpc() {
         let conn = test_db();
-        assert!(list_folder(&conn, "/games/Amiga", &[])
+        assert!(list_folder(&conn, "/games/Amiga", &[], &|| false)
             .expect("query ok")
             .is_none());
     }
@@ -623,10 +653,10 @@ mod tests {
     #[test]
     fn trailing_slash_input_lists_the_same_folder() {
         let conn = test_db();
-        let a = list_folder(&conn, "/games/C64", &[])
+        let a = list_folder(&conn, "/games/C64", &[], &|| false)
             .expect("query ok")
             .expect("listed");
-        let b = list_folder(&conn, "/games/C64/", &[])
+        let b = list_folder(&conn, "/games/C64/", &[], &|| false)
             .expect("query ok")
             .expect("listed");
         assert_eq!(a.entries.len(), b.entries.len());
@@ -641,7 +671,7 @@ mod tests {
             [],
         )
         .expect("update version");
-        assert!(list_folder(&conn, "/games/C64", &[])
+        assert!(list_folder(&conn, "/games/C64", &[], &|| false)
             .expect("query ok")
             .is_some());
     }
@@ -651,5 +681,17 @@ mod tests {
         assert_eq!(basename_no_ext("/a/b/Game Name.crt"), "Game Name");
         assert_eq!(basename_no_ext("/a/b/noext"), "noext");
         assert_eq!(basename_no_ext("/a/b/.hidden"), ".hidden");
+    }
+
+    #[test]
+    fn cancelled_read_returns_none() {
+        let conn = test_db();
+        // A read whose browse got superseded must bail with None no
+        // matter how far it progressed; the caller's ticket check
+        // discards the slot either way, so None is the only honest
+        // answer a cancelled read can give.
+        assert!(list_folder(&conn, "/games/C64", &[], &|| true)
+            .expect("query ok")
+            .is_none());
     }
 }

--- a/rust/frontend/src/media_browse_db.rs
+++ b/rust/frontend/src/media_browse_db.rs
@@ -1,0 +1,655 @@
+// Zaparoo Frontend
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// Read-only folder listing against Core's media database. Core already
+// maintains everything a browse page needs as plain indexed tables:
+// `BrowseDirs`/`BrowseDirCounts` hold the pre-computed directory tree
+// (built by Core's browse cache), and `Media` rows carry `ParentDir`,
+// `SortName` and `IsMissing` behind the dedicated
+// `idx_media_browse_sort` index. Reading those tables directly lets the
+// frontend load an entire folder in one local query instead of paging
+// it over the RPC one chunk at a time — the same read-only fast-path
+// architecture as `media_art_db`, extended from artwork to listings.
+//
+// The payoff is structural, not just latency: a full local listing has
+// no `has_next_page`, so the paged fetch machinery (background fill,
+// tail prefetch, edge stalls, the append trickle competing with input
+// on the UI thread) simply never engages for a folder served here.
+//
+// Boundaries, stated for the reader who wants to rip this out:
+// - Strictly read-only, same contract as `media_art_db`: opened with
+//   `SQLITE_OPEN_READ_ONLY`, never writes, checkpoints, or tunes.
+// - Folder listings only (`path` non-empty). Root browsing, the letter
+//   index, search, meta, and favorite writes stay on the RPC — roots
+//   need Core's launcher routes, which do not live in the database.
+// - Requires Core's browse cache to be serveable
+//   (`DBConfig.BrowseIndexVersion` of "2" or "2-stale", the same gate
+//   Core itself uses in `sqlBrowseCacheStatus`). Anything else returns
+//   `None` and the caller uses the RPC exactly as before.
+// - Known divergences from Core's `media.browse`, accepted for this
+//   path: no singleton media-container aliasing (zip-as-dir folders
+//   render as plain directories), no rank/date prefix sort-mode
+//   detection (always `SortName ASC, DBID ASC`, Core's `name-asc`),
+//   and no `disambiguatingTags` variant badges.
+// - Schema drift: a guard at open verifies every table this module
+//   touches and disables the layer loudly if Core renames one.
+//
+// `ZAPAROO_FRONTEND_DB_BROWSE=0` disables the layer at runtime for A/B
+// comparison.
+
+use std::fmt::Write as _;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::Instant;
+
+use rusqlite::types::Value;
+use rusqlite::{Connection, OpenFlags, OptionalExtension};
+use tracing::{debug, info, warn};
+
+use zaparoo_core::media_types::{BrowseEntry, MediaBrowseResult, TagInfo};
+
+/// Tables this module queries. Verified at open so a Core schema change
+/// turns the layer off instead of producing wrong listings.
+const REQUIRED_TABLES: &[&str] = &[
+    "Media",
+    "Systems",
+    "MediaTitles",
+    "BrowseDirs",
+    "BrowseDirCounts",
+    "MediaTags",
+    "Tags",
+    "TagTypes",
+    "DBConfig",
+    "MediaProperties",
+    "MediaTitleProperties",
+];
+
+struct BrowseDb {
+    conn: Mutex<Option<Connection>>,
+    db_path: PathBuf,
+}
+
+static BROWSE_DB: OnceLock<Option<BrowseDb>> = OnceLock::new();
+
+fn browse_db() -> Option<&'static BrowseDb> {
+    BROWSE_DB
+        .get_or_init(|| {
+            let disabled = std::env::var("ZAPAROO_FRONTEND_DB_BROWSE")
+                .is_ok_and(|v| v == "0" || v.eq_ignore_ascii_case("off"));
+            if disabled {
+                info!("media_browse_db: disabled via ZAPAROO_FRONTEND_DB_BROWSE");
+                return None;
+            }
+            let db_path = PathBuf::from(crate::media_art_db::MEDIA_DB_PATH);
+            if !db_path.is_file() {
+                return None;
+            }
+            match open_checked(&db_path) {
+                Ok(conn) => {
+                    info!(db = %db_path.display(), "media_browse_db: direct folder listing active");
+                    Some(BrowseDb {
+                        conn: Mutex::new(Some(conn)),
+                        db_path,
+                    })
+                }
+                Err(e) => {
+                    warn!("media_browse_db: unavailable ({e}), listings use RPC only");
+                    None
+                }
+            }
+        })
+        .as_ref()
+}
+
+/// Whether the direct listing layer initialized. A `true` here does not
+/// promise a given folder will resolve — `browse_folder` still returns
+/// `None` per call when the browse cache is not serveable — it only
+/// says the database is present, readable, and schema-compatible.
+pub fn enabled() -> bool {
+    browse_db().is_some()
+}
+
+fn open_checked(db_path: &Path) -> Result<Connection, String> {
+    let conn = Connection::open_with_flags(
+        db_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|e| e.to_string())?;
+    conn.busy_timeout(std::time::Duration::from_millis(200))
+        .map_err(|e| e.to_string())?;
+    let placeholders = vec!["?"; REQUIRED_TABLES.len()].join(",");
+    let sql = format!(
+        "SELECT count(*) FROM sqlite_master WHERE type='table' AND name IN ({placeholders})"
+    );
+    let n: i64 = conn
+        .query_row(
+            &sql,
+            rusqlite::params_from_iter(REQUIRED_TABLES.iter()),
+            |r| r.get(0),
+        )
+        .map_err(|e| e.to_string())?;
+    let expected = i64::try_from(REQUIRED_TABLES.len()).unwrap_or(i64::MAX);
+    if n != expected {
+        return Err(format!(
+            "expected {expected} known tables, found {n} — Core schema changed, refusing to guess"
+        ));
+    }
+    Ok(conn)
+}
+
+/// List a folder straight from the database. Returns `None` whenever the
+/// answer cannot be produced with full confidence — layer disabled, cache
+/// not serveable, path unknown — and the caller falls through to the RPC
+/// exactly as before this module existed.
+pub fn browse_folder(path: &str, systems: &[String]) -> Option<MediaBrowseResult> {
+    let db = browse_db()?;
+    let started = Instant::now();
+    #[allow(clippy::unwrap_used, reason = "Mutex poisoning is unrecoverable")]
+    let mut guard = db.conn.lock().unwrap();
+    if guard.is_none() {
+        // A previous call dropped the connection after an error; try a
+        // fresh open so one transient failure (e.g. mid-reindex churn)
+        // does not disable the layer for the whole session.
+        match open_checked(&db.db_path) {
+            Ok(conn) => *guard = Some(conn),
+            Err(e) => {
+                debug!("media_browse_db: reopen failed ({e})");
+                return None;
+            }
+        }
+    }
+    let conn = guard.as_ref()?;
+    match list_folder(conn, path, systems) {
+        Ok(result) => {
+            if let Some(r) = &result {
+                debug!(
+                    ?path,
+                    entries = r.entries.len(),
+                    total_files = r.total_files,
+                    lookup_ms = started.elapsed().as_millis(),
+                    "media_browse_db: folder listed",
+                );
+            }
+            result
+        }
+        Err(e) => {
+            warn!("media_browse_db: query failed ({e}), dropping connection; listing falls back to RPC");
+            *guard = None;
+            None
+        }
+    }
+}
+
+/// SQL fragment `?N,?N+1,...` for `len` placeholders starting at `start`.
+fn placeholder_list(start: usize, len: usize) -> String {
+    (start..start + len)
+        .map(|i| format!("?{i}"))
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn tag_ids(
+    conn: &Connection,
+    tag_type: &str,
+    tag_match: &str,
+    like: bool,
+) -> rusqlite::Result<Vec<i64>> {
+    let sql = if like {
+        "SELECT t.DBID FROM Tags t JOIN TagTypes tt ON tt.DBID = t.TypeDBID \
+         WHERE tt.Type = ?1 AND t.Tag LIKE ?2 ORDER BY t.DBID"
+    } else {
+        "SELECT t.DBID FROM Tags t JOIN TagTypes tt ON tt.DBID = t.TypeDBID \
+         WHERE tt.Type = ?1 AND t.Tag = ?2 ORDER BY t.DBID"
+    };
+    let mut stmt = conn.prepare(sql)?;
+    let rows = stmt.query_map(rusqlite::params![tag_type, tag_match], |r| r.get(0))?;
+    rows.collect()
+}
+
+/// Display-name fallback for `Media.SortName == ''` (rows predating
+/// Core's sortname migration): the filename without its extension,
+/// mirroring Core's `sqlBrowseFilesFromMedia` fallback.
+fn basename_no_ext(path: &str) -> String {
+    let base = path.rsplit('/').next().unwrap_or(path);
+    match base.rsplit_once('.') {
+        Some((stem, _)) if !stem.is_empty() => stem.to_string(),
+        _ => base.to_string(),
+    }
+}
+
+fn list_folder(
+    conn: &Connection,
+    path: &str,
+    systems: &[String],
+) -> rusqlite::Result<Option<MediaBrowseResult>> {
+    let cleaned = path.trim_end_matches('/');
+    if cleaned.is_empty() {
+        return Ok(None);
+    }
+    // Core stores both `BrowseDirs.Path` and `Media.ParentDir` with a
+    // trailing slash (`browseCacheAncestorDirs`, `ParentDirForMediaPath`).
+    let prefix = format!("{cleaned}/");
+
+    // Same serveability gate as Core's `sqlBrowseCacheStatus`: version
+    // "2" is fresh, "2-stale" is stale-but-served, anything else means
+    // the cache is absent or mid-rebuild and the RPC must answer.
+    let version: Option<String> = conn
+        .query_row(
+            "SELECT Value FROM DBConfig WHERE Name = 'BrowseIndexVersion'",
+            [],
+            |r| r.get(0),
+        )
+        .optional()?;
+    if !matches!(version.as_deref(), Some("2" | "2-stale")) {
+        return Ok(None);
+    }
+
+    let parent_id: Option<i64> = conn
+        .query_row(
+            "SELECT DBID FROM BrowseDirs WHERE Path = ?1",
+            [&prefix],
+            |r| r.get(0),
+        )
+        .optional()?;
+
+    let mut entries: Vec<BrowseEntry> = Vec::new();
+    if let Some(pid) = parent_id {
+        dir_entries(conn, pid, cleaned, systems, &mut entries)?;
+    }
+    let total_dirs = u32::try_from(entries.len()).unwrap_or(u32::MAX);
+    let total_files = file_entries(conn, &prefix, systems, &mut entries)?;
+
+    // A path the browse cache does not know, with no files either, is
+    // one this module cannot vouch for (fresh folder mid-index, virtual
+    // scheme, typo): let the RPC answer rather than asserting "empty".
+    if parent_id.is_none() && total_files == 0 {
+        return Ok(None);
+    }
+
+    Ok(Some(MediaBrowseResult {
+        path: cleaned.to_string(),
+        entries,
+        total_files,
+        total_dirs: Some(total_dirs),
+        pagination: None,
+    }))
+}
+
+/// Immediate child directories, mirroring Core's cache-path query:
+/// recursive per-system file counts summed per child, empty dirs never
+/// present, BINARY name order (dirs always precede files).
+fn dir_entries(
+    conn: &Connection,
+    parent_id: i64,
+    cleaned: &str,
+    systems: &[String],
+    entries: &mut Vec<BrowseEntry>,
+) -> rusqlite::Result<()> {
+    let mut sql = String::from(
+        "SELECT d.Name, SUM(c.FileCount), GROUP_CONCAT(DISTINCT s.SystemID) \
+         FROM BrowseDirCounts c \
+         INNER JOIN BrowseDirs d ON c.ChildDirDBID = d.DBID \
+         INNER JOIN Systems s ON c.SystemDBID = s.DBID \
+         WHERE c.ParentDirDBID = ?1 AND c.ChildDirDBID != c.ParentDirDBID \
+         AND d.IsVirtual = 0",
+    );
+    let mut params: Vec<Value> = vec![Value::Integer(parent_id)];
+    if !systems.is_empty() {
+        let _ = write!(
+            sql,
+            " AND s.SystemID IN ({})",
+            placeholder_list(2, systems.len())
+        );
+        params.extend(systems.iter().map(|s| Value::Text(s.clone())));
+    }
+    sql.push_str(" GROUP BY d.DBID, d.Name ORDER BY d.Name ASC");
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(rusqlite::params_from_iter(params), |r| {
+        let name: String = r.get(0)?;
+        let file_count: i64 = r.get(1)?;
+        let sids: Option<String> = r.get(2)?;
+        Ok((name, file_count, sids))
+    })?;
+    for row in rows {
+        let (name, file_count, sids) = row?;
+        let mut system_ids: Vec<String> = sids
+            .unwrap_or_default()
+            .split(',')
+            .filter(|s| !s.is_empty())
+            .map(str::to_string)
+            .collect();
+        system_ids.sort();
+        system_ids.dedup();
+        entries.push(BrowseEntry {
+            path: format!("{cleaned}/{name}"),
+            name,
+            entry_type: "directory".to_string(),
+            file_count: u32::try_from(file_count).unwrap_or(u32::MAX),
+            system_ids,
+            ..BrowseEntry::default()
+        });
+    }
+    Ok(())
+}
+
+/// Media files with `ParentDir` equal to `prefix`, in Core's `name-asc`
+/// order (`SortName ASC, DBID ASC`, BINARY collation). The favorite
+/// heart and has-cover flag come from tag-id sets resolved the same way
+/// Core does (`resolveUtilityTagDBIDs`, `resolveImagePropertyTagDBIDs`);
+/// `favorite` is stored unpadded (`PadTagValue` only pads all-digit
+/// values). Returns the number of files appended.
+fn file_entries(
+    conn: &Connection,
+    prefix: &str,
+    systems: &[String],
+    entries: &mut Vec<BrowseEntry>,
+) -> rusqlite::Result<u32> {
+    let fav_ids = tag_ids(conn, "user", "favorite", false)?;
+    let img_ids = tag_ids(conn, "property", "image-%", true)?;
+
+    let mut sql = String::from("SELECT s.SystemID, m.SortName, m.Path, m.DBID");
+    let mut params: Vec<Value> = vec![Value::Text(prefix.to_string())];
+    let mut next_ph = 2usize;
+    if fav_ids.is_empty() {
+        sql.push_str(", 0");
+    } else {
+        let _ = write!(
+            sql,
+            ", EXISTS(SELECT 1 FROM MediaTags x WHERE x.MediaDBID = m.DBID AND x.TagDBID IN ({}))",
+            placeholder_list(next_ph, fav_ids.len())
+        );
+        params.extend(fav_ids.iter().map(|id| Value::Integer(*id)));
+        next_ph += fav_ids.len();
+    }
+    if img_ids.is_empty() {
+        // No image property tags exist yet (pre-scrape database). Match
+        // the wire default: report covers as available so the image
+        // path, not the listing, decides.
+        sql.push_str(", 1");
+    } else {
+        let ph_a = placeholder_list(next_ph, img_ids.len());
+        params.extend(img_ids.iter().map(|id| Value::Integer(*id)));
+        next_ph += img_ids.len();
+        let ph_b = placeholder_list(next_ph, img_ids.len());
+        params.extend(img_ids.iter().map(|id| Value::Integer(*id)));
+        next_ph += img_ids.len();
+        let _ = write!(
+            sql,
+            ", (EXISTS(SELECT 1 FROM MediaProperties mp WHERE mp.MediaDBID = m.DBID \
+             AND mp.TypeTagDBID IN ({ph_a})) \
+             OR EXISTS(SELECT 1 FROM MediaTitleProperties tp \
+             WHERE tp.MediaTitleDBID = m.MediaTitleDBID AND tp.TypeTagDBID IN ({ph_b})))"
+        );
+    }
+    sql.push_str(
+        " FROM Media m INNER JOIN Systems s ON m.SystemDBID = s.DBID \
+         WHERE m.ParentDir = ?1 AND m.IsMissing = 0",
+    );
+    if !systems.is_empty() {
+        let _ = write!(
+            sql,
+            " AND s.SystemID IN ({})",
+            placeholder_list(next_ph, systems.len())
+        );
+        params.extend(systems.iter().map(|s| Value::Text(s.clone())));
+    }
+    sql.push_str(" ORDER BY m.SortName ASC, m.DBID ASC");
+
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(rusqlite::params_from_iter(params), |r| {
+        let system_id: String = r.get(0)?;
+        let sort_name: String = r.get(1)?;
+        let file_path: String = r.get(2)?;
+        let dbid: i64 = r.get(3)?;
+        let favorite: bool = r.get(4)?;
+        let has_cover: bool = r.get(5)?;
+        Ok((system_id, sort_name, file_path, dbid, favorite, has_cover))
+    })?;
+    let mut total_files = 0u32;
+    for row in rows {
+        let (system_id, sort_name, file_path, dbid, favorite, has_cover) = row?;
+        total_files = total_files.saturating_add(1);
+        let name = if sort_name.is_empty() {
+            basename_no_ext(&file_path)
+        } else {
+            sort_name
+        };
+        let tags = if favorite {
+            vec![TagInfo {
+                tag: "favorite".to_string(),
+                tag_type: "user".to_string(),
+                label: String::new(),
+            }]
+        } else {
+            Vec::new()
+        };
+        entries.push(BrowseEntry {
+            media_id: Some(dbid),
+            name,
+            path: file_path,
+            entry_type: "media".to_string(),
+            system_id,
+            tags,
+            has_cover,
+            ..BrowseEntry::default()
+        });
+    }
+    Ok(total_files)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(
+        clippy::expect_used,
+        clippy::unwrap_used,
+        clippy::panic,
+        reason = "tests should fail-fast on unexpected errors"
+    )]
+
+    use super::{basename_no_ext, list_folder};
+    use rusqlite::Connection;
+
+    fn test_db() -> Connection {
+        let conn = Connection::open_in_memory().expect("open in-memory db");
+        conn.execute_batch(
+            "CREATE TABLE DBConfig (Name text PRIMARY KEY, Value text);
+             CREATE TABLE Systems (DBID INTEGER PRIMARY KEY, SystemID text, Name text);
+             CREATE TABLE MediaTitles (DBID INTEGER PRIMARY KEY, SystemDBID integer, Name text);
+             CREATE TABLE Media (
+                 DBID INTEGER PRIMARY KEY, MediaTitleDBID integer, SystemDBID integer,
+                 Path text, ParentDir text NOT NULL DEFAULT '',
+                 IsMissing integer NOT NULL DEFAULT 0, SortName text NOT NULL DEFAULT ''
+             );
+             CREATE TABLE BrowseDirs (
+                 DBID integer primary key, ParentDirDBID integer,
+                 Path text unique not null, Name text not null, IsVirtual bool default false
+             );
+             CREATE TABLE BrowseDirCounts (
+                 ParentDirDBID integer not null, ChildDirDBID integer not null,
+                 SystemDBID integer not null, FileCount integer not null
+             );
+             CREATE TABLE TagTypes (DBID INTEGER PRIMARY KEY, Type text);
+             CREATE TABLE Tags (DBID INTEGER PRIMARY KEY, TypeDBID integer, Tag text);
+             CREATE TABLE MediaTags (MediaDBID INTEGER NOT NULL, TagDBID INTEGER NOT NULL);
+             CREATE TABLE MediaProperties (
+                 DBID INTEGER PRIMARY KEY, MediaDBID integer, TypeTagDBID integer,
+                 Text text NOT NULL DEFAULT '', BlobDBID integer
+             );
+             CREATE TABLE MediaTitleProperties (
+                 DBID INTEGER PRIMARY KEY, MediaTitleDBID integer, TypeTagDBID integer,
+                 Text text NOT NULL DEFAULT '', BlobDBID integer
+             );
+             INSERT INTO DBConfig VALUES ('BrowseIndexVersion', '2');
+             INSERT INTO Systems VALUES (1, 'C64', 'Commodore 64');
+             INSERT INTO Systems VALUES (2, 'NES', 'NES');
+             INSERT INTO MediaTitles VALUES (10, 1, 'Alpha');
+             INSERT INTO MediaTitles VALUES (11, 1, 'Beta');
+             INSERT INTO MediaTitles VALUES (12, 2, 'Gamma');
+             INSERT INTO BrowseDirs VALUES (1, NULL, '/games/', 'games', 0);
+             INSERT INTO BrowseDirs VALUES (2, 1, '/games/C64/', 'C64', 0);
+             INSERT INTO BrowseDirs VALUES (3, 2, '/games/C64/Extras/', 'Extras', 0);
+             INSERT INTO BrowseDirCounts VALUES (2, 3, 1, 7);
+             INSERT INTO TagTypes VALUES (1, 'user');
+             INSERT INTO TagTypes VALUES (2, 'property');
+             INSERT INTO Tags VALUES (1, 1, 'favorite');
+             INSERT INTO Tags VALUES (2, 2, 'image-screenshot');
+             -- Files in /games/C64/: Beta sorts before Zeta; the third
+             -- row has an empty SortName and must fall back to its stem.
+             INSERT INTO Media VALUES (100, 11, 1, '/games/C64/beta.crt', '/games/C64/', 0, 'Beta');
+             INSERT INTO Media VALUES (101, 10, 1, '/games/C64/zeta.crt', '/games/C64/', 0, 'Zeta');
+             INSERT INTO Media VALUES (102, 10, 1, '/games/C64/Old Game.crt', '/games/C64/', 0, '');
+             INSERT INTO Media VALUES (103, 12, 2, '/games/C64/nes-file.nes', '/games/C64/', 0, 'NesFile');
+             INSERT INTO Media VALUES (104, 10, 1, '/games/C64/missing.crt', '/games/C64/', 1, 'Missing');
+             INSERT INTO MediaTags VALUES (100, 1);
+             INSERT INTO MediaProperties VALUES (1, 100, 2, '/art/beta.png', NULL);
+             INSERT INTO MediaTitleProperties VALUES (1, 10, 2, '/art/alpha.png', NULL);",
+        )
+        .expect("seed schema");
+        conn
+    }
+
+    #[test]
+    fn dirs_precede_files_and_both_are_name_ordered() {
+        let conn = test_db();
+        let result = list_folder(&conn, "/games/C64", &[])
+            .expect("query ok")
+            .expect("folder listed");
+        let names: Vec<&str> = result.entries.iter().map(|e| e.name.as_str()).collect();
+        // Files order by SortName in SQL, and the empty-SortName row
+        // sorts before everything ('' < 'Beta' in BINARY order) with
+        // its display-name fallback applied only afterwards — exactly
+        // Core's behavior (`sql_browse.go` applies the filename
+        // fallback post-query too).
+        assert_eq!(names, ["Extras", "Old Game", "Beta", "NesFile", "Zeta"]);
+        assert_eq!(result.entries[0].entry_type, "directory");
+        assert_eq!(result.entries[0].file_count, 7);
+        assert_eq!(result.total_dirs, Some(1));
+        assert_eq!(result.total_files, 4);
+        assert!(result.pagination.is_none());
+    }
+
+    #[test]
+    fn favorite_tag_maps_to_user_favorite() {
+        let conn = test_db();
+        let result = list_folder(&conn, "/games/C64", &[])
+            .expect("query ok")
+            .expect("folder listed");
+        let beta = result
+            .entries
+            .iter()
+            .find(|e| e.name == "Beta")
+            .expect("beta present");
+        assert_eq!(beta.tags.len(), 1);
+        assert_eq!(beta.tags[0].tag, "favorite");
+        assert_eq!(beta.tags[0].tag_type, "user");
+        let zeta = result
+            .entries
+            .iter()
+            .find(|e| e.name == "Zeta")
+            .expect("zeta present");
+        assert!(zeta.tags.is_empty());
+    }
+
+    #[test]
+    fn has_cover_from_media_and_title_level_properties() {
+        let conn = test_db();
+        let result = list_folder(&conn, "/games/C64", &[])
+            .expect("query ok")
+            .expect("folder listed");
+        let by_name = |n: &str| {
+            result
+                .entries
+                .iter()
+                .find(|e| e.name == n)
+                .unwrap_or_else(|| panic!("{n} present"))
+        };
+        // Beta: media-level property. Zeta: title 10's title-level
+        // property. NesFile: title 12, no properties anywhere.
+        assert!(by_name("Beta").has_cover);
+        assert!(by_name("Zeta").has_cover);
+        assert!(!by_name("NesFile").has_cover);
+    }
+
+    #[test]
+    fn empty_sortname_falls_back_to_file_stem() {
+        let conn = test_db();
+        let result = list_folder(&conn, "/games/C64", &[])
+            .expect("query ok")
+            .expect("folder listed");
+        assert!(result.entries.iter().any(|e| e.name == "Old Game"));
+    }
+
+    #[test]
+    fn system_filter_excludes_other_systems() {
+        let conn = test_db();
+        let result = list_folder(&conn, "/games/C64", &["C64".to_string()])
+            .expect("query ok")
+            .expect("folder listed");
+        assert!(result.entries.iter().all(|e| e.name != "NesFile"));
+        assert_eq!(result.total_files, 3);
+    }
+
+    #[test]
+    fn missing_rows_are_excluded() {
+        let conn = test_db();
+        let result = list_folder(&conn, "/games/C64", &[])
+            .expect("query ok")
+            .expect("folder listed");
+        assert!(result.entries.iter().all(|e| e.name != "Missing"));
+    }
+
+    #[test]
+    fn unserveable_cache_version_defers_to_rpc() {
+        let conn = test_db();
+        conn.execute(
+            "UPDATE DBConfig SET Value = '1' WHERE Name = 'BrowseIndexVersion'",
+            [],
+        )
+        .expect("update version");
+        assert!(list_folder(&conn, "/games/C64", &[])
+            .expect("query ok")
+            .is_none());
+    }
+
+    #[test]
+    fn unknown_empty_path_defers_to_rpc() {
+        let conn = test_db();
+        assert!(list_folder(&conn, "/games/Amiga", &[])
+            .expect("query ok")
+            .is_none());
+    }
+
+    #[test]
+    fn trailing_slash_input_lists_the_same_folder() {
+        let conn = test_db();
+        let a = list_folder(&conn, "/games/C64", &[])
+            .expect("query ok")
+            .expect("listed");
+        let b = list_folder(&conn, "/games/C64/", &[])
+            .expect("query ok")
+            .expect("listed");
+        assert_eq!(a.entries.len(), b.entries.len());
+        assert_eq!(a.path, b.path);
+    }
+
+    #[test]
+    fn stale_cache_version_still_serves() {
+        let conn = test_db();
+        conn.execute(
+            "UPDATE DBConfig SET Value = '2-stale' WHERE Name = 'BrowseIndexVersion'",
+            [],
+        )
+        .expect("update version");
+        assert!(list_folder(&conn, "/games/C64", &[])
+            .expect("query ok")
+            .is_some());
+    }
+
+    #[test]
+    fn basename_fallback_strips_one_extension() {
+        assert_eq!(basename_no_ext("/a/b/Game Name.crt"), "Game Name");
+        assert_eq!(basename_no_ext("/a/b/noext"), "noext");
+        assert_eq!(basename_no_ext("/a/b/.hidden"), ".hidden");
+    }
+}

--- a/rust/frontend/src/media_favorites_db.rs
+++ b/rust/frontend/src/media_favorites_db.rs
@@ -1,0 +1,338 @@
+// Zaparoo Frontend
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// Read-only favorites listing against Core's media database. The
+// favorites screen needs the complete favorite set for its sort and
+// scope filter, which over the RPC means a chained sequence of
+// `media.search` requests, one Core round trip per thousand rows. The
+// same rows live in plain indexed tables (`MediaTags` against the
+// `user:favorite` tag joined to `Media`), so one local query returns
+// the whole set in milliseconds — the same read-only fast-path
+// architecture as `media_art_db` and `media_browse_db`, extended from
+// artwork and listings to favorites.
+//
+// The store's endpoint subscription remains the freshness signal: a
+// favorite toggle still invalidates `media.favorites`, the refetched
+// first page still applies, and this layer then upgrades the model to
+// the full local set. Writes never come near this module.
+//
+// Known divergences from the RPC set, accepted for this path:
+// - `zapScript` is not populated (it is not stored in the database);
+//   launching uses the media path, which is the primary launch text
+//   anyway. Portable card-write text falls back to the path too.
+// - No `disambiguatingTags` variant badges, matching the listings
+//   module's divergence.
+// - Entries order by `SortName ASC, DBID ASC` rather than Core's
+//   search order; the view's own sort modes are unaffected.
+//
+// `ZAPAROO_FRONTEND_DB_FAVORITES=0` disables the layer at runtime for
+// A/B comparison.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::Instant;
+
+use rusqlite::types::Value;
+use rusqlite::{Connection, OpenFlags};
+use tracing::{debug, info, warn};
+
+use zaparoo_core::media_types::{MediaItem, System, TagInfo};
+
+/// Tables this module queries. Verified at open so a Core schema change
+/// turns the layer off instead of producing wrong favorites.
+const REQUIRED_TABLES: &[&str] = &["Media", "Systems", "MediaTags", "Tags", "TagTypes"];
+
+struct FavoritesDb {
+    conn: Mutex<Option<Connection>>,
+    db_path: PathBuf,
+}
+
+static FAVORITES_DB: OnceLock<Option<FavoritesDb>> = OnceLock::new();
+
+fn favorites_db() -> Option<&'static FavoritesDb> {
+    FAVORITES_DB
+        .get_or_init(|| {
+            let disabled = std::env::var("ZAPAROO_FRONTEND_DB_FAVORITES")
+                .is_ok_and(|v| v == "0" || v.eq_ignore_ascii_case("off"));
+            if disabled {
+                info!("media_favorites_db: disabled via ZAPAROO_FRONTEND_DB_FAVORITES");
+                return None;
+            }
+            let db_path = PathBuf::from(crate::media_art_db::MEDIA_DB_PATH);
+            if !db_path.is_file() {
+                return None;
+            }
+            match open_checked(&db_path) {
+                Ok(conn) => {
+                    info!(db = %db_path.display(), "media_favorites_db: direct favorites listing active");
+                    Some(FavoritesDb {
+                        conn: Mutex::new(Some(conn)),
+                        db_path,
+                    })
+                }
+                Err(e) => {
+                    warn!("media_favorites_db: unavailable ({e}), favorites use RPC only");
+                    None
+                }
+            }
+        })
+        .as_ref()
+}
+
+/// Whether the direct favorites layer initialized. Says the database is
+/// present, readable, and schema-compatible; `favorites` can still
+/// return `None` per call on query errors.
+pub fn enabled() -> bool {
+    favorites_db().is_some()
+}
+
+fn open_checked(db_path: &Path) -> Result<Connection, String> {
+    let conn = Connection::open_with_flags(
+        db_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|e| e.to_string())?;
+    conn.busy_timeout(std::time::Duration::from_millis(200))
+        .map_err(|e| e.to_string())?;
+    let placeholders = vec!["?"; REQUIRED_TABLES.len()].join(",");
+    let sql = format!(
+        "SELECT count(*) FROM sqlite_master WHERE type='table' AND name IN ({placeholders})"
+    );
+    let n: i64 = conn
+        .query_row(
+            &sql,
+            rusqlite::params_from_iter(REQUIRED_TABLES.iter()),
+            |r| r.get(0),
+        )
+        .map_err(|e| e.to_string())?;
+    let expected = i64::try_from(REQUIRED_TABLES.len()).unwrap_or(i64::MAX);
+    if n != expected {
+        return Err(format!(
+            "expected {expected} known tables, found {n} — Core schema changed, refusing to guess"
+        ));
+    }
+    Ok(conn)
+}
+
+/// The complete favorite set, in one query. Returns `None` whenever the
+/// answer cannot be produced with full confidence (layer disabled,
+/// query error) and the caller falls through to the RPC full load; an
+/// empty list is a real answer, not a fallback case.
+///
+/// `cancelled` is polled at each stage and periodically inside the row
+/// loop so a superseded load stops consuming its blocking worker.
+pub fn favorites(cancelled: &(dyn Fn() -> bool + Sync)) -> Option<Vec<MediaItem>> {
+    let db = favorites_db()?;
+    if cancelled() {
+        return None;
+    }
+    let started = Instant::now();
+    #[allow(clippy::unwrap_used, reason = "Mutex poisoning is unrecoverable")]
+    let mut guard = db.conn.lock().unwrap();
+    if guard.is_none() {
+        match open_checked(&db.db_path) {
+            Ok(conn) => *guard = Some(conn),
+            Err(e) => {
+                debug!("media_favorites_db: reopen failed ({e})");
+                return None;
+            }
+        }
+    }
+    let conn = guard.as_ref()?;
+    match list_favorites(conn, cancelled) {
+        Ok(result) => {
+            if cancelled() {
+                return None;
+            }
+            if let Some(items) = &result {
+                debug!(
+                    entries = items.len(),
+                    lookup_ms = started.elapsed().as_millis(),
+                    "media_favorites_db: favorites listed",
+                );
+            }
+            result
+        }
+        Err(e) => {
+            warn!(
+                "media_favorites_db: query failed ({e}), dropping connection; favorites fall back to RPC"
+            );
+            *guard = None;
+            None
+        }
+    }
+}
+
+fn list_favorites(
+    conn: &Connection,
+    cancelled: &(dyn Fn() -> bool + Sync),
+) -> rusqlite::Result<Option<Vec<MediaItem>>> {
+    // Exact-match `user:favorite`, the same resolution Core performs;
+    // the tag is stored unpadded (PadTagValue only pads all-digit
+    // values). No tag rows means no favorites exist yet — an empty
+    // list, not a fallback.
+    let mut stmt = conn.prepare(
+        "SELECT t.DBID FROM Tags t JOIN TagTypes tt ON tt.DBID = t.TypeDBID \
+         WHERE tt.Type = 'user' AND t.Tag = 'favorite' ORDER BY t.DBID",
+    )?;
+    let fav_ids: Vec<i64> = stmt
+        .query_map([], |r| r.get(0))?
+        .collect::<Result<_, _>>()?;
+    if fav_ids.is_empty() {
+        return Ok(Some(Vec::new()));
+    }
+    if cancelled() {
+        return Ok(None);
+    }
+    let placeholders = (1..=fav_ids.len())
+        .map(|i| format!("?{i}"))
+        .collect::<Vec<_>>()
+        .join(",");
+    let sql = format!(
+        "SELECT DISTINCT s.SystemID, s.Name, m.SortName, m.Path, m.DBID \
+         FROM Media m \
+         INNER JOIN Systems s ON m.SystemDBID = s.DBID \
+         INNER JOIN MediaTags mt ON mt.MediaDBID = m.DBID \
+         WHERE mt.TagDBID IN ({placeholders}) AND m.IsMissing = 0 \
+         ORDER BY m.SortName ASC, m.DBID ASC"
+    );
+    let params: Vec<Value> = fav_ids.iter().map(|id| Value::Integer(*id)).collect();
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(rusqlite::params_from_iter(params), |r| {
+        let system_id: String = r.get(0)?;
+        let system_name: String = r.get(1)?;
+        let sort_name: String = r.get(2)?;
+        let path: String = r.get(3)?;
+        let dbid: i64 = r.get(4)?;
+        Ok((system_id, system_name, sort_name, path, dbid))
+    })?;
+    let mut out: Vec<MediaItem> = Vec::new();
+    for row in rows {
+        if out.len().is_multiple_of(256) && cancelled() {
+            return Ok(None);
+        }
+        let (system_id, system_name, sort_name, path, dbid) = row?;
+        let name = if sort_name.is_empty() {
+            basename_no_ext(&path)
+        } else {
+            sort_name
+        };
+        out.push(MediaItem {
+            media_id: Some(dbid),
+            name,
+            path,
+            system: System {
+                id: system_id,
+                name: system_name,
+                ..System::default()
+            },
+            tags: vec![TagInfo {
+                tag: "favorite".to_string(),
+                tag_type: "user".to_string(),
+                label: String::new(),
+            }],
+            ..MediaItem::default()
+        });
+    }
+    Ok(Some(out))
+}
+
+/// Display-name fallback for rows whose `SortName` was never migrated:
+/// the file name with one extension stripped, matching Core's fallback.
+fn basename_no_ext(path: &str) -> String {
+    let file = path
+        .trim_end_matches(['/', '\\'])
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or(path);
+    match file.rsplit_once('.') {
+        Some((stem, _)) if !stem.is_empty() => stem.to_string(),
+        _ => file.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{basename_no_ext, list_favorites};
+    use rusqlite::Connection;
+
+    fn test_db() -> Connection {
+        #[allow(clippy::expect_used, reason = "test setup")]
+        let conn = Connection::open_in_memory().expect("open in-memory db");
+        #[allow(clippy::expect_used, reason = "test setup")]
+        conn.execute_batch(
+            "CREATE TABLE Systems (DBID INTEGER PRIMARY KEY, SystemID TEXT NOT NULL, Name TEXT NOT NULL DEFAULT '');
+             CREATE TABLE Media (
+                 DBID INTEGER PRIMARY KEY,
+                 SystemDBID INTEGER NOT NULL,
+                 Path TEXT NOT NULL,
+                 SortName TEXT NOT NULL DEFAULT '',
+                 IsMissing INTEGER NOT NULL DEFAULT 0
+             );
+             CREATE TABLE TagTypes (DBID INTEGER PRIMARY KEY, Type TEXT NOT NULL);
+             CREATE TABLE Tags (DBID INTEGER PRIMARY KEY, TypeDBID INTEGER NOT NULL, Tag TEXT NOT NULL);
+             CREATE TABLE MediaTags (MediaDBID INTEGER NOT NULL, TagDBID INTEGER NOT NULL);
+             INSERT INTO Systems VALUES (1,'C64','Commodore 64'),(2,'NES','NES');
+             INSERT INTO TagTypes VALUES (1,'user'),(2,'property');
+             INSERT INTO Tags VALUES (10,1,'favorite'),(11,2,'image-boxart');
+             INSERT INTO Media VALUES
+                 (100,1,'/games/C64/Beta.crt','Beta',0),
+                 (101,1,'/games/C64/Old Game.crt','',0),
+                 (102,2,'/games/NES/Zeta.nes','Zeta',0),
+                 (103,1,'/games/C64/Gone.crt','Gone',1),
+                 (104,2,'/games/NES/NotFav.nes','NotFav',0);
+             INSERT INTO MediaTags VALUES (100,10),(101,10),(102,10),(103,10),(104,11);",
+        )
+        .expect("seed schema");
+        conn
+    }
+
+    #[test]
+    fn returns_only_tagged_living_rows_in_name_order() {
+        let conn = test_db();
+        #[allow(clippy::expect_used, reason = "test assertion")]
+        let items = list_favorites(&conn, &|| false)
+            .expect("query ok")
+            .expect("some");
+        let names: Vec<&str> = items.iter().map(|i| i.name.as_str()).collect();
+        // Empty SortName sorts first in BINARY order with the stem
+        // fallback applied afterwards, matching the listings module;
+        // the missing row and the untagged row never appear.
+        assert_eq!(names, ["Old Game", "Beta", "Zeta"]);
+        assert_eq!(items[1].system.id, "C64");
+        assert_eq!(items[1].system.name, "Commodore 64");
+        assert_eq!(items[2].system.id, "NES");
+        assert!(items.iter().all(|i| i.media_id.is_some()));
+        assert!(items.iter().all(|i| i
+            .tags
+            .iter()
+            .any(|t| t.tag == "favorite" && t.tag_type == "user")));
+    }
+
+    #[test]
+    fn no_favorite_tag_yields_empty_list_not_fallback() {
+        let conn = test_db();
+        #[allow(clippy::expect_used, reason = "test setup")]
+        conn.execute_batch("DELETE FROM Tags WHERE Tag='favorite'; DELETE FROM MediaTags;")
+            .expect("clear tags");
+        #[allow(clippy::expect_used, reason = "test assertion")]
+        let items = list_favorites(&conn, &|| false)
+            .expect("query ok")
+            .expect("some");
+        assert!(items.is_empty());
+    }
+
+    #[test]
+    #[allow(clippy::expect_used, reason = "test assertion")]
+    fn cancelled_read_returns_none() {
+        let conn = test_db();
+        assert!(list_favorites(&conn, &|| true).expect("query ok").is_none());
+    }
+
+    #[test]
+    fn basename_fallback_strips_one_extension() {
+        assert_eq!(basename_no_ext("/g/C64/Old Game.crt"), "Old Game");
+        assert_eq!(basename_no_ext("plain"), "plain");
+    }
+}

--- a/rust/frontend/src/media_history_db.rs
+++ b/rust/frontend/src/media_history_db.rs
@@ -1,0 +1,373 @@
+// Zaparoo Frontend
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// Read-only play-history listing against Core's user database. Recents
+// over the RPC pages `media.history` twenty-five raw events at a time
+// and dedupes client-side; the same events live in `user.db`'s
+// `MediaHistory` table (indexed by `StartTime`), so one local window
+// query returns the complete deduplicated list in milliseconds — the
+// same read-only fast-path architecture as the media-database modules,
+// applied to Core's second database file under the same contract.
+//
+// `media_id` is resolved best-effort by attaching the media database
+// read-only and matching path plus system, exactly the resolution Core
+// performs when serving `media.history`; an entry that does not
+// resolve keeps `None`, which the cover pipeline already handles by
+// resolving through `(system, path)`.
+//
+// Timestamps: `StartTime`/`EndTime` are unix seconds in the table and
+// RFC3339 strings on the wire (the Resume feature parses them), so
+// this module formats them the same way. A still-open session has
+// `EndTime` NULL and maps to `ended_at: None`, which Resume relies on.
+//
+// `ZAPAROO_FRONTEND_DB_HISTORY=0` disables the layer at runtime for
+// A/B comparison.
+
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::Instant;
+
+use rusqlite::{Connection, OpenFlags};
+use time::format_description::well_known::Rfc3339;
+use time::OffsetDateTime;
+use tracing::{debug, info, warn};
+
+use zaparoo_core::media_types::MediaHistoryEntry;
+
+/// Core's user database on the card, next to the media database.
+const USER_DB_PATH: &str = "/media/fat/zaparoo/user.db";
+
+/// Tables this module queries in `user.db`. Verified at open so a Core
+/// schema change turns the layer off instead of producing wrong
+/// history.
+const REQUIRED_TABLES: &[&str] = &["MediaHistory"];
+
+struct HistoryDb {
+    conn: Mutex<Option<Connection>>,
+    db_path: PathBuf,
+}
+
+static HISTORY_DB: OnceLock<Option<HistoryDb>> = OnceLock::new();
+
+fn history_db() -> Option<&'static HistoryDb> {
+    HISTORY_DB
+        .get_or_init(|| {
+            let disabled = std::env::var("ZAPAROO_FRONTEND_DB_HISTORY")
+                .is_ok_and(|v| v == "0" || v.eq_ignore_ascii_case("off"));
+            if disabled {
+                info!("media_history_db: disabled via ZAPAROO_FRONTEND_DB_HISTORY");
+                return None;
+            }
+            let db_path = PathBuf::from(USER_DB_PATH);
+            if !db_path.is_file() {
+                return None;
+            }
+            match open_checked(&db_path) {
+                Ok(conn) => {
+                    info!(db = %db_path.display(), "media_history_db: direct history listing active");
+                    Some(HistoryDb {
+                        conn: Mutex::new(Some(conn)),
+                        db_path,
+                    })
+                }
+                Err(e) => {
+                    warn!("media_history_db: unavailable ({e}), history uses RPC only");
+                    None
+                }
+            }
+        })
+        .as_ref()
+}
+
+/// Whether the direct history layer initialized.
+pub fn enabled() -> bool {
+    history_db().is_some()
+}
+
+fn open_checked(db_path: &Path) -> Result<Connection, String> {
+    let conn = Connection::open_with_flags(
+        db_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY
+            | OpenFlags::SQLITE_OPEN_NO_MUTEX
+            | OpenFlags::SQLITE_OPEN_URI,
+    )
+    .map_err(|e| e.to_string())?;
+    conn.busy_timeout(std::time::Duration::from_millis(200))
+        .map_err(|e| e.to_string())?;
+    let placeholders = vec!["?"; REQUIRED_TABLES.len()].join(",");
+    let sql = format!(
+        "SELECT count(*) FROM sqlite_master WHERE type='table' AND name IN ({placeholders})"
+    );
+    let n: i64 = conn
+        .query_row(
+            &sql,
+            rusqlite::params_from_iter(REQUIRED_TABLES.iter()),
+            |r| r.get(0),
+        )
+        .map_err(|e| e.to_string())?;
+    let expected = i64::try_from(REQUIRED_TABLES.len()).unwrap_or(i64::MAX);
+    if n != expected {
+        return Err(format!(
+            "expected {expected} known tables, found {n} — Core schema changed, refusing to guess"
+        ));
+    }
+    // Best-effort media-id resolution: attach the media database
+    // read-only. Attachment failure is not fatal — entries then carry
+    // `media_id: None` and the cover pipeline resolves by path.
+    let media_uri = format!(
+        "file:{}?mode=ro",
+        crate::media_art_db::MEDIA_DB_PATH.replace('?', "%3F")
+    );
+    if let Err(e) = conn.execute("ATTACH DATABASE ?1 AS mediadb", [&media_uri]) {
+        debug!("media_history_db: media db attach failed ({e}); media ids unresolved");
+    }
+    Ok(conn)
+}
+
+fn media_attached(conn: &Connection) -> bool {
+    let Ok(mut stmt) = conn.prepare("PRAGMA database_list") else {
+        return false;
+    };
+    let names = stmt.query_map([], |r| r.get::<_, String>(1));
+    match names {
+        Ok(rows) => rows.flatten().any(|n| n == "mediadb"),
+        Err(_) => false,
+    }
+}
+
+/// The complete deduplicated play history, newest first, in one query.
+/// Returns `None` on any error (caller falls back to the RPC) and an
+/// empty list when there is genuinely no history.
+pub fn history(cancelled: &(dyn Fn() -> bool + Sync)) -> Option<Vec<MediaHistoryEntry>> {
+    let db = history_db()?;
+    if cancelled() {
+        return None;
+    }
+    let started = Instant::now();
+    #[allow(clippy::unwrap_used, reason = "Mutex poisoning is unrecoverable")]
+    let mut guard = db.conn.lock().unwrap();
+    if guard.is_none() {
+        match open_checked(&db.db_path) {
+            Ok(conn) => *guard = Some(conn),
+            Err(e) => {
+                debug!("media_history_db: reopen failed ({e})");
+                return None;
+            }
+        }
+    }
+    let conn = guard.as_ref()?;
+    match list_history(conn, media_attached(conn), cancelled) {
+        Ok(result) => {
+            if cancelled() {
+                return None;
+            }
+            if let Some(items) = &result {
+                debug!(
+                    entries = items.len(),
+                    lookup_ms = started.elapsed().as_millis(),
+                    "media_history_db: history listed",
+                );
+            }
+            result
+        }
+        Err(e) => {
+            warn!(
+                "media_history_db: query failed ({e}), dropping connection; history falls back to RPC"
+            );
+            *guard = None;
+            None
+        }
+    }
+}
+
+fn list_history(
+    conn: &Connection,
+    resolve_media: bool,
+    cancelled: &(dyn Fn() -> bool + Sync),
+) -> rusqlite::Result<Option<Vec<MediaHistoryEntry>>> {
+    // Latest event per media path, mirroring the client-side
+    // `dedupe_latest_by_path` the RPC pages go through; the DBID
+    // tiebreak keeps same-second replays deterministic.
+    let media_join = if resolve_media {
+        "LEFT JOIN mediadb.Media m ON m.Path = h.MediaPath \
+         LEFT JOIN mediadb.Systems s ON s.DBID = m.SystemDBID AND s.SystemID = h.SystemID "
+    } else {
+        ""
+    };
+    let media_id_col = if resolve_media {
+        "CASE WHEN s.SystemID IS NULL THEN NULL ELSE m.DBID END"
+    } else {
+        "NULL"
+    };
+    let sql = format!(
+        "SELECT h.SystemID, h.SystemName, h.MediaName, h.MediaPath, h.LauncherID, \
+                h.StartTime, h.EndTime, h.PlayTime, {media_id_col} \
+         FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY MediaPath \
+               ORDER BY StartTime DESC, DBID DESC) AS rn \
+               FROM MediaHistory WHERE IsDeleted = 0) h \
+         {media_join} \
+         WHERE h.rn = 1 \
+         ORDER BY h.StartTime DESC, h.DBID DESC"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map([], |r| {
+        let system_id: String = r.get(0)?;
+        let system_name: String = r.get(1)?;
+        let media_name: String = r.get(2)?;
+        let media_path: String = r.get(3)?;
+        let launcher_id: String = r.get(4)?;
+        let start_time: i64 = r.get(5)?;
+        let end_time: Option<i64> = r.get(6)?;
+        let play_time: i64 = r.get(7)?;
+        let media_id: Option<i64> = r.get(8)?;
+        Ok((
+            system_id,
+            system_name,
+            media_name,
+            media_path,
+            launcher_id,
+            start_time,
+            end_time,
+            play_time,
+            media_id,
+        ))
+    })?;
+    let mut out: Vec<MediaHistoryEntry> = Vec::new();
+    for row in rows {
+        if out.len().is_multiple_of(256) && cancelled() {
+            return Ok(None);
+        }
+        let (
+            system_id,
+            system_name,
+            media_name,
+            media_path,
+            launcher_id,
+            start_time,
+            end_time,
+            play_time,
+            media_id,
+        ) = row?;
+        out.push(MediaHistoryEntry {
+            media_id,
+            system_id,
+            system_name,
+            media_name,
+            media_path,
+            launcher_id,
+            started_at: rfc3339(start_time),
+            ended_at: end_time.map(rfc3339),
+            play_time: u64::try_from(play_time.max(0)).unwrap_or(0),
+        });
+    }
+    Ok(Some(out))
+}
+
+/// Unix seconds to the RFC3339 form the wire uses. An out-of-range
+/// value (garbage row) formats as the epoch rather than failing the
+/// whole listing.
+fn rfc3339(unix_seconds: i64) -> String {
+    OffsetDateTime::from_unix_timestamp(unix_seconds)
+        .unwrap_or(OffsetDateTime::UNIX_EPOCH)
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{list_history, rfc3339};
+    use rusqlite::Connection;
+
+    fn test_db() -> Connection {
+        #[allow(clippy::expect_used, reason = "test setup")]
+        let conn = Connection::open_in_memory().expect("open in-memory db");
+        #[allow(clippy::expect_used, reason = "test setup")]
+        conn.execute_batch(
+            "CREATE TABLE MediaHistory (
+                 DBID INTEGER PRIMARY KEY,
+                 StartTime INTEGER NOT NULL,
+                 EndTime INTEGER,
+                 SystemID TEXT NOT NULL,
+                 SystemName TEXT NOT NULL,
+                 MediaPath TEXT NOT NULL,
+                 MediaName TEXT NOT NULL,
+                 LauncherID TEXT NOT NULL,
+                 PlayTime INTEGER DEFAULT 0,
+                 IsDeleted INTEGER DEFAULT 0
+             );
+             INSERT INTO MediaHistory
+                 (DBID, StartTime, EndTime, SystemID, SystemName, MediaPath, MediaName, LauncherID, PlayTime, IsDeleted)
+             VALUES
+                 (1, 1000, 1600, 'C64', 'Commodore 64', '/g/C64/A.crt', 'A', 'l', 600, 0),
+                 (2, 2000, 2100, 'C64', 'Commodore 64', '/g/C64/A.crt', 'A', 'l', 100, 0),
+                 (3, 1500, NULL, 'NES', 'NES', '/g/NES/B.nes', 'B', 'l', 0, 0),
+                 (4, 3000, 3100, 'C64', 'Commodore 64', '/g/C64/Del.crt', 'Del', 'l', 10, 1);",
+        )
+        .expect("seed schema");
+        conn
+    }
+
+    #[test]
+    fn dedupes_latest_per_path_newest_first_and_skips_deleted() {
+        let conn = test_db();
+        #[allow(clippy::expect_used, reason = "test assertion")]
+        let items = list_history(&conn, false, &|| false)
+            .expect("query ok")
+            .expect("some");
+        let names: Vec<&str> = items.iter().map(|i| i.media_name.as_str()).collect();
+        assert_eq!(names, ["A", "B"]);
+        // The kept "A" row is the later session, whose end is known.
+        assert_eq!(items[0].started_at, rfc3339(2000));
+        assert_eq!(items[0].ended_at.as_deref(), Some(rfc3339(2100).as_str()));
+        // The open session keeps ended_at None, which Resume relies on.
+        assert!(items[1].ended_at.is_none());
+        assert_eq!(items[0].play_time, 100);
+    }
+
+    #[test]
+    fn media_ids_resolve_via_attached_media_db_with_system_match() {
+        let conn = test_db();
+        #[allow(clippy::expect_used, reason = "test setup")]
+        conn.execute_batch(
+            "ATTACH DATABASE ':memory:' AS mediadb;
+             CREATE TABLE mediadb.Systems (DBID INTEGER PRIMARY KEY, SystemID TEXT NOT NULL);
+             CREATE TABLE mediadb.Media (DBID INTEGER PRIMARY KEY, SystemDBID INTEGER NOT NULL, Path TEXT NOT NULL);
+             INSERT INTO mediadb.Systems VALUES (1,'C64'),(2,'NES');
+             INSERT INTO mediadb.Media VALUES (500,1,'/g/C64/A.crt'),(501,2,'/g/NES/B.nes');",
+        )
+        .expect("attach media");
+        #[allow(clippy::expect_used, reason = "test assertion")]
+        let items = list_history(&conn, true, &|| false)
+            .expect("query ok")
+            .expect("some");
+        assert_eq!(items[0].media_id, Some(500));
+        assert_eq!(items[1].media_id, Some(501));
+    }
+
+    #[test]
+    fn unresolved_paths_keep_media_id_none() {
+        let conn = test_db();
+        #[allow(clippy::expect_used, reason = "test setup")]
+        conn.execute_batch(
+            "ATTACH DATABASE ':memory:' AS mediadb;
+             CREATE TABLE mediadb.Systems (DBID INTEGER PRIMARY KEY, SystemID TEXT NOT NULL);
+             CREATE TABLE mediadb.Media (DBID INTEGER PRIMARY KEY, SystemDBID INTEGER NOT NULL, Path TEXT NOT NULL);",
+        )
+        .expect("attach media");
+        #[allow(clippy::expect_used, reason = "test assertion")]
+        let items = list_history(&conn, true, &|| false)
+            .expect("query ok")
+            .expect("some");
+        assert!(items.iter().all(|i| i.media_id.is_none()));
+    }
+
+    #[test]
+    #[allow(clippy::expect_used, reason = "test assertion")]
+    fn cancelled_read_returns_none() {
+        let conn = test_db();
+        assert!(list_history(&conn, false, &|| true)
+            .expect("query ok")
+            .is_none());
+    }
+}

--- a/rust/frontend/src/media_history_db.rs
+++ b/rust/frontend/src/media_history_db.rs
@@ -188,15 +188,15 @@ fn list_history(
 ) -> rusqlite::Result<Option<Vec<MediaHistoryEntry>>> {
     // Latest event per media path, mirroring the client-side
     // `dedupe_latest_by_path` the RPC pages go through; the DBID
-    // tiebreak keeps same-second replays deterministic.
-    let media_join = if resolve_media {
-        "LEFT JOIN mediadb.Media m ON m.Path = h.MediaPath \
-         LEFT JOIN mediadb.Systems s ON s.DBID = m.SystemDBID AND s.SystemID = h.SystemID "
-    } else {
-        ""
-    };
+    // tiebreak keeps same-second replays deterministic. The media id
+    // resolves through a correlated scalar subquery rather than joins:
+    // a path indexed under two systems (arcade classification twins)
+    // would otherwise duplicate the history row and break the
+    // deduplicated contract this function promises.
     let media_id_col = if resolve_media {
-        "CASE WHEN s.SystemID IS NULL THEN NULL ELSE m.DBID END"
+        "(SELECT m.DBID FROM mediadb.Media m \
+          INNER JOIN mediadb.Systems s ON s.DBID = m.SystemDBID \
+          WHERE m.Path = h.MediaPath AND s.SystemID = h.SystemID LIMIT 1)"
     } else {
         "NULL"
     };
@@ -206,7 +206,6 @@ fn list_history(
          FROM (SELECT *, ROW_NUMBER() OVER (PARTITION BY MediaPath \
                ORDER BY StartTime DESC, DBID DESC) AS rn \
                FROM MediaHistory WHERE IsDeleted = 0) h \
-         {media_join} \
          WHERE h.rn = 1 \
          ORDER BY h.StartTime DESC, h.DBID DESC"
     );
@@ -343,6 +342,40 @@ mod tests {
             .expect("some");
         assert_eq!(items[0].media_id, Some(500));
         assert_eq!(items[1].media_id, Some(501));
+    }
+
+    #[test]
+    fn twin_path_media_rows_do_not_duplicate_history() {
+        let conn = test_db();
+        #[allow(clippy::expect_used, reason = "test setup")]
+        conn.execute_batch(
+            "ATTACH DATABASE ':memory:' AS mediadb;
+             CREATE TABLE mediadb.Systems (DBID INTEGER PRIMARY KEY, SystemID TEXT NOT NULL);
+             CREATE TABLE mediadb.Media (DBID INTEGER PRIMARY KEY, SystemDBID INTEGER NOT NULL, Path TEXT NOT NULL);
+             INSERT INTO mediadb.Systems VALUES (1,'C64'),(2,'C64Alt');
+             -- The same file indexed under two systems: one media row per
+             -- system, identical path. History references the C64 one.
+             INSERT INTO mediadb.Media VALUES (500,1,'/g/C64/A.crt'),(600,2,'/g/C64/A.crt');",
+        )
+        .expect("attach media");
+        #[allow(clippy::expect_used, reason = "test assertion")]
+        let items = list_history(&conn, true, &|| false)
+            .expect("query ok")
+            .expect("some");
+        let a_rows: Vec<_> = items
+            .iter()
+            .filter(|i| i.media_path == "/g/C64/A.crt")
+            .collect();
+        assert_eq!(
+            a_rows.len(),
+            1,
+            "twin media rows must not duplicate history entries"
+        );
+        assert_eq!(
+            a_rows[0].media_id,
+            Some(500),
+            "the id must match the history row's own system"
+        );
     }
 
     #[test]

--- a/rust/frontend/src/media_image_cache.rs
+++ b/rust/frontend/src/media_image_cache.rs
@@ -128,7 +128,14 @@ const SUPPORTED_PLAIN_EXTS: &[&str] = &["png", "jpg", "jpeg", "webp"];
 /// would carry: when non-empty, a hit of a different type is rejected
 /// rather than guessed at, so a typed carousel request never silently
 /// receives the wrong art kind. Returns `None` on any miss or error and
-/// the caller falls through to the disk cache / RPC exactly as before.
+/// the caller falls through to the RPC exactly as before.
+///
+/// Unlike the RPC path there is no `max_size` downscale here: the
+/// original file is returned as-is. Producing a resized variant
+/// locally would mean re-encoding or storing thumbnails, both ruled
+/// out for this path, and decode cost stays bounded regardless
+/// because views decode at their snapped `sourceSize` tier; only the
+/// encoded bytes held in RAM are larger than what Core would send.
 async fn db_art_lookup(
     key: &MediaKey,
     wanted: &[String],

--- a/rust/frontend/src/media_image_cache.rs
+++ b/rust/frontend/src/media_image_cache.rs
@@ -16,7 +16,9 @@
 // **Memory only — never disk.** Zaparoo Core is the canonical
 // persistent store for media images and metadata; the frontend caches
 // in process memory only and re-fetches what it needs after a cold
-// start. MiSTer has under 512 MB of shared system RAM with the frontend
+// start. (On `MiSTer`, a miss first resolves the artwork file directly
+// via `media_art_db` and reads it off the card — a read-only fast path,
+// not a second store.) MiSTer has under 512 MB of shared system RAM with the frontend
 // competing against Core, the FPGA wrapper, and the active core for it,
 // so the cache enforces a strict bytes cap (`CACHE_CAP_BYTES`) with LRU
 // eviction that prefers read entries over still-unread prefetches.
@@ -80,11 +82,24 @@ const CACHE_CAP_BYTES: usize = 128 * 1024 * 1024;
 const MAX_FETCH_ATTEMPTS: u8 = 3;
 
 /// Number of fetch worker tasks pulling from the shared LIFO queue.
-/// Two workers let visible pages fill multiple covers at a time
-/// while keeping Core/WebSocket pressure low on `MiSTer`. If runtime
-/// logs show stalls, resets, or media.image rate-limit errors, tune
-/// this before trying any broader queue changes.
-const FETCH_DRIVER_WORKERS: usize = 2;
+/// Sized for the local fast paths (media.db lookup ~7 ms median, disk
+/// read ~26 ms measured on `MiSTer`): eight workers drain a 30-tile
+/// page burst in well under the old two-worker queue wait (p90 was
+/// 150 ms of queueing against a 20 ms lookup). Core is protected
+/// separately — only the `media.image` RPC branch passes through
+/// `RPC_CONCURRENCY`, so raising this does not add WebSocket pressure.
+const FETCH_DRIVER_WORKERS: usize = 8;
+
+/// Cap on concurrent `media.image` RPC calls across all fetch workers.
+/// Preserves the original two-outstanding-requests politeness toward
+/// Core (which serializes image lookups internally anyway) now that
+/// `FETCH_DRIVER_WORKERS` is sized for the local fast paths instead.
+const RPC_CONCURRENCY: usize = 2;
+
+fn rpc_gate() -> &'static tokio::sync::Semaphore {
+    static GATE: OnceLock<tokio::sync::Semaphore> = OnceLock::new();
+    GATE.get_or_init(|| tokio::sync::Semaphore::new(RPC_CONCURRENCY))
+}
 
 /// Hard cap on pending enqueues in the fetch queue. Sized for a few
 /// dense visual pages (current, lookahead, previous) plus margin, so
@@ -104,6 +119,71 @@ const SUPPORTED_EXTS: &[(&str, &str)] = &[
 ];
 
 const SUPPORTED_PLAIN_EXTS: &[&str] = &["png", "jpg", "jpeg", "webp"];
+
+/// Direct-read: resolve the cover's artwork file from Core's media
+/// database and read it straight off the card. This is the
+/// first-view fast path — no RPC, no semaphore, no base64 — available
+/// because Core already persisted every scraper match as a plain file
+/// path. `wanted` mirrors the `image_types` restriction the RPC request
+/// would carry: when non-empty, a hit of a different type is rejected
+/// rather than guessed at, so a typed carousel request never silently
+/// receives the wrong art kind. Returns `None` on any miss or error and
+/// the caller falls through to the disk cache / RPC exactly as before.
+async fn db_art_lookup(
+    key: &MediaKey,
+    wanted: &[String],
+    queue_wait: Duration,
+) -> Option<FetchOutcome> {
+    let key_owned = key.clone();
+    let wanted_owned = wanted.to_vec();
+    let started = Instant::now();
+    let hit = tokio::task::spawn_blocking(move || {
+        // Try candidates best-first: the database can hold dead paths
+        // (files moved after an old scrape), so a failed read moves on
+        // to the next candidate instead of surrendering to RPC.
+        for hit in crate::media_art_db::resolve_art(&key_owned, &wanted_owned) {
+            if !wanted_owned.is_empty() && !wanted_owned.contains(&hit.type_tag) {
+                continue;
+            }
+            let Some(ext) = hit
+                .path
+                .extension()
+                .and_then(|e| e.to_str())
+                .and_then(ext_from_extension_field)
+            else {
+                continue;
+            };
+            match std::fs::read(&hit.path) {
+                Ok(bytes) if !bytes.is_empty() => return Some((bytes, ext, hit.type_tag)),
+                Ok(_) => {}
+                Err(e) => {
+                    debug!(
+                        art_path = %hit.path.display(),
+                        "media_art_db: art file unreadable ({e}), trying next candidate",
+                    );
+                }
+            }
+        }
+        None
+    })
+    .await
+    .ok()??;
+    let (bytes, ext, type_tag) = hit;
+    debug!(
+        system_id = %key.system_id,
+        path = %key.path,
+        bytes = bytes.len(),
+        lookup_ms = started.elapsed().as_millis(),
+        queue_wait_ms = queue_wait.as_millis(),
+        "media_image_cache: db art direct read",
+    );
+    Some(FetchOutcome::Success {
+        bytes,
+        ext,
+        type_tag,
+    })
+}
+
 const CORE_DEFAULT_IMAGE_TYPES: &[&str] = &[
     "image",
     "thumbnail",
@@ -1357,6 +1437,9 @@ async fn fetch_one(
     if max_size > 0 {
         params.max_size = Some(max_size);
     }
+    if let Some(outcome) = db_art_lookup(&key, &params.image_types, queue_wait).await {
+        return (entry, outcome);
+    }
     debug!(
         system_id = %key.system_id,
         path = %key.path,
@@ -1368,7 +1451,17 @@ async fn fetch_one(
         "media_image_cache: media.image request"
     );
     let fetch_started = Instant::now();
-    let result = store.client().media_image(params).await;
+    // Only the RPC passes through the gate: local lookups above run at
+    // full worker width, while Core never sees more than
+    // `RPC_CONCURRENCY` outstanding image requests.
+    let result = {
+        #[allow(
+            clippy::unwrap_used,
+            reason = "gate semaphore is never closed, acquire cannot fail"
+        )]
+        let _permit = rpc_gate().acquire().await.unwrap();
+        store.client().media_image(params).await
+    };
     let fetch_duration = fetch_started.elapsed();
     let (outcome, decode_duration) = match result {
         Ok(image) => classify_media_image_result(&key, &image),
@@ -2020,7 +2113,7 @@ mod tests {
         // against any future Core regression that lets empty payloads
         // through. We can't drive the decoder directly without a live Store, so exercise the
         // downstream contract: `NoImage` → negative memo, no map
-        // entry, pending cleared. This locks in the behaviour that
+        // entry, pending cleared. This locks in the behavior that
         // empty payloads do not pollute the cache and the
         // `(system_id, path)` is suppressed from refetch.
         let state = Arc::new(RwLock::new(CacheState::new()));

--- a/rust/frontend/src/media_image_cache.rs
+++ b/rust/frontend/src/media_image_cache.rs
@@ -1450,18 +1450,21 @@ async fn fetch_one(
         max_size,
         "media_image_cache: media.image request"
     );
-    let fetch_started = Instant::now();
     // Only the RPC passes through the gate: local lookups above run at
     // full worker width, while Core never sees more than
-    // `RPC_CONCURRENCY` outstanding image requests.
-    let result = {
-        #[allow(
-            clippy::unwrap_used,
-            reason = "gate semaphore is never closed, acquire cannot fail"
-        )]
-        let _permit = rpc_gate().acquire().await.unwrap();
-        store.client().media_image(params).await
-    };
+    // `RPC_CONCURRENCY` outstanding image requests. The gate wait is
+    // timed separately so `fetch_ms` keeps meaning "Core round trip"
+    // and stays comparable with pre-gate logs.
+    let gate_started = Instant::now();
+    #[allow(
+        clippy::unwrap_used,
+        reason = "gate semaphore is never closed, acquire cannot fail"
+    )]
+    let permit = rpc_gate().acquire().await.unwrap();
+    let gate_duration = gate_started.elapsed();
+    let fetch_started = Instant::now();
+    let result = store.client().media_image(params).await;
+    drop(permit);
     let fetch_duration = fetch_started.elapsed();
     let (outcome, decode_duration) = match result {
         Ok(image) => classify_media_image_result(&key, &image),
@@ -1479,6 +1482,7 @@ async fn fetch_one(
         path = %key.path,
         outcome = fetch_outcome_label(&outcome),
         queue_wait_ms = queue_wait.as_millis(),
+        gate_ms = gate_duration.as_millis(),
         fetch_ms = fetch_duration.as_millis(),
         decode_ms = decode_duration.as_millis(),
         "media_image_cache: cover timing",

--- a/rust/frontend/src/media_meta_cache.rs
+++ b/rust/frontend/src/media_meta_cache.rs
@@ -125,9 +125,14 @@ impl MediaMetaCache {
             let store = global_store();
             let cache = global_media_meta_cache();
             for (key, params) in to_fetch {
-                let meta = match store.client().media_meta(params).await {
-                    Ok(result) => Some(result.media),
-                    Err(_) => None,
+                // Direct database resolution first; the RPC remains the
+                // fallback for any None, mirroring the other read paths.
+                let meta = match crate::media_meta_db::media_meta_async(params.clone()).await {
+                    Some(media) => Some(media),
+                    None => match store.client().media_meta(params).await {
+                        Ok(result) => Some(result.media),
+                        Err(_) => None,
+                    },
                 };
                 cache.store(key, meta);
             }

--- a/rust/frontend/src/media_meta_db.rs
+++ b/rust/frontend/src/media_meta_db.rs
@@ -1,0 +1,473 @@
+// Zaparoo Frontend
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// Read-only media metadata against Core's media database. The detail
+// pane and the game-info modal fetch `media.meta` per selection settle;
+// everything the response carries — tags, scraped properties, the
+// title record, available image types — lives in plain indexed tables,
+// so a handful of point lookups replace the round trip. The same
+// read-only fast-path architecture as the other direct modules; the
+// RPC remains the fallback for any `None`.
+//
+// Known divergences from Core's `media.meta`, accepted for this path:
+// - `TagInfo.label` is empty (labels come from Core's tag registry,
+//   not the database); every consumer falls back to the tag value via
+//   `tag_display_value`.
+// - `MediaMetaProperty.content_type`/`blob_size` are not populated
+//   (no consumer reads them from meta); `extension` derives from the
+//   property's file path where one exists.
+//
+// `ZAPAROO_FRONTEND_DB_META=0` disables the layer at runtime for A/B
+// comparison.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, OnceLock};
+use std::time::Instant;
+
+use rusqlite::{Connection, OpenFlags, OptionalExtension};
+use tracing::{debug, info, warn};
+
+use zaparoo_core::media_types::{
+    MediaMeta, MediaMetaParams, MediaMetaProperty, MediaMetaSystemRef, MediaMetaTitle, TagInfo,
+};
+
+/// Tables this module queries. Verified at open so a Core schema change
+/// turns the layer off instead of producing wrong metadata.
+const REQUIRED_TABLES: &[&str] = &[
+    "Media",
+    "MediaTitles",
+    "Systems",
+    "MediaTags",
+    "MediaTitleTags",
+    "Tags",
+    "TagTypes",
+    "MediaProperties",
+    "MediaTitleProperties",
+];
+
+struct MetaDb {
+    conn: Mutex<Option<Connection>>,
+    db_path: PathBuf,
+}
+
+static META_DB: OnceLock<Option<MetaDb>> = OnceLock::new();
+
+fn meta_db() -> Option<&'static MetaDb> {
+    META_DB
+        .get_or_init(|| {
+            let disabled = std::env::var("ZAPAROO_FRONTEND_DB_META")
+                .is_ok_and(|v| v == "0" || v.eq_ignore_ascii_case("off"));
+            if disabled {
+                info!("media_meta_db: disabled via ZAPAROO_FRONTEND_DB_META");
+                return None;
+            }
+            let db_path = PathBuf::from(crate::media_art_db::MEDIA_DB_PATH);
+            if !db_path.is_file() {
+                return None;
+            }
+            match open_checked(&db_path) {
+                Ok(conn) => {
+                    info!(db = %db_path.display(), "media_meta_db: direct metadata active");
+                    Some(MetaDb {
+                        conn: Mutex::new(Some(conn)),
+                        db_path,
+                    })
+                }
+                Err(e) => {
+                    warn!("media_meta_db: unavailable ({e}), metadata uses RPC only");
+                    None
+                }
+            }
+        })
+        .as_ref()
+}
+
+/// Whether the direct metadata layer initialized.
+pub fn enabled() -> bool {
+    meta_db().is_some()
+}
+
+fn open_checked(db_path: &Path) -> Result<Connection, String> {
+    let conn = Connection::open_with_flags(
+        db_path,
+        OpenFlags::SQLITE_OPEN_READ_ONLY | OpenFlags::SQLITE_OPEN_NO_MUTEX,
+    )
+    .map_err(|e| e.to_string())?;
+    conn.busy_timeout(std::time::Duration::from_millis(200))
+        .map_err(|e| e.to_string())?;
+    let placeholders = vec!["?"; REQUIRED_TABLES.len()].join(",");
+    let sql = format!(
+        "SELECT count(*) FROM sqlite_master WHERE type='table' AND name IN ({placeholders})"
+    );
+    let n: i64 = conn
+        .query_row(
+            &sql,
+            rusqlite::params_from_iter(REQUIRED_TABLES.iter()),
+            |r| r.get(0),
+        )
+        .map_err(|e| e.to_string())?;
+    let expected = i64::try_from(REQUIRED_TABLES.len()).unwrap_or(i64::MAX);
+    if n != expected {
+        return Err(format!(
+            "expected {expected} known tables, found {n} — Core schema changed, refusing to guess"
+        ));
+    }
+    Ok(conn)
+}
+
+/// Async wrapper for call sites living on the runtime: the lookup is a
+/// few indexed point queries but still file IO, so it runs on the
+/// blocking pool.
+pub async fn media_meta_async(params: MediaMetaParams) -> Option<MediaMeta> {
+    if !enabled() {
+        return None;
+    }
+    tokio::task::spawn_blocking(move || media_meta(&params))
+        .await
+        .ok()
+        .flatten()
+}
+
+/// Resolve one media row's metadata. Returns `None` whenever the answer
+/// cannot be produced with full confidence (layer disabled, row not
+/// found, query error) and the caller falls through to the RPC.
+pub fn media_meta(params: &MediaMetaParams) -> Option<MediaMeta> {
+    let db = meta_db()?;
+    let started = Instant::now();
+    #[allow(clippy::unwrap_used, reason = "Mutex poisoning is unrecoverable")]
+    let mut guard = db.conn.lock().unwrap();
+    if guard.is_none() {
+        match open_checked(&db.db_path) {
+            Ok(conn) => *guard = Some(conn),
+            Err(e) => {
+                debug!("media_meta_db: reopen failed ({e})");
+                return None;
+            }
+        }
+    }
+    let conn = guard.as_ref()?;
+    match lookup_meta(conn, params) {
+        Ok(result) => {
+            if result.is_some() {
+                debug!(
+                    lookup_ms = started.elapsed().as_millis(),
+                    "media_meta_db: metadata resolved",
+                );
+            }
+            result
+        }
+        Err(e) => {
+            warn!("media_meta_db: query failed ({e}), dropping connection; metadata falls back to RPC");
+            *guard = None;
+            None
+        }
+    }
+}
+
+fn lookup_meta(conn: &Connection, params: &MediaMetaParams) -> rusqlite::Result<Option<MediaMeta>> {
+    // Keyed row: media id when the caller has one, else system + path —
+    // the same resolution order the RPC accepts.
+    let row = if let Some(media_id) = params.media_id {
+        conn.query_row(
+            "SELECT m.DBID, m.MediaTitleDBID, m.Path, m.ParentDir, m.IsMissing, s.SystemID \
+             FROM Media m INNER JOIN Systems s ON s.DBID = m.SystemDBID \
+             WHERE m.DBID = ?1",
+            [media_id],
+            map_media_row,
+        )
+        .optional()?
+    } else if !params.system.is_empty() && !params.path.is_empty() {
+        conn.query_row(
+            "SELECT m.DBID, m.MediaTitleDBID, m.Path, m.ParentDir, m.IsMissing, s.SystemID \
+             FROM Media m INNER JOIN Systems s ON s.DBID = m.SystemDBID \
+             WHERE s.SystemID = ?1 AND m.Path = ?2",
+            rusqlite::params![params.system, params.path],
+            map_media_row,
+        )
+        .optional()?
+    } else {
+        None
+    };
+    let Some((media_dbid, title_dbid, path, parent_dir, is_missing, _system_id)) = row else {
+        return Ok(None);
+    };
+
+    let tags = entity_tags(conn, "MediaTags", "MediaDBID", media_dbid)?;
+    let properties = entity_properties(conn, "MediaProperties", "MediaDBID", media_dbid)?;
+    let available_image_types = image_types_from(&properties);
+
+    let title = conn
+        .query_row(
+            "SELECT t.Slug, t.SecondarySlug, t.Name, t.SlugLength, t.SlugWordCount, s.SystemID \
+             FROM MediaTitles t INNER JOIN Systems s ON s.DBID = t.SystemDBID \
+             WHERE t.DBID = ?1",
+            [title_dbid],
+            |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, Option<String>>(1)?,
+                    r.get::<_, String>(2)?,
+                    r.get::<_, i64>(3)?,
+                    r.get::<_, i64>(4)?,
+                    r.get::<_, String>(5)?,
+                ))
+            },
+        )
+        .optional()?;
+    let title = match title {
+        Some((slug, secondary_slug, name, slug_length, slug_word_count, system_id)) => {
+            let title_tags = entity_tags(conn, "MediaTitleTags", "MediaTitleDBID", title_dbid)?;
+            let title_properties =
+                entity_properties(conn, "MediaTitleProperties", "MediaTitleDBID", title_dbid)?;
+            let title_image_types = image_types_from(&title_properties);
+            MediaMetaTitle {
+                slug,
+                secondary_slug,
+                name,
+                slug_length: u32::try_from(slug_length.max(0)).unwrap_or(0),
+                slug_word_count: u32::try_from(slug_word_count.max(0)).unwrap_or(0),
+                system: MediaMetaSystemRef {
+                    id: system_id,
+                    name: String::new(),
+                },
+                tags: title_tags,
+                properties: title_properties,
+                available_image_types: title_image_types,
+            }
+        }
+        None => MediaMetaTitle::default(),
+    };
+
+    Ok(Some(MediaMeta {
+        path,
+        parent_dir,
+        is_missing,
+        tags,
+        properties,
+        available_image_types,
+        title,
+    }))
+}
+
+type MediaRow = (i64, i64, String, String, bool, String);
+
+fn map_media_row(r: &rusqlite::Row<'_>) -> rusqlite::Result<MediaRow> {
+    Ok((
+        r.get(0)?,
+        r.get(1)?,
+        r.get(2)?,
+        r.get(3)?,
+        r.get(4)?,
+        r.get(5)?,
+    ))
+}
+
+/// Tags attached to a media row or title, as wire `TagInfo` with the
+/// label left empty (consumers fall back to the tag value).
+fn entity_tags(
+    conn: &Connection,
+    join_table: &str,
+    join_col: &str,
+    dbid: i64,
+) -> rusqlite::Result<Vec<TagInfo>> {
+    let sql = format!(
+        "SELECT tt.Type, t.Tag FROM {join_table} j \
+         INNER JOIN Tags t ON t.DBID = j.TagDBID \
+         INNER JOIN TagTypes tt ON tt.DBID = t.TypeDBID \
+         WHERE j.{join_col} = ?1 ORDER BY t.DBID"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map([dbid], |r| {
+        Ok(TagInfo {
+            tag_type: r.get(0)?,
+            tag: r.get(1)?,
+            label: String::new(),
+        })
+    })?;
+    rows.collect()
+}
+
+/// Scraped properties for a media row or title, keyed the wire way:
+/// `property:<tag>`. Extensions derive from the stored file path where
+/// one exists; text-only properties keep `None`.
+fn entity_properties(
+    conn: &Connection,
+    table: &str,
+    join_col: &str,
+    dbid: i64,
+) -> rusqlite::Result<HashMap<String, MediaMetaProperty>> {
+    let sql = format!(
+        "SELECT t.Tag, p.Text FROM {table} p \
+         INNER JOIN Tags t ON t.DBID = p.TypeTagDBID \
+         INNER JOIN TagTypes tt ON tt.DBID = t.TypeDBID \
+         WHERE p.{join_col} = ?1 AND tt.Type = 'property'"
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map([dbid], |r| {
+        Ok((r.get::<_, String>(0)?, r.get::<_, String>(1)?))
+    })?;
+    let mut out = HashMap::new();
+    for row in rows {
+        let (tag, text) = row?;
+        let extension = extension_of(&text);
+        out.insert(
+            format!("property:{tag}"),
+            MediaMetaProperty {
+                text,
+                content_type: String::new(),
+                extension,
+                blob_size: 0,
+            },
+        );
+    }
+    Ok(out)
+}
+
+/// Bare image types ("boxart", "screenshot", plain "image") derived
+/// from the `image*` property tags, matching Core's wire form.
+fn image_types_from(properties: &HashMap<String, MediaMetaProperty>) -> Vec<String> {
+    let mut out: Vec<String> = properties
+        .keys()
+        .filter_map(|key| {
+            let suffix = key.strip_prefix("property:image")?;
+            if suffix.is_empty() {
+                return Some("image".to_string());
+            }
+            let bare = suffix.trim_start_matches('-');
+            (!bare.is_empty()).then(|| bare.to_string())
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+/// Extension (no dot) of a file-path-shaped property value; `None` for
+/// text-only values with no plausible extension.
+fn extension_of(text: &str) -> Option<String> {
+    let name = text.rsplit(['/', '\\']).next()?;
+    let (_, ext) = name.rsplit_once('.')?;
+    let ext = ext.trim().to_ascii_lowercase();
+    (!ext.is_empty() && ext.len() <= 5 && ext.chars().all(|c| c.is_ascii_alphanumeric()))
+        .then_some(ext)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{extension_of, lookup_meta};
+    use rusqlite::Connection;
+    use zaparoo_core::media_types::MediaMetaParams;
+
+    fn test_db() -> Connection {
+        #[allow(clippy::expect_used, reason = "test setup")]
+        let conn = Connection::open_in_memory().expect("open in-memory db");
+        #[allow(clippy::expect_used, reason = "test setup")]
+        conn.execute_batch(
+            "CREATE TABLE Systems (DBID INTEGER PRIMARY KEY, SystemID TEXT NOT NULL);
+             CREATE TABLE MediaTitles (
+                 DBID INTEGER PRIMARY KEY, SystemDBID INTEGER NOT NULL,
+                 Slug TEXT NOT NULL, Name TEXT NOT NULL, SecondarySlug TEXT,
+                 SlugLength INTEGER DEFAULT 0, SlugWordCount INTEGER DEFAULT 0
+             );
+             CREATE TABLE Media (
+                 DBID INTEGER PRIMARY KEY, MediaTitleDBID INTEGER NOT NULL,
+                 SystemDBID INTEGER NOT NULL, Path TEXT NOT NULL,
+                 ParentDir TEXT NOT NULL DEFAULT '', SortName TEXT NOT NULL DEFAULT '',
+                 IsMissing INTEGER NOT NULL DEFAULT 0
+             );
+             CREATE TABLE TagTypes (DBID INTEGER PRIMARY KEY, Type TEXT NOT NULL);
+             CREATE TABLE Tags (DBID INTEGER PRIMARY KEY, TypeDBID INTEGER NOT NULL, Tag TEXT NOT NULL);
+             CREATE TABLE MediaTags (MediaDBID INTEGER NOT NULL, TagDBID INTEGER NOT NULL);
+             CREATE TABLE MediaTitleTags (MediaTitleDBID INTEGER NOT NULL, TagDBID INTEGER NOT NULL);
+             CREATE TABLE MediaProperties (
+                 DBID INTEGER PRIMARY KEY, MediaDBID INTEGER NOT NULL,
+                 TypeTagDBID INTEGER NOT NULL, Text TEXT NOT NULL DEFAULT '', BlobDBID INTEGER
+             );
+             CREATE TABLE MediaTitleProperties (
+                 DBID INTEGER PRIMARY KEY, MediaTitleDBID INTEGER NOT NULL,
+                 TypeTagDBID INTEGER NOT NULL, Text TEXT NOT NULL DEFAULT '', BlobDBID INTEGER
+             );
+             INSERT INTO Systems VALUES (1,'C64');
+             INSERT INTO MediaTitles VALUES (50,1,'beta','Beta','beta-alt',4,1);
+             INSERT INTO Media VALUES (100,50,1,'/g/C64/Beta.crt','/g/C64/','Beta',0);
+             INSERT INTO TagTypes VALUES (1,'user'),(2,'property'),(3,'region');
+             INSERT INTO Tags VALUES
+                 (10,1,'favorite'),(11,2,'image-boxart'),(12,2,'description'),
+                 (13,3,'europe'),(14,2,'image-screenshot');
+             INSERT INTO MediaTags VALUES (100,10),(100,13);
+             INSERT INTO MediaTitleTags VALUES (50,13);
+             INSERT INTO MediaProperties VALUES (1,100,11,'/art/beta-box.png',NULL);
+             INSERT INTO MediaTitleProperties VALUES
+                 (1,50,12,'A fine game.',NULL),(2,50,14,'/art/beta-shot.jpg',NULL);",
+        )
+        .expect("seed schema");
+        conn
+    }
+
+    #[test]
+    fn resolves_by_system_and_path_with_full_shape() {
+        let conn = test_db();
+        #[allow(clippy::expect_used, reason = "test assertion")]
+        let meta = lookup_meta(&conn, &MediaMetaParams::for_media("C64", "/g/C64/Beta.crt"))
+            .expect("query ok")
+            .expect("resolved");
+        assert_eq!(meta.path, "/g/C64/Beta.crt");
+        assert_eq!(meta.parent_dir, "/g/C64/");
+        assert!(!meta.is_missing);
+        assert!(meta
+            .tags
+            .iter()
+            .any(|t| t.tag == "favorite" && t.tag_type == "user"));
+        assert!(meta
+            .tags
+            .iter()
+            .any(|t| t.tag == "europe" && t.tag_type == "region"));
+        let boxart = &meta.properties["property:image-boxart"];
+        assert_eq!(boxart.extension.as_deref(), Some("png"));
+        assert_eq!(meta.available_image_types, ["boxart"]);
+        assert_eq!(meta.title.name, "Beta");
+        assert_eq!(meta.title.slug, "beta");
+        assert_eq!(meta.title.secondary_slug.as_deref(), Some("beta-alt"));
+        assert_eq!(meta.title.system.id, "C64");
+        assert_eq!(
+            meta.title.properties["property:description"].text,
+            "A fine game."
+        );
+        assert_eq!(meta.title.available_image_types, ["screenshot"]);
+        assert!(meta.title.tags.iter().any(|t| t.tag == "europe"));
+    }
+
+    #[test]
+    fn resolves_by_media_id() {
+        let conn = test_db();
+        let params = MediaMetaParams {
+            media_id: Some(100),
+            ..MediaMetaParams::default()
+        };
+        #[allow(clippy::expect_used, reason = "test assertion")]
+        let meta = lookup_meta(&conn, &params)
+            .expect("query ok")
+            .expect("resolved");
+        assert_eq!(meta.title.slug, "beta");
+    }
+
+    #[test]
+    #[allow(clippy::expect_used, reason = "test assertion")]
+    fn unknown_row_defers_to_rpc() {
+        let conn = test_db();
+        assert!(
+            lookup_meta(&conn, &MediaMetaParams::for_media("C64", "/nope"))
+                .expect("query ok")
+                .is_none()
+        );
+    }
+
+    #[test]
+    #[allow(clippy::expect_used, reason = "test assertion")]
+    fn extension_heuristic_rejects_prose() {
+        assert_eq!(extension_of("/a/b.png").as_deref(), Some("png"));
+        assert_eq!(extension_of("A fine game. Really"), None);
+        assert_eq!(extension_of("noext"), None);
+    }
+}

--- a/rust/frontend/src/models/alternate_versions.rs
+++ b/rust/frontend/src/models/alternate_versions.rs
@@ -165,14 +165,17 @@ async fn discover_alternate_versions(
     if system_id != ARCADE_SYSTEM_ID || name.trim().is_empty() || selected_path.trim().is_empty() {
         return Ok(Vec::new());
     }
-    let canonical_title = client
-        .media_meta(MediaMetaParams::for_media(
-            system_id.to_string(),
-            selected_path.to_string(),
-        ))
-        .await
-        .ok()
-        .map(|result| result.media.title.name.trim().to_string())
+    let meta_params = MediaMetaParams::for_media(system_id.to_string(), selected_path.to_string());
+    let canonical_media = match crate::media_meta_db::media_meta_async(meta_params.clone()).await {
+        Some(media) => Some(media),
+        None => client
+            .media_meta(meta_params)
+            .await
+            .ok()
+            .map(|result| result.media),
+    };
+    let canonical_title = canonical_media
+        .map(|media| media.title.name.trim().to_string())
         .filter(|title| !title.is_empty())
         .unwrap_or_else(|| name.trim().to_string());
     let result = client

--- a/rust/frontend/src/models/app_status.rs
+++ b/rust/frontend/src/models/app_status.rs
@@ -74,6 +74,7 @@ pub struct AppStatusRust {
     /// `MIN_CORE_VERSION` as a `QString`, exposed so the warning message has
     /// a single source of truth for the required version.
     min_core_version: QString,
+    direct_meta: bool,
 }
 
 impl Default for AppStatusRust {
@@ -86,6 +87,7 @@ impl Default for AppStatusRust {
             core_version_supported: true,
             core_version_checked: false,
             min_core_version: QString::from(MIN_CORE_VERSION),
+            direct_meta: false,
         }
     }
 }
@@ -129,6 +131,9 @@ pub mod ffi {
         #[qproperty(bool, core_version_supported)]
         #[qproperty(bool, core_version_checked)]
         #[qproperty(QString, min_core_version)]
+        /// True when the direct-database metadata layer initialized;
+        /// QML shortens the detail settle debounce accordingly.
+        #[qproperty(bool, direct_meta)]
         type AppStatus = super::AppStatusRust;
     }
 
@@ -140,6 +145,10 @@ impl Initialize for ffi::AppStatus {
     fn initialize(mut self: Pin<&mut Self>) {
         let started = std::time::Instant::now();
         crate::startup_trace("rust:model AppStatus init start");
+        // Seeded once: the layer's availability is decided at first
+        // touch and stable for the process lifetime.
+        let direct_meta = crate::media_meta_db::enabled();
+        self.as_mut().set_direct_meta(direct_meta);
         bind_catalog_status(self.as_mut());
         bind_link_state(self.as_mut());
         bind_core_version(self);

--- a/rust/frontend/src/models/favorites.rs
+++ b/rust/frontend/src/models/favorites.rs
@@ -355,12 +355,27 @@ fn project(status: &ResourceStatus<MediaSearchResult>) -> (Option<PageSnapshot>,
     }
 }
 
-fn apply_state(
-    mut model: Pin<&mut ffi::FavoritesModel>,
-    (data, err): (Option<PageSnapshot>, String),
-) {
+fn apply_state(model: Pin<&mut ffi::FavoritesModel>, (data, err): (Option<PageSnapshot>, String)) {
+    if let Some(snapshot) = data {
+        // Direct-first: the store's Ready is the trigger and the local
+        // read is the content; the RPC page it delivered is only
+        // applied when the local read cannot answer. Freshness paths
+        // (favorite toggles, reconnects) stay intact while the painted
+        // list always comes from the complete local set.
+        if crate::media_favorites_db::enabled() {
+            spawn_direct_ready(model, snapshot);
+        } else {
+            apply_ready_page(model, snapshot);
+        }
+    } else {
+        apply_pending_or_error(model, &err);
+    }
+}
+
+fn apply_ready_page(mut model: Pin<&mut ffi::FavoritesModel>, snapshot: PageSnapshot) {
     let apply_started = Instant::now();
-    if let Some((entries, has_next_page, next_cursor)) = data {
+    {
+        let (entries, has_next_page, next_cursor) = snapshot;
         if model.nav_timing.is_none() {
             model.as_mut().rust_mut().nav_timing = Some(NavTiming::new("cache"));
         }
@@ -419,7 +434,125 @@ fn apply_state(
         if has_next_page && !model.cover_requests_paused {
             model.as_mut().fetch_more();
         }
-    } else if err.is_empty() {
+    }
+}
+
+/// Direct-first Ready handling: bump the chain, read the complete
+/// local favorite set, and paint it; the RPC page in `snapshot`
+/// applies only when the local read cannot answer.
+fn spawn_direct_ready(mut model: Pin<&mut ffi::FavoritesModel>, snapshot: PageSnapshot) {
+    model.as_mut().rust_mut().seq.fetch_add(1, Ordering::SeqCst);
+    let seq = model.rust().seq.clone();
+    let ticket = seq.load(Ordering::SeqCst);
+    let qt_thread = model.qt_thread();
+    global_handle().spawn(async move {
+        let cancel_seq = seq.clone();
+        let direct = tokio::task::spawn_blocking(move || {
+            crate::media_favorites_db::favorites(&|| cancel_seq.load(Ordering::SeqCst) != ticket)
+        })
+        .await
+        .ok()
+        .flatten();
+        let _ = qt_thread.queue(move |model| {
+            if seq.load(Ordering::SeqCst) != ticket {
+                return;
+            }
+            match direct {
+                Some(entries) => apply_direct_full_paint(model, entries),
+                None => apply_ready_page(model, snapshot),
+            }
+        });
+    });
+}
+
+/// Early paint: fired from the Pending branch so a cold entry shows the
+/// complete local set in tens of milliseconds instead of waiting for
+/// the store's first network Ready, which then re-confirms it.
+fn spawn_direct_early_paint(model: &Pin<&mut ffi::FavoritesModel>) {
+    if !crate::media_favorites_db::enabled() || model.count > 0 {
+        return;
+    }
+    let seq = model.rust().seq.clone();
+    let ticket = seq.load(Ordering::SeqCst);
+    let qt_thread = model.qt_thread();
+    global_handle().spawn(async move {
+        let cancel_seq = seq.clone();
+        let direct = tokio::task::spawn_blocking(move || {
+            crate::media_favorites_db::favorites(&|| cancel_seq.load(Ordering::SeqCst) != ticket)
+        })
+        .await
+        .ok()
+        .flatten();
+        let Some(entries) = direct else {
+            return;
+        };
+        let _ = qt_thread.queue(move |model| {
+            if model.rust().seq.load(Ordering::SeqCst) != ticket {
+                return;
+            }
+            apply_direct_full_paint(model, entries);
+        });
+    });
+}
+
+/// Land the complete local favorite set as a first-class paint: the
+/// direct counterpart of `apply_ready_page` with terminal pagination,
+/// serving both the cold entry and every store-triggered refresh.
+fn apply_direct_full_paint(mut model: Pin<&mut ffi::FavoritesModel>, entries: Vec<MediaItem>) {
+    let apply_started = Instant::now();
+    if model.nav_timing.is_none() {
+        model.as_mut().rust_mut().nav_timing = Some(NavTiming::new("direct"));
+    }
+    if let Some(timing) = model.as_mut().rust_mut().nav_timing.as_mut() {
+        timing.set_source("direct");
+        timing.mark_request_done();
+    }
+    model.as_mut().ensure_cover_subscription();
+    if !model.cover_requests_paused {
+        enqueue_favorites_covers(&entries);
+    }
+    let count = i32::try_from(entries.len()).unwrap_or(i32::MAX);
+    clear_current_detail_state(model.as_mut());
+    let displays = compute_favorites_disambig_displays(&entries, model.show_original_filenames);
+    model.as_mut().begin_reset_model();
+    {
+        let mut rust = model.as_mut().rust_mut();
+        rust.entries = entries;
+        rust.disambig_displays = displays;
+        rust.count = count;
+        rust.next_cursor = None;
+    }
+    model.as_mut().end_reset_model();
+    model.as_mut().count_changed();
+    if let Some(timing) = model.as_mut().rust_mut().nav_timing.as_mut() {
+        timing.mark_apply_done();
+    }
+    info!(
+        apply_ms = apply_started.elapsed().as_millis(),
+        "favorites: apply_direct_full_paint timing",
+    );
+    if model.has_next_page {
+        model.as_mut().set_has_next_page(false);
+    }
+    if model.cover_requests_paused {
+        disarm_cover_gate(model.as_mut());
+        if model.loading {
+            model.as_mut().set_loading(false);
+        }
+        finish_nav_timing(model.as_mut(), "covers-paused", 0);
+    } else {
+        arm_cover_gate(model.as_mut());
+    }
+    if model.loading_more {
+        model.as_mut().set_loading_more(false);
+    }
+    if !model.error_message.is_empty() {
+        model.as_mut().set_error_message(QString::default());
+    }
+}
+
+fn apply_pending_or_error(mut model: Pin<&mut ffi::FavoritesModel>, err: &str) {
+    if err.is_empty() {
         if model.nav_timing.is_none() {
             model.as_mut().rust_mut().nav_timing = Some(NavTiming::new("network"));
         } else if let Some(timing) = model.as_mut().rust_mut().nav_timing.as_mut() {
@@ -443,6 +576,7 @@ fn apply_state(
         if model.has_next_page {
             model.as_mut().set_has_next_page(false);
         }
+        spawn_direct_early_paint(&model);
     } else {
         // Same disarm as the Pending branch — an Errored transition
         // doesn't reset entries, so a callback queued during the prior
@@ -460,7 +594,7 @@ fn apply_state(
             model.as_mut().set_has_next_page(false);
         }
     }
-    let qerr = QString::from(err.as_str());
+    let qerr = QString::from(err);
     if model.error_message != qerr {
         model.as_mut().set_error_message(qerr);
     }

--- a/rust/frontend/src/models/game_info.rs
+++ b/rust/frontend/src/models/game_info.rs
@@ -105,10 +105,11 @@ impl ffi::GameInfo {
         let qt_thread = self.qt_thread();
         let store = global_store();
         global_handle().spawn(async move {
-            let result = store
-                .client()
-                .media_meta(MediaMetaParams::for_media(system.clone(), path.clone()))
-                .await;
+            let params = MediaMetaParams::for_media(system.clone(), path.clone());
+            let result = match crate::media_meta_db::media_meta_async(params.clone()).await {
+                Some(media) => Ok(zaparoo_core::media_types::MediaMetaResult { media }),
+                None => store.client().media_meta(params).await,
+            };
             let _ = qt_thread.queue(move |mut model| {
                 if seq.load(Ordering::SeqCst) != ticket {
                     return;

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -1239,7 +1239,10 @@ impl ffi::GamesModel {
         let qt_thread = self.qt_thread();
         let store = global_store();
         global_handle().spawn(async move {
-            let result = store.client().media_meta(params).await;
+            let result = match crate::media_meta_db::media_meta_async(params.clone()).await {
+                Some(media) => Ok(zaparoo_core::media_types::MediaMetaResult { media }),
+                None => store.client().media_meta(params).await,
+            };
             let _ = qt_thread.queue(move |mut model| {
                 if seq.load(Ordering::SeqCst) != ticket {
                     return;
@@ -1729,7 +1732,11 @@ async fn resolve_media_capable_directory_run_text(
     fallback_text: Option<String>,
 ) -> Option<String> {
     if let Some(params) = meta_params {
-        match client.media_meta(params).await {
+        let resolved = match crate::media_meta_db::media_meta_async(params.clone()).await {
+            Some(media) => Ok(zaparoo_core::media_types::MediaMetaResult { media }),
+            None => client.media_meta(params).await,
+        };
+        match resolved {
             Ok(result) if !result.media.path.trim().is_empty() => return Some(result.media.path),
             Ok(_) => warn!(
                 "singleton launch path resolve returned empty path for {}; trying folder browse",

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -1516,8 +1516,11 @@ impl ffi::GamesModel {
             global_handle().spawn(async move {
                 let query_path = path_direct.clone();
                 let query_systems = systems_direct.clone();
+                let cancel_seq = seq_direct.clone();
                 let direct = tokio::task::spawn_blocking(move || {
-                    crate::media_browse_db::browse_folder(&query_path, &query_systems)
+                    crate::media_browse_db::browse_folder(&query_path, &query_systems, &|| {
+                        cancel_seq.load(Ordering::SeqCst) != ticket
+                    })
                 })
                 .await
                 .ok()

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -1504,6 +1504,11 @@ impl ffi::GamesModel {
         // serveable, unknown path, query error) falls through to the
         // exact RPC subscribe this method always performed.
         if !path.is_empty() && crate::media_browse_db::enabled() {
+            // Mirror the RPC path's Pending status so the query window
+            // shows the loading cue instead of an empty view: the RPC
+            // flow gets this from the store's status stream, the direct
+            // flow must say it itself.
+            apply_status(self.as_mut(), ResourceStatus::Loading);
             let qt_thread = self.qt_thread();
             let seq_direct = seq.clone();
             let path_direct = path.clone();

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -120,7 +120,11 @@ const DEFAULT_PAGE_SIZE: i32 = 15;
 // the visible and next pages, so a large `FETCH_MORE_CHUNK_SIZE` no
 // longer floods the cover queue.
 const FETCH_MORE_CHUNK_SIZE: i32 = 100;
-const FETCH_MORE_RAPID_CHUNK_SIZE: i32 = 300;
+// Core's max_results ceiling. media.browse costs the same round trip
+// whether it returns 300 rows or 1000 on a large folder (the server-side
+// listing dominates), so rapid scrolling buys the biggest runway one
+// call can provide: ~100 list-layout pages per fetch instead of ~30.
+const FETCH_MORE_RAPID_CHUNK_SIZE: i32 = 1000;
 // Ceiling for a jump-to-letter fetch (Core's `max_results` cap). A position
 // jump must load every row up to the target before
 // `PagedGrid._commitPendingTarget` can land on it; doing that as the 12-row

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -120,11 +120,15 @@ const DEFAULT_PAGE_SIZE: i32 = 15;
 // the visible and next pages, so a large `FETCH_MORE_CHUNK_SIZE` no
 // longer floods the cover queue.
 const FETCH_MORE_CHUNK_SIZE: i32 = 100;
-// Core's max_results ceiling. media.browse costs the same round trip
-// whether it returns 300 rows or 1000 on a large folder (the server-side
-// listing dominates), so rapid scrolling buys the biggest runway one
-// call can provide: ~100 list-layout pages per fetch instead of ~30.
-const FETCH_MORE_RAPID_CHUNK_SIZE: i32 = 1000;
+// Rapid-scroll chunk. Bigger chunks are not free: measured on device,
+// media.browse response time grows superlinearly with chunk size on a
+// large folder (a max-size 1000-row request costs several seconds while
+// a 100-row request returns in well under one), and a blocked pager
+// waits that whole time. 300 buys ~30 list pages of runway per fetch
+// while keeping the worst-case wait at the loaded edge short. The
+// background folder fill (GamesScreen.qml) is what makes edge waits
+// rare; this chunk only sets how painful one is when it happens.
+const FETCH_MORE_RAPID_CHUNK_SIZE: i32 = 300;
 // Ceiling for a jump-to-letter fetch (Core's `max_results` cap). A position
 // jump must load every row up to the target before
 // `PagedGrid._commitPendingTarget` can land on it; doing that as the 12-row

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -55,7 +55,7 @@ use zaparoo_core::endpoints::readers_write::ReadersWriteMutation;
 use zaparoo_core::endpoints::run::RunMutation;
 use zaparoo_core::media_types::{
     BrowseEntry, MediaBrowseIndexParams, MediaBrowseParams, MediaBrowseResult, MediaMeta,
-    MediaMetaParams, MediaTagsUpdateParams, ReadersWriteParams, RunParams, TagInfo,
+    MediaMetaParams, MediaTagsUpdateParams, Pagination, ReadersWriteParams, RunParams, TagInfo,
 };
 use zaparoo_core::platform::{self, Platform};
 use zaparoo_core::remote_resource::ResourceStatus;
@@ -1517,6 +1517,7 @@ impl ffi::GamesModel {
                 .await
                 .ok()
                 .flatten();
+                let qt_thread_tail = qt_thread.clone();
                 let _ = qt_thread.queue(move |mut model| {
                     if seq_direct.load(Ordering::SeqCst) != ticket {
                         return;
@@ -1524,7 +1525,13 @@ impl ffi::GamesModel {
                     match direct {
                         Some(result) => {
                             mark_nav_source(model.as_mut(), "direct");
-                            apply_status(model, ResourceStatus::Ready(result));
+                            apply_direct_listing(
+                                model,
+                                result,
+                                ticket,
+                                seq_direct,
+                                &qt_thread_tail,
+                            );
                         }
                         None => subscribe_browse_endpoint(
                             model,
@@ -1540,6 +1547,83 @@ impl ffi::GamesModel {
         }
         subscribe_browse_endpoint(self, path, systems, ticket, seq);
     }
+}
+
+/// Hand a complete direct listing to the model: paint first, bulk the
+/// rest. A model reset costs the UI thread roughly linear time in row
+/// count (measured on device at a few milliseconds per row, so a
+/// two-thousand-row folder froze entry for several seconds), while
+/// inserts beyond the viewport stay cheap because tile delegates are
+/// retention-gated. The reset therefore carries only the first page,
+/// and the remainder lands as bulk inserts queued behind the paint.
+/// During the gap the model reports `has_next_page = true` (synthetic
+/// pagination, no cursor) with `loading_more` held true, so the
+/// saved-selection chase keeps waiting and every fetch path no-ops
+/// instead of firing an RPC; the last chunk flips both off, and the
+/// resulting `onCountChanged` re-runs the restore against the full
+/// listing.
+fn apply_direct_listing(
+    mut model: Pin<&mut ffi::GamesModel>,
+    mut result: MediaBrowseResult,
+    ticket: u64,
+    seq: Arc<AtomicU64>,
+    qt_thread: &cxx_qt::CxxQtThread<ffi::GamesModel>,
+) {
+    let head_len = usize::try_from(model.page_size.max(1)).unwrap_or(30);
+    if result.entries.len() <= head_len.saturating_mul(2) {
+        apply_status(model, ResourceStatus::Ready(result));
+        return;
+    }
+    let tail = result.entries.split_off(head_len);
+    result.pagination = Some(Pagination {
+        has_next_page: true,
+        page_size: 0,
+        next_cursor: None,
+    });
+    apply_status(model.as_mut(), ResourceStatus::Ready(result));
+    // Same Qt-thread call as the head apply: QML cannot observe the gap
+    // between the reset and this flag, so no fetch can slip in between.
+    model.as_mut().set_loading_more(true);
+    queue_direct_tail(qt_thread, tail, ticket, seq);
+}
+
+/// One bulk insert per event-loop turn keeps the paint responsive
+/// between chunks; the jump path uses the same size for the same
+/// reason. Stale chunks self-disarm on the browse ticket: a newer
+/// `start_initial_browse` owns the model and resets its own flags.
+const DIRECT_TAIL_CHUNK: usize = 1000;
+
+fn queue_direct_tail(
+    qt_thread: &cxx_qt::CxxQtThread<ffi::GamesModel>,
+    mut tail: Vec<BrowseEntry>,
+    ticket: u64,
+    seq: Arc<AtomicU64>,
+) {
+    let rest = if tail.len() > DIRECT_TAIL_CHUNK {
+        tail.split_off(DIRECT_TAIL_CHUNK)
+    } else {
+        Vec::new()
+    };
+    let qt_thread_next = qt_thread.clone();
+    let _ = qt_thread.queue(move |mut model| {
+        if seq.load(Ordering::SeqCst) != ticket {
+            return;
+        }
+        let started = Instant::now();
+        let entries = transform_entries(tail, platform::current().as_ref());
+        insert_sub_batch(model.as_mut(), entries);
+        debug!(
+            insert_ms = started.elapsed().as_millis(),
+            remaining = rest.len(),
+            "games: direct tail chunk",
+        );
+        if rest.is_empty() {
+            model.as_mut().set_loading_more(false);
+            model.as_mut().set_has_next_page(false);
+            return;
+        }
+        queue_direct_tail(&qt_thread_next, rest, ticket, seq);
+    });
 }
 
 /// Subscribe to the store-backed `media.browse` endpoint and wire its

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -1493,49 +1493,108 @@ impl ffi::GamesModel {
         let seq = self.rust().seq.clone();
         let ticket = seq.fetch_add(1, Ordering::SeqCst) + 1;
 
-        let max_results = u32::try_from(self.page_size.max(1)).unwrap_or(u32::from(u16::MAX));
-        let resource = global_store().subscribe::<MediaBrowseEndpoint>(BrowseArgs::new(
-            path,
-            systems,
-            max_results,
-        ));
-        let mut status_rx = resource.subscribe();
-
-        // Spawn the watcher BEFORE applying the sync seed. If
-        // `apply_status` recurses into `start_initial_browse` (auto-nav
-        // cascade on a single-folder result), the inner call's
-        // `watcher.take().abort()` cleans up this handle correctly —
-        // doing this in the other order leaks the inner watcher when
-        // the outer call later overwrites `self.watcher`.
-        let qt_thread = self.qt_thread();
-        let snapshot = status_rx.borrow_and_update().clone();
-        if let Some(timing) = self.as_mut().rust_mut().nav_timing.as_mut() {
-            if matches!(snapshot, ResourceStatus::Ready(_)) {
-                timing.set_source("cache");
-                timing.mark_request_done();
-            }
-        }
-        let seq_for_loop = seq.clone();
-        let handle = global_handle().spawn(async move {
-            while status_rx.changed().await.is_ok() {
-                let snapshot = status_rx.borrow_and_update().clone();
-                let seq_for_closure = seq_for_loop.clone();
-                let _ = qt_thread.queue(move |model| {
-                    if seq_for_closure.load(Ordering::SeqCst) != ticket {
+        // MiSTer fast path: list the folder straight from Core's media
+        // database (`media_browse_db`) and hand the result to the same
+        // Ready pipeline the RPC feeds. A full local listing arrives in
+        // one piece with no further pages, so the paged fetch machinery
+        // (background fill, tail prefetch, edge stalls) stays idle for
+        // folders served this way. Root browses (empty path) always use
+        // the RPC — their entries come from Core's launcher routes,
+        // which do not live in the database. Any `None` (cache not
+        // serveable, unknown path, query error) falls through to the
+        // exact RPC subscribe this method always performed.
+        if !path.is_empty() && crate::media_browse_db::enabled() {
+            let qt_thread = self.qt_thread();
+            let seq_direct = seq.clone();
+            let path_direct = path.clone();
+            let systems_direct = systems.clone();
+            global_handle().spawn(async move {
+                let query_path = path_direct.clone();
+                let query_systems = systems_direct.clone();
+                let direct = tokio::task::spawn_blocking(move || {
+                    crate::media_browse_db::browse_folder(&query_path, &query_systems)
+                })
+                .await
+                .ok()
+                .flatten();
+                let _ = qt_thread.queue(move |mut model| {
+                    if seq_direct.load(Ordering::SeqCst) != ticket {
                         return;
                     }
-                    apply_status(model, snapshot);
+                    match direct {
+                        Some(result) => {
+                            mark_nav_source(model.as_mut(), "direct");
+                            apply_status(model, ResourceStatus::Ready(result));
+                        }
+                        None => subscribe_browse_endpoint(
+                            model,
+                            path_direct,
+                            systems_direct,
+                            ticket,
+                            seq_direct,
+                        ),
+                    }
                 });
-            }
-        });
-        self.as_mut().rust_mut().watcher = Some(handle);
-
-        // Sync seed runs inline on the Qt thread, so it cannot race a
-        // queued callback (Qt won't pump events until set_system /
-        // set_path returns). No ticket check needed; the value we read
-        // is whichever the resource has right now.
-        apply_status(self.as_mut(), snapshot);
+            });
+            return;
+        }
+        subscribe_browse_endpoint(self, path, systems, ticket, seq);
     }
+}
+
+/// Subscribe to the store-backed `media.browse` endpoint and wire its
+/// status stream into `apply_status`. Split out of
+/// `start_initial_browse` so the direct-database fast path can fall
+/// back to the identical RPC flow from an async context.
+fn subscribe_browse_endpoint(
+    mut model: Pin<&mut ffi::GamesModel>,
+    path: String,
+    systems: Vec<String>,
+    ticket: u64,
+    seq: Arc<AtomicU64>,
+) {
+    let max_results = u32::try_from(model.page_size.max(1)).unwrap_or(u32::from(u16::MAX));
+    let resource = global_store().subscribe::<MediaBrowseEndpoint>(BrowseArgs::new(
+        path,
+        systems,
+        max_results,
+    ));
+    let mut status_rx = resource.subscribe();
+
+    // Spawn the watcher BEFORE applying the sync seed. If
+    // `apply_status` recurses into `start_initial_browse` (auto-nav
+    // cascade on a single-folder result), the inner call's
+    // `watcher.take().abort()` cleans up this handle correctly —
+    // doing this in the other order leaks the inner watcher when
+    // the outer call later overwrites `self.watcher`.
+    let qt_thread = model.qt_thread();
+    let snapshot = status_rx.borrow_and_update().clone();
+    if let Some(timing) = model.as_mut().rust_mut().nav_timing.as_mut() {
+        if matches!(snapshot, ResourceStatus::Ready(_)) {
+            timing.set_source("cache");
+            timing.mark_request_done();
+        }
+    }
+    let seq_for_loop = seq;
+    let handle = global_handle().spawn(async move {
+        while status_rx.changed().await.is_ok() {
+            let snapshot = status_rx.borrow_and_update().clone();
+            let seq_for_closure = seq_for_loop.clone();
+            let _ = qt_thread.queue(move |model| {
+                if seq_for_closure.load(Ordering::SeqCst) != ticket {
+                    return;
+                }
+                apply_status(model, snapshot);
+            });
+        }
+    });
+    model.as_mut().rust_mut().watcher = Some(handle);
+
+    // Sync seed runs inline on the Qt thread, so it cannot race a
+    // queued callback (Qt won't pump events until set_system /
+    // set_path returns). No ticket check needed; the value we read
+    // is whichever the resource has right now.
+    apply_status(model, snapshot);
 }
 
 /// Resolve the system id role exposed to QML. Single-system entries

--- a/rust/frontend/src/models/recents.rs
+++ b/rust/frontend/src/models/recents.rs
@@ -345,68 +345,13 @@ fn page_snapshot(result: &MediaHistoryResult) -> PageSnapshot {
     )
 }
 
-/// Post-Ready pagination: warm page 2 over the RPC, or upgrade to the
-/// complete local history when the direct layer is available — the
-/// paged chain then never starts. `fetch_more` is itself guarded by
-/// `has_next_page` and `loading_more`.
+/// Post-Ready pagination: warm page 2 over the RPC. Reached only when
+/// the direct read could not answer (or the layer is disabled), so the
+/// paged chain must continue exactly as it always did. `fetch_more` is
+/// itself guarded by `has_next_page` and `loading_more`.
 fn finish_ready_pagination(mut model: Pin<&mut ffi::RecentsModel>, has_next_page: bool) {
-    let direct_full = crate::media_history_db::enabled();
-    if has_next_page && !model.cover_requests_paused && !direct_full {
+    if has_next_page && !model.cover_requests_paused {
         model.as_mut().fetch_more();
-    }
-    if direct_full && has_next_page {
-        spawn_direct_history_upgrade(&model);
-    }
-}
-
-/// Upgrade the freshly applied RPC page to the complete local history:
-/// spawn the read off the Qt thread and land it under the same seq
-/// ticket the cursor chain uses, so a newer refetch discards it.
-fn spawn_direct_history_upgrade(model: &Pin<&mut ffi::RecentsModel>) {
-    let seq = model.rust().seq.clone();
-    let ticket = seq.load(Ordering::SeqCst);
-    let qt_thread = model.qt_thread();
-    global_handle().spawn(async move {
-        let cancel_seq = seq.clone();
-        let direct = tokio::task::spawn_blocking(move || {
-            crate::media_history_db::history(&|| cancel_seq.load(Ordering::SeqCst) != ticket)
-        })
-        .await
-        .ok()
-        .flatten();
-        let Some(entries) = direct else {
-            return;
-        };
-        let _ = qt_thread.queue(move |mut model| {
-            if model.rust().seq.load(Ordering::SeqCst) != ticket {
-                return;
-            }
-            apply_direct_history(model.as_mut(), entries);
-        });
-    });
-}
-
-/// Land the complete local history: the direct counterpart of a
-/// terminal cursor page. The set arrives already deduplicated
-/// latest-per-path; the reset mirrors the Ready apply and the cursor
-/// chain ends here.
-fn apply_direct_history(mut model: Pin<&mut ffi::RecentsModel>, entries: Vec<MediaHistoryEntry>) {
-    if !model.cover_requests_paused {
-        enqueue_recents_covers(&entries);
-    }
-    let count = i32::try_from(entries.len()).unwrap_or(i32::MAX);
-    model.as_mut().begin_reset_model();
-    {
-        let mut rust = model.as_mut().rust_mut();
-        rust.entries = entries;
-        rust.count = count;
-        rust.next_cursor = None;
-    }
-    model.as_mut().end_reset_model();
-    model.as_mut().count_changed();
-    sync_resume_state(model.as_mut());
-    if model.has_next_page {
-        model.as_mut().set_has_next_page(false);
     }
 }
 

--- a/rust/frontend/src/models/recents.rs
+++ b/rust/frontend/src/models/recents.rs
@@ -345,12 +345,90 @@ fn page_snapshot(result: &MediaHistoryResult) -> PageSnapshot {
     )
 }
 
-fn apply_state(
-    mut model: Pin<&mut ffi::RecentsModel>,
-    (data, err): (Option<PageSnapshot>, String),
-) {
+/// Post-Ready pagination: warm page 2 over the RPC, or upgrade to the
+/// complete local history when the direct layer is available — the
+/// paged chain then never starts. `fetch_more` is itself guarded by
+/// `has_next_page` and `loading_more`.
+fn finish_ready_pagination(mut model: Pin<&mut ffi::RecentsModel>, has_next_page: bool) {
+    let direct_full = crate::media_history_db::enabled();
+    if has_next_page && !model.cover_requests_paused && !direct_full {
+        model.as_mut().fetch_more();
+    }
+    if direct_full && has_next_page {
+        spawn_direct_history_upgrade(&model);
+    }
+}
+
+/// Upgrade the freshly applied RPC page to the complete local history:
+/// spawn the read off the Qt thread and land it under the same seq
+/// ticket the cursor chain uses, so a newer refetch discards it.
+fn spawn_direct_history_upgrade(model: &Pin<&mut ffi::RecentsModel>) {
+    let seq = model.rust().seq.clone();
+    let ticket = seq.load(Ordering::SeqCst);
+    let qt_thread = model.qt_thread();
+    global_handle().spawn(async move {
+        let cancel_seq = seq.clone();
+        let direct = tokio::task::spawn_blocking(move || {
+            crate::media_history_db::history(&|| cancel_seq.load(Ordering::SeqCst) != ticket)
+        })
+        .await
+        .ok()
+        .flatten();
+        let Some(entries) = direct else {
+            return;
+        };
+        let _ = qt_thread.queue(move |mut model| {
+            if model.rust().seq.load(Ordering::SeqCst) != ticket {
+                return;
+            }
+            apply_direct_history(model.as_mut(), entries);
+        });
+    });
+}
+
+/// Land the complete local history: the direct counterpart of a
+/// terminal cursor page. The set arrives already deduplicated
+/// latest-per-path; the reset mirrors the Ready apply and the cursor
+/// chain ends here.
+fn apply_direct_history(mut model: Pin<&mut ffi::RecentsModel>, entries: Vec<MediaHistoryEntry>) {
+    if !model.cover_requests_paused {
+        enqueue_recents_covers(&entries);
+    }
+    let count = i32::try_from(entries.len()).unwrap_or(i32::MAX);
+    model.as_mut().begin_reset_model();
+    {
+        let mut rust = model.as_mut().rust_mut();
+        rust.entries = entries;
+        rust.count = count;
+        rust.next_cursor = None;
+    }
+    model.as_mut().end_reset_model();
+    model.as_mut().count_changed();
+    sync_resume_state(model.as_mut());
+    if model.has_next_page {
+        model.as_mut().set_has_next_page(false);
+    }
+}
+
+fn apply_state(model: Pin<&mut ffi::RecentsModel>, (data, err): (Option<PageSnapshot>, String)) {
+    if let Some(snapshot) = data {
+        // Direct-first: the store's Ready is the trigger and the local
+        // read is the content; the RPC page it delivered is only
+        // applied when the local read cannot answer.
+        if crate::media_history_db::enabled() {
+            spawn_direct_ready(model, snapshot);
+        } else {
+            apply_ready_page(model, snapshot);
+        }
+    } else {
+        apply_pending_or_error(model, &err);
+    }
+}
+
+fn apply_ready_page(mut model: Pin<&mut ffi::RecentsModel>, snapshot: PageSnapshot) {
     let apply_started = Instant::now();
-    if let Some((entries, has_next_page, next_cursor)) = data {
+    {
+        let (entries, has_next_page, next_cursor) = snapshot;
         if let Some(timing) = model.as_mut().rust_mut().nav_timing.as_mut() {
             timing.mark_request_done();
         }
@@ -410,13 +488,131 @@ fn apply_state(
         if model.loading_more {
             model.as_mut().set_loading_more(false);
         }
-        // Look-ahead prefetch: warm page 2 so the first scroll past the
-        // initial page doesn't surface a "Loading more…" cue. `fetch_more`
-        // is itself guarded by `has_next_page` and `loading_more`.
-        if has_next_page && !model.cover_requests_paused {
-            model.as_mut().fetch_more();
+        finish_ready_pagination(model.as_mut(), has_next_page);
+    }
+}
+
+/// Direct-first Ready handling: bump the chain, read the complete
+/// deduplicated local history, and paint it; the RPC page in
+/// `snapshot` applies only when the local read cannot answer.
+fn spawn_direct_ready(mut model: Pin<&mut ffi::RecentsModel>, snapshot: PageSnapshot) {
+    model.as_mut().rust_mut().seq.fetch_add(1, Ordering::SeqCst);
+    let seq = model.rust().seq.clone();
+    let ticket = seq.load(Ordering::SeqCst);
+    let qt_thread = model.qt_thread();
+    global_handle().spawn(async move {
+        let cancel_seq = seq.clone();
+        let direct = tokio::task::spawn_blocking(move || {
+            crate::media_history_db::history(&|| cancel_seq.load(Ordering::SeqCst) != ticket)
+        })
+        .await
+        .ok()
+        .flatten();
+        let _ = qt_thread.queue(move |model| {
+            if seq.load(Ordering::SeqCst) != ticket {
+                return;
+            }
+            match direct {
+                Some(entries) => apply_direct_full_paint(model, entries),
+                None => apply_ready_page(model, snapshot),
+            }
+        });
+    });
+}
+
+/// Early paint: fired from the Pending branch so a cold entry shows the
+/// complete local history in tens of milliseconds instead of waiting
+/// for the store's first network Ready, which then re-confirms it.
+fn spawn_direct_early_paint(model: &Pin<&mut ffi::RecentsModel>) {
+    if !crate::media_history_db::enabled() || model.count > 0 {
+        return;
+    }
+    let seq = model.rust().seq.clone();
+    let ticket = seq.load(Ordering::SeqCst);
+    let qt_thread = model.qt_thread();
+    global_handle().spawn(async move {
+        let cancel_seq = seq.clone();
+        let direct = tokio::task::spawn_blocking(move || {
+            crate::media_history_db::history(&|| cancel_seq.load(Ordering::SeqCst) != ticket)
+        })
+        .await
+        .ok()
+        .flatten();
+        let Some(entries) = direct else {
+            return;
+        };
+        let _ = qt_thread.queue(move |model| {
+            if model.rust().seq.load(Ordering::SeqCst) != ticket {
+                return;
+            }
+            apply_direct_full_paint(model, entries);
+        });
+    });
+}
+
+/// Land the complete local history as a first-class paint: the direct
+/// counterpart of `apply_ready_page` with terminal pagination, serving
+/// both the cold entry and every store-triggered refresh.
+fn apply_direct_full_paint(
+    mut model: Pin<&mut ffi::RecentsModel>,
+    entries: Vec<MediaHistoryEntry>,
+) {
+    let apply_started = Instant::now();
+    if model.nav_timing.is_none() {
+        model.as_mut().rust_mut().nav_timing = Some(NavTiming::new("direct"));
+    }
+    if let Some(timing) = model.as_mut().rust_mut().nav_timing.as_mut() {
+        timing.set_source("direct");
+        timing.mark_request_done();
+    }
+    model.as_mut().rust_mut().history_requested = true;
+    model.as_mut().rust_mut().history_fetching = false;
+    model.as_mut().rust_mut().history_subscription = None;
+    model.as_mut().ensure_cover_subscription();
+    if !model.cover_requests_paused {
+        enqueue_recents_covers(&entries);
+    }
+    let count = i32::try_from(entries.len()).unwrap_or(i32::MAX);
+    clear_current_detail_state(model.as_mut());
+    model.as_mut().begin_reset_model();
+    {
+        let mut rust = model.as_mut().rust_mut();
+        rust.entries = entries;
+        rust.count = count;
+        rust.next_cursor = None;
+    }
+    model.as_mut().end_reset_model();
+    model.as_mut().count_changed();
+    sync_resume_state(model.as_mut());
+    if let Some(timing) = model.as_mut().rust_mut().nav_timing.as_mut() {
+        timing.mark_apply_done();
+    }
+    debug!(
+        apply_ms = apply_started.elapsed().as_millis(),
+        "recents: apply_direct_full_paint timing",
+    );
+    if model.has_next_page {
+        model.as_mut().set_has_next_page(false);
+    }
+    if model.cover_requests_paused {
+        disarm_cover_gate(model.as_mut());
+        if model.loading {
+            model.as_mut().set_loading(false);
         }
-    } else if err.is_empty() {
+        finish_nav_timing(model.as_mut(), "covers-paused", 0);
+    } else {
+        arm_cover_gate(model.as_mut());
+    }
+    if model.loading_more {
+        model.as_mut().set_loading_more(false);
+    }
+    if !model.error_message.is_empty() {
+        model.as_mut().set_error_message(QString::default());
+    }
+}
+
+fn apply_pending_or_error(mut model: Pin<&mut ffi::RecentsModel>, err: &str) {
+    if err.is_empty() {
         info!(
             count = model.count,
             "recents-diag: apply_state Pending branch (loading, entries untouched)"
@@ -443,9 +639,10 @@ fn apply_state(
         if model.has_next_page {
             model.as_mut().set_has_next_page(false);
         }
+        spawn_direct_early_paint(&model);
     } else {
         info!(
-            error = err.as_str(),
+            error = err,
             count = model.count,
             "recents-diag: apply_state Errored branch (history_requested reset, entries untouched)"
         );
@@ -469,7 +666,7 @@ fn apply_state(
             model.as_mut().set_has_next_page(false);
         }
     }
-    let qerr = QString::from(err.as_str());
+    let qerr = QString::from(err);
     if model.error_message != qerr {
         model.as_mut().set_error_message(qerr);
     }
@@ -928,10 +1125,11 @@ impl ffi::RecentsModel {
         let store = global_store();
         let store_key = meta_key.clone();
         global_handle().spawn(async move {
-            let result = store
-                .client()
-                .media_meta(MediaMetaParams::for_media(system, path.clone()))
-                .await;
+            let params = MediaMetaParams::for_media(system, path.clone());
+            let result = match crate::media_meta_db::media_meta_async(params.clone()).await {
+                Some(media) => Ok(zaparoo_core::media_types::MediaMetaResult { media }),
+                None => store.client().media_meta(params).await,
+            };
             // Cache the outcome (positive or negative) regardless of whether
             // this callback is still current, so a later revisit is instant.
             match &result {

--- a/rust/zaparoo-core/src/endpoints/media_tags_update.rs
+++ b/rust/zaparoo-core/src/endpoints/media_tags_update.rs
@@ -6,8 +6,7 @@
 
 use crate::client::{Client, ClientError};
 use crate::endpoints::{
-    media_browse::MediaBrowseEndpoint, media_favorites::MediaFavoritesEndpoint,
-    media_search::MediaSearchEndpoint,
+    media_favorites::MediaFavoritesEndpoint, media_search::MediaSearchEndpoint,
 };
 use crate::media_types::{MediaTagsUpdateParams, MediaTagsUpdateResult};
 use crate::store::{Endpoint, Mutation, Tag};
@@ -30,7 +29,15 @@ impl Mutation for MediaTagsUpdateMutation {
 
     fn invalidates(_args: &Self::Args, _result: &Self::Output) -> Vec<Tag> {
         vec![
-            Tag::any(MediaBrowseEndpoint::NAME),
+            // Deliberately NOT Tag::any(MediaBrowseEndpoint::NAME): a
+            // favorite toggle only flips one row's heart, and the views
+            // that show hearts patch the row in place when they issue the
+            // mutation. Blanket-invalidating every cached folder listing
+            // forced the next entry into any folder back through a full
+            // media.browse round trip, which on large folders costs
+            // seconds; the trade is a cosmetically stale heart in *other*
+            // cached folders holding the same title, corrected by the
+            // next natural refetch or MEDIA_DB pulse.
             Tag::any(MediaFavoritesEndpoint::NAME),
             Tag::any(MediaSearchEndpoint::NAME),
         ]

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -2617,7 +2617,14 @@ MainLayout {
     // active, just like fresh presses.
     readonly property int _repeatInitialMs: 350
     readonly property int _repeatTickMs: 90
-    readonly property int _rapidNavigationQuietMs: 260
+    // Taps only engage rapid mode from a sustained burst: with covers now
+    // loading locally in milliseconds, gating on the second press hid
+    // speed the frontend has — a quick double-tap skip paid an artificial
+    // wait. Held-key repeat still forces rapid mode through its own path,
+    // and the quiet window stays above the 90 ms repeat tick so a held
+    // key cannot flicker the detail pane between ticks.
+    readonly property int _rapidNavigationQuietMs: 120
+    readonly property int _rapidNavigationTapThreshold: 5
     // Window for collapsing a second delivery of the same key into one
     // press — hardware contact bounce or input-stack double send. Far
     // below _repeatInitialMs and the repeat tick so it never touches
@@ -2717,9 +2724,9 @@ MainLayout {
         const sameBurst = rapidNavigationQuiet.running && root.rapidNavigationAction === action;
         root._rapidNavigationTapCount = sameBurst ? root._rapidNavigationTapCount + 1 : 1;
         root.rapidNavigationAction = action;
-        if (forceActive || rapidNavigationQuiet.running)
+        if (forceActive || root._rapidNavigationTapCount >= root._rapidNavigationTapThreshold)
             root.rapidNavigationActive = true;
-        if (forceActive || root._rapidNavigationTapCount >= 3)
+        if (forceActive || root._rapidNavigationTapCount >= root._rapidNavigationTapThreshold)
             root.rapidNavigationIndicatorActive = true;
         rapidNavigationQuiet.restart();
     }

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -2811,11 +2811,20 @@ MainLayout {
     property double _pageTurboLastPressMs: 0
     property double _pageTurboGapMs: 500
 
+    // The games screen routes Left/Right through _performPage in list
+    // layout (see GamesScreen), so a held Left/Right there is a held
+    // page button and must feed the turbo like the dedicated page keys.
+    function _pageTurboEligible(action: string): bool {
+        if (action === "page_next" || action === "page_prev")
+            return true;
+        return (action === "left" || action === "right") && root.activeScreen === root.screenGames && Browse.Settings.current_browse_layout === "list";
+    }
+
     // Returns true when the press was absorbed because turbo is (or
-    // has just started) driving that action. Any non-page action, or a
-    // direction flip, stops turbo and handles the press normally.
+    // has just started) driving that action. Any non-eligible action,
+    // or a direction flip, stops turbo and handles the press normally.
     function _notePageTurboPress(action: string): bool {
-        if (action !== "page_next" && action !== "page_prev") {
+        if (!root._pageTurboEligible(action)) {
             root._stopPageTurbo();
             return false;
         }

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -2782,6 +2782,93 @@ MainLayout {
     // arms the initial-delay timer. Pulled out of handleKey so unit
     // tests can drive the repeat state machine without also routing
     // through handleAction → real screens. No-op for non-dpad actions.
+    // ── Page turbo ─────────────────────────────────────────────────
+    // Held L/R page buttons arrive from the platform's pad bridge as
+    // discrete press/release pairs at the bridge's own autofire cadence
+    // (about two per second measured), not as a held key: Qt-level
+    // autorepeats are dropped at the Keys handler, our hold-repeat
+    // needs a genuinely held key, and the rapid chain window is
+    // narrower than the bridge cadence, so held paging crawled at
+    // bridge speed with cover work running the whole time. The turbo
+    // treats the press *stream* as the hold signal: the third chained
+    // press starts a self-driven tick that pages at `_pageTurboTickMs`,
+    // forces rapid mode (pausing cover work), and swallows further
+    // bridge presses while it runs. The bridge releases immediately
+    // after every press, so release events carry no lift information;
+    // the stop condition is press silence — once no press has arrived
+    // for ~1.3x the observed cadence the button is deemed lifted. That
+    // leaves a short coast after lift (bounded by that deadline), the
+    // unavoidable price of pair-shaped input. A threshold of three
+    // keeps deliberate double-taps out of turbo entirely.
+    // Exposed for tst_navigation: the tick's running state is the
+    // observable "turbo is driving" contract.
+    readonly property bool pageTurboRunning: pageTurboTick.running
+    readonly property int _pageTurboTickMs: 170
+    readonly property int _pageTurboChainMs: 700
+    readonly property int _pageTurboThreshold: 3
+    property string _pageTurboAction: ""
+    property int _pageTurboChainCount: 0
+    property double _pageTurboLastPressMs: 0
+    property double _pageTurboGapMs: 500
+
+    // Returns true when the press was absorbed because turbo is (or
+    // has just started) driving that action. Any non-page action, or a
+    // direction flip, stops turbo and handles the press normally.
+    function _notePageTurboPress(action: string): bool {
+        if (action !== "page_next" && action !== "page_prev") {
+            root._stopPageTurbo();
+            return false;
+        }
+        // A direction flip stops the old turbo but falls through, so
+        // the flip press itself seeds a fresh chain and pages once.
+        if (pageTurboTick.running && action !== root._pageTurboAction)
+            root._stopPageTurbo();
+        const now = Date.now();
+        const gap = now - root._pageTurboLastPressMs;
+        if (root._pageTurboAction === action && gap < root._pageTurboChainMs) {
+            root._pageTurboChainCount += 1;
+            // Sub-120ms doubles are bounce or test drivers, not the
+            // bridge cadence; keep them out of the estimate.
+            if (gap > 120)
+                root._pageTurboGapMs = 0.5 * root._pageTurboGapMs + 0.5 * gap;
+        } else {
+            root._pageTurboAction = action;
+            root._pageTurboChainCount = 1;
+            root._pageTurboGapMs = 500;
+        }
+        root._pageTurboLastPressMs = now;
+        if (pageTurboTick.running)
+            return true;
+        if (root._pageTurboChainCount >= root._pageTurboThreshold) {
+            root._noteRapidNavigationAction(action, true);
+            pageTurboTick.restart();
+            return true;
+        }
+        return false;
+    }
+
+    function _stopPageTurbo(): void {
+        pageTurboTick.stop();
+        root._pageTurboChainCount = 0;
+        root._pageTurboAction = "";
+    }
+
+    Timer {
+        id: pageTurboTick
+        interval: root._pageTurboTickMs
+        repeat: true
+        onTriggered: {
+            const now = Date.now();
+            const deadline = root._pageTurboLastPressMs + Math.max(420, root._pageTurboGapMs * 1.3);
+            if (now > deadline) {
+                root._stopPageTurbo();
+                return;
+            }
+            root._noteRapidNavigationAction(root._pageTurboAction, true);
+            root.handleAction(root._pageTurboAction);
+        }
+    }
+
     function _armRepeat(action: string, key: int): void {
         if (!root._isRepeatableAction(action))
             return;
@@ -2805,6 +2892,8 @@ MainLayout {
         const action = Browse.Input.action_for_key(key);
         root._startupTrace("input/qml key mapped", "key=" + key, "action=" + action);
         if (action === "")
+            return;
+        if (root._notePageTurboPress(action))
             return;
         root.handleAction(action);
         root._armRepeat(action, key);

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -1047,6 +1047,13 @@ MainLayout {
     // gamesScreen.onRequestSystemsScreen below) so this path needs
     // no per-transition flag.
     function _navigateFromSystems(systemId: string): void {
+        // A repeat Accept for the same system while its entry is still
+        // in flight would restart the whole load from scratch (model
+        // reset, re-browse, re-restore) and double the visible loading
+        // time; users press again exactly when a load feels slow, so
+        // absorb the duplicate instead.
+        if (root.pendingTransition === "games" && Browse.GamesState.system_id === systemId)
+            return;
         root._requestScreen(root.screenGames);
         Browse.SystemsState.system_id = systemId;
         // Setting system_id on GamesState resets path_stack/selected_at_level

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -2631,6 +2631,18 @@ MainLayout {
     // and the quiet window stays above the 90 ms repeat tick so a held
     // key cannot flicker the detail pane between ticks.
     readonly property int _rapidNavigationQuietMs: 120
+    // Chain window for discrete repeats. Gamepad input stacks (MiSTer's
+    // pad-to-key translation among them) deliver a held dpad as separate
+    // press/release pairs at their own cadence rather than one held key,
+    // so the QML hold-repeat never establishes and every repeat counts
+    // through the tap path. At repeat cadences slower than the 120 ms
+    // quiet window the burst count reset on every press and rapid mode
+    // never engaged — cover work then churned through the whole hold.
+    // While no QML repeat is established, the quiet timer runs at this
+    // wider interval instead: it chains any realistic pad repeat rate
+    // into one burst, while a genuine held key keeps the tight window
+    // (the 90 ms tick re-arms it, so exit stays fast after release).
+    readonly property int _rapidNavigationChainQuietMs: 300
     readonly property int _rapidNavigationTapThreshold: 5
     // Window for collapsing a second delivery of the same key into one
     // press — hardware contact bounce or input-stack double send. Far
@@ -2735,6 +2747,14 @@ MainLayout {
             root.rapidNavigationActive = true;
         if (forceActive || root._rapidNavigationTapCount >= root._rapidNavigationTapThreshold)
             root.rapidNavigationIndicatorActive = true;
+        // An established QML hold-repeat (forced tick notes, and the
+        // action router's follow-up notes while the tick runs) re-arms
+        // the tight window so rapid exits fast after release. Discrete
+        // taps — including gamepad stacks that deliver a held dpad as
+        // press/release pairs at their own cadence — get the wider
+        // chain window so the burst survives between repeats instead
+        // of resetting on every press.
+        rapidNavigationQuiet.interval = forceActive || repeatTick.running ? root._rapidNavigationQuietMs : root._rapidNavigationChainQuietMs;
         rapidNavigationQuiet.restart();
     }
 
@@ -2924,6 +2944,10 @@ MainLayout {
 
     Timer {
         id: rapidNavigationQuiet
+        // Interval is assigned imperatively on every note (see
+        // _noteRapidNavigationAction) — held-key notes use the tight
+        // window, discrete taps the chain window. Assigning per restart
+        // keeps the running countdown immune to binding re-evaluation.
         interval: root._rapidNavigationQuietMs
         repeat: false
         onTriggered: {

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -2867,6 +2867,10 @@ MainLayout {
         interval: root._pageTurboTickMs
         repeat: true
         onTriggered: {
+            if (root.pendingTransition !== "" || root.transitionCueVisible || ScreenManager.hasModal || !root.active) {
+                root._stopPageTurbo();
+                return;
+            }
             const now = Date.now();
             const deadline = root._pageTurboLastPressMs + Math.max(420, root._pageTurboGapMs * 1.3);
             if (now > deadline) {
@@ -2902,7 +2906,13 @@ MainLayout {
         root._startupTrace("input/qml key mapped", "key=" + key, "action=" + action);
         if (action === "")
             return;
-        if (root._notePageTurboPress(action))
+        // The turbo must observe the same gates handleAction applies:
+        // presses swallowed by a transition or owned by a modal must not
+        // feed or sustain it, or a tick could page the newly ready
+        // screen with input the user never aimed at it.
+        if (root.pendingTransition !== "" || root.transitionCueVisible || ScreenManager.hasModal)
+            root._stopPageTurbo();
+        else if (root._notePageTurboPress(action))
             return;
         root.handleAction(action);
         root._armRepeat(action, key);

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -3086,9 +3086,21 @@ MainLayout {
         }
     }
 
+    // Pure: the repeat cadence for a genuinely held key. Left/Right on
+    // the games list page whole pages, and the page repaint is the
+    // expensive unit, so a held page key repeats at the page-turbo
+    // cadence rather than the 90 ms row cadence — the same rhythm the
+    // pair-shaped input path produces through the turbo ticker, so both
+    // hold shapes travel identically. Everything else keeps the row
+    // cadence.
+    function _heldRepeatIntervalFor(action: string, screen: var, layout: string): int {
+        const heldPaging = (action === "left" || action === "right") && screen === root.screenGames && layout === "list";
+        return heldPaging ? root._pageTurboTickMs : root._repeatTickMs;
+    }
+
     Timer {
         id: repeatTick
-        interval: root._repeatTickMs
+        interval: root._heldRepeatIntervalFor(root._heldAction, root.activeScreen, Browse.Settings.current_browse_layout)
         repeat: true
         onTriggered: {
             if (root._heldAction === "") {

--- a/src/ui/components/BrowseList.qml
+++ b/src/ui/components/BrowseList.qml
@@ -75,6 +75,13 @@ Item {
     // not persist when the screen is shown again. Set by the host to
     // !active while the screen is off-screen.
     property bool screenSettling: false
+    // During rapid scrolling every landing rebinds all visible rows at
+    // once, and on the software renderer the decoration (heart icon,
+    // disambiguating tag layout) is a measurable share of that cost.
+    // Rapid render mode strips rows to their plain title so fast paging
+    // spends its frame budget on travel, mirroring the grid's
+    // rapidRenderMode; decoration pops back in when the scroll settles.
+    property bool rapidRenderMode: false
 
     signal itemHovered(int index)
     signal itemClicked(int index)
@@ -182,7 +189,7 @@ Item {
             readonly property bool _highlightVisible: row.selected && root.focusReady
             readonly property string _baseTitle: row.name !== "" ? row.name : row.fileStem
             // Horizontal space reserved on the right for the favorite heart.
-            readonly property int _favoriteSlot: row.favorite !== 0 ? root._favoriteRightPadding + Sizing.pctH(3.2) : 0
+            readonly property int _favoriteSlot: row.favorite !== 0 && !root.rapidRenderMode ? root._favoriteRightPadding + Sizing.pctH(3.2) : 0
             property real _activateScale: 1.0
 
             // Push in and hold — mirrors Tile.qml. The activate leg has no
@@ -287,7 +294,7 @@ Item {
                 anchors.verticalCenter: parent.verticalCenter
                 height: parent.height
                 name: row._baseTitle
-                tags: row.disambiguatingTags
+                tags: root.rapidRenderMode ? "" : row.disambiguatingTags
                 focused: row._highlightVisible
                 centerContent: false
                 fontPixelSize: Sizing.fontSize(2.9)
@@ -306,7 +313,7 @@ Item {
                 fillMode: Image.PreserveAspectFit
                 smooth: true
                 asynchronous: false
-                visible: row.favorite !== 0
+                visible: row.favorite !== 0 && !root.rapidRenderMode
             }
 
             MouseArea {

--- a/src/ui/components/BrowseList.qml
+++ b/src/ui/components/BrowseList.qml
@@ -189,7 +189,10 @@ Item {
             readonly property bool _highlightVisible: row.selected && root.focusReady
             readonly property string _baseTitle: row.name !== "" ? row.name : row.fileStem
             // Horizontal space reserved on the right for the favorite heart.
-            readonly property int _favoriteSlot: row.favorite !== 0 && !root.rapidRenderMode ? root._favoriteRightPadding + Sizing.pctH(3.2) : 0
+            // The heart stays through rapid mode: one cached pixmap per
+            // row is within the rapid frame budget, and hiding it made
+            // rows appear to change state during fast travel.
+            readonly property int _favoriteSlot: row.favorite !== 0 ? root._favoriteRightPadding + Sizing.pctH(3.2) : 0
             property real _activateScale: 1.0
 
             // Push in and hold — mirrors Tile.qml. The activate leg has no
@@ -313,7 +316,7 @@ Item {
                 fillMode: Image.PreserveAspectFit
                 smooth: true
                 asynchronous: false
-                visible: row.favorite !== 0 && !root.rapidRenderMode
+                visible: row.favorite !== 0
             }
 
             MouseArea {

--- a/src/ui/components/BrowseListDetailView.qml
+++ b/src/ui/components/BrowseListDetailView.qml
@@ -31,6 +31,7 @@ Item {
     property alias releasePulse: browseList.releasePulse
     property alias screenSettling: browseList.screenSettling
     property alias focusReady: browseList.focusReady
+    property alias rapidRenderMode: browseList.rapidRenderMode
     property alias detailCanPreviousImage: detailPane.canPreviousImage
     property alias detailCanNextImage: detailPane.canNextImage
     property alias detailReserveImageNav: detailPane.reserveImageNav

--- a/src/ui/components/FocusedMediaDetailController.qml
+++ b/src/ui/components/FocusedMediaDetailController.qml
@@ -12,6 +12,9 @@ Item {
 
     property int itemCount: 0
     property int currentIndex: 0
+    // Sized for a Core round trip; when metadata is a local database
+    // read the wait serves no purpose beyond input coalescing, so the
+    // host may drop it to a frame-scale value (see MediaListScreen).
     property int debounceMs: 220
     property var mediaModel: null
     property var identityForIndex: null

--- a/src/ui/components/PagedGrid.qml
+++ b/src/ui/components/PagedGrid.qml
@@ -46,7 +46,7 @@ Item {
 
     property int currentIndex: 0
     // List layout never renders the grid, but the Repeater still
-    // materialises one cell per model row (five role reads each) —
+    // materializes one cell per model row (five role reads each) —
     // measured at roughly three milliseconds per row on the DE10, which
     // turned every large-folder reset or insert into seconds of
     // UI-thread stall. Suspending swaps the Repeater's model out and
@@ -363,7 +363,7 @@ Item {
     // `hasMorePages` watcher so a final empty append still resolves
     // a chain. Waiting on the exact target index (not just `pageCount`
     // catching up) avoids an early commit while the Repeater is mid-
-    // materialisation: the target page may report `pageCount` reached
+    // materialization: the target page may report `pageCount` reached
     // while the row/col slot itself isn't realised yet.
     function _commitPendingTarget(): void {
         // Jump-to-index: land on the exact absolute target. Pages stay
@@ -652,7 +652,7 @@ Item {
                 readonly property int cellCol: cellLocal % root.columns
                 readonly property bool isSelected: index === root.currentIndex
 
-                // Cover-decode gate AND delegate-materialisation gate.
+                // Cover-decode gate AND delegate-materialization gate.
                 // PagedGrid's Repeater creates one cellItem per model
                 // row at construction. Two-tier gate, both anchored on
                 // distance from `root.currentPage`:
@@ -665,7 +665,7 @@ Item {
                 //     consume already-warmed bytes early enough.
                 //   - retention range (±5 pages): cells inside this
                 //     radius keep their TileLoader.active=true so the
-                //     Tile delegate stays materialised, AND cells that
+                //     Tile delegate stays materialized, AND cells that
                 //     have already requested keep their coverKey set
                 //     so Tile's Image keeps the decoded texture
                 //     referenced. The active gate is what prevents
@@ -772,7 +772,7 @@ Item {
 
                     anchors.fill: parent
                     sourceComponent: root.delegate
-                    // Bound delegate materialisation to the retention
+                    // Bound delegate materialization to the retention
                     // window. Cells outside +/-5 pages keep their
                     // cellItem (Repeater contract - it owns one item
                     // per model row) but don't construct a Tile, so

--- a/src/ui/components/PagedGrid.qml
+++ b/src/ui/components/PagedGrid.qml
@@ -45,7 +45,16 @@ Item {
     required property Component delegate
 
     property int currentIndex: 0
-    readonly property int itemCount: itemRepeater.count
+    // List layout never renders the grid, but the Repeater still
+    // materialises one cell per model row (five role reads each) —
+    // measured at roughly three milliseconds per row on the DE10, which
+    // turned every large-folder reset or insert into seconds of
+    // UI-thread stall. Suspending swaps the Repeater's model out and
+    // serves `itemCount` straight from the model's own count property,
+    // so the list cursor, page math, and jump logic keep working with
+    // zero delegates alive.
+    property bool suspendDelegates: false
+    readonly property int itemCount: root.suspendDelegates ? (root.model && root.model.count !== undefined ? root.model.count : 0) : itemRepeater.count
 
     // Whether this section currently owns user focus. Tile uses this to
     // gate the selection card so only one section shows the focus cue
@@ -618,7 +627,7 @@ Item {
         Repeater {
             id: itemRepeater
 
-            model: root.model
+            model: root.suspendDelegates ? null : root.model
 
             Item {
                 id: cellItem

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -339,7 +339,10 @@ MediaListScreen {
         id: backgroundFolderFill
         interval: 200
         repeat: true
-        running: games.active && !Browse.GamesModel.loading && Browse.GamesModel.has_next_page
+        // List layout only: grid delegates are not suspended, so a
+        // background append there would materialize delegate cells the
+        // user never asked for; grid paging keeps its own look-ahead.
+        running: games.active && games._listLayout && !Browse.GamesModel.loading && Browse.GamesModel.has_next_page
         onTriggered: {
             if (!Browse.GamesModel.loading_more && Browse.GamesModel.has_next_page)
                 Browse.GamesModel.fetch_more();

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -26,6 +26,11 @@ MediaListScreen {
 
     readonly property bool _portraitNonCrtList: !Theme.crtNativePath && Browse.Settings.current_orientation !== "horizontal"
     readonly property int _listPageSize: games._portraitNonCrtList ? 16 : 10
+    // How many list pages before the loaded edge `_prefetchListTail`
+    // starts a fetch. The background fill below does the heavy lifting;
+    // this only covers the gap when the user is outrunning it and the
+    // next fill tick has not fired yet.
+    readonly property int _listPrefetchPages: 5
     readonly property bool _tateOrientation: Browse.Settings.current_orientation !== "horizontal"
     readonly property var _gridShape: Sizing.gamesGridShape(games._gridViewportWidth, games._gridViewportHeight)
     readonly property int _gridColumns: games._gridShape.columns
@@ -138,7 +143,11 @@ MediaListScreen {
     topStripRightTextProvider: () => {
         if (!games._listLayout)
             return "";
-        if (Browse.GamesModel.loading_more)
+        // The background fill keeps `loading_more` true for most of a
+        // large folder's first seconds, so the banner only shows when
+        // the user is actually near the loaded edge waiting on rows;
+        // everywhere else the position readout keeps priority.
+        if (Browse.GamesModel.loading_more && games.gamesGrid.currentIndex >= games.gamesGrid.itemCount - games._browsePageSize)
             return qsTr("Loading more…");
         if (games.gamesGrid.itemCount <= 0)
             return "";
@@ -311,8 +320,30 @@ MediaListScreen {
             return;
         const count = games.gamesGrid.itemCount;
         const knownTotal = Browse.GamesModel.total_dirs + Browse.GamesModel.total_files;
-        if (index >= count - games._listPageSize && games._listHasMore(count, knownTotal))
+        if (index >= count - games._listPageSize * games._listPrefetchPages && games._listHasMore(count, knownTotal))
             Browse.GamesModel.fetch_more();
+    }
+
+    // Background folder fill. The paged model used to fetch only on
+    // demand, so paging raced a media.browse round trip and lost
+    // routinely ("Loading more…" at the loaded edge). Instead, once a
+    // folder's first page is up, keep pulling gentle chunks until the
+    // whole folder is local. The repeat interval paces Core so other
+    // requests interleave between chunks; a tick during an in-flight
+    // fetch is a no-op (`fetch_more` debounces on `loading_more`) and
+    // the next tick resumes. Leaving the screen stops the timer via
+    // `active`; switching folders re-aims it (`has_next_page` resets
+    // with the new browse, and stale responses die on the model's
+    // browse generation counter).
+    Timer {
+        id: backgroundFolderFill
+        interval: 200
+        repeat: true
+        running: games.active && !Browse.GamesModel.loading && Browse.GamesModel.has_next_page
+        onTriggered: {
+            if (!Browse.GamesModel.loading_more && Browse.GamesModel.has_next_page)
+                Browse.GamesModel.fetch_more();
+        }
     }
 
     // Page jump (L/R shoulder buttons). Wraps in both directions; same

--- a/src/ui/screens/MediaListScreen.qml
+++ b/src/ui/screens/MediaListScreen.qml
@@ -456,6 +456,7 @@ Item {
     BrowseListDetailView {
         id: listCard
 
+        rapidRenderMode: root.detailRapidScrollActive
         visible: !root._gateHide && root._listLayout
         anchors.left: parent.left
         anchors.leftMargin: root._listLayoutProfile && root._listLayoutProfile.list ? root._listLayoutProfile.list.cardSideMargin : Sizing.pctW(5)
@@ -502,6 +503,10 @@ Item {
         // fetch while the user is still many pages from the loaded edge,
         // so "Loading more" stops interrupting sustained paging.
         loadAheadPages: root.detailRapidScrollActive ? 8 : 2
+        // The grid is invisible in list layout but stays the row/cursor
+        // authority; suspending its delegates removes the per-row
+        // materialisation cost from every model reset and insert.
+        suspendDelegates: root._listLayout
         id: mediaGrid
 
         visible: !root._gateHide && !root._listLayout && root.renderGridLayout

--- a/src/ui/screens/MediaListScreen.qml
+++ b/src/ui/screens/MediaListScreen.qml
@@ -505,7 +505,7 @@ Item {
         loadAheadPages: root.detailRapidScrollActive ? 8 : 2
         // The grid is invisible in list layout but stays the row/cursor
         // authority; suspending its delegates removes the per-row
-        // materialisation cost from every model reset and insert.
+        // materialization cost from every model reset and insert.
         suspendDelegates: root._listLayout
         id: mediaGrid
 

--- a/src/ui/screens/MediaListScreen.qml
+++ b/src/ui/screens/MediaListScreen.qml
@@ -497,6 +497,11 @@ Item {
     }
 
     PagedGrid {
+        // Rapid paging crosses the default 2-page buffer faster than a
+        // media.browse refill can land; a deeper look-ahead starts the
+        // fetch while the user is still many pages from the loaded edge,
+        // so "Loading more" stops interrupting sustained paging.
+        loadAheadPages: root.detailRapidScrollActive ? 8 : 2
         id: mediaGrid
 
         visible: !root._gateHide && !root._listLayout && root.renderGridLayout

--- a/src/ui/screens/MediaListScreen.qml
+++ b/src/ui/screens/MediaListScreen.qml
@@ -426,6 +426,10 @@ Item {
     FocusedMediaDetailController {
         id: focusedDetail
 
+        // With direct-database metadata the fetch costs a millisecond,
+        // so the settle wait shrinks to a couple of frames — enough to
+        // coalesce a fast tap burst, no longer a visible pause.
+        debounceMs: Browse.AppStatus.direct_meta ? 40 : 220
         enabled: !root._gateHide && root._listLayout
         itemCount: mediaGrid.itemCount
         currentIndex: mediaGrid.currentIndex

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -714,37 +714,37 @@ Euskara - devilschile2</source>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3161"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3165"/>
+        <location filename="../app/Main.qml" line="3175"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3167"/>
+        <location filename="../app/Main.qml" line="3177"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3169"/>
+        <location filename="../app/Main.qml" line="3179"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3181"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3173"/>
+        <location filename="../app/Main.qml" line="3183"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -710,37 +710,37 @@ Euskara - devilschile2</source>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3039"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3041"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3067"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3045"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3047"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3049"/>
+        <location filename="../app/Main.qml" line="3073"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3051"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -714,37 +714,37 @@ Euskara - devilschile2</source>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3152"/>
+        <location filename="../app/Main.qml" line="3161"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3154"/>
+        <location filename="../app/Main.qml" line="3163"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3156"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3158"/>
+        <location filename="../app/Main.qml" line="3167"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3160"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3164"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -443,34 +443,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="177"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="186"/>
         <source>%1 files</source>
         <translation>%1 ملفات</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="54"/>
+        <location filename="../screens/GamesScreen.qml" line="59"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
-        <location filename="../screens/GamesScreen.qml" line="178"/>
+        <location filename="../screens/GamesScreen.qml" line="155"/>
+        <location filename="../screens/GamesScreen.qml" line="187"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="53"/>
         <source>No games in this system</source>
         <translation>لا توجد ألعاب في هذا النظام</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="49"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="151"/>
         <source>Loading more…</source>
         <translation>جارٍ تحميل المزيد…</translation>
     </message>
@@ -599,148 +599,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1518"/>
+        <location filename="../app/Main.qml" line="1525"/>
         <source>Launch core</source>
         <translation>تشغيل النواة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1527"/>
-        <location filename="../app/Main.qml" line="1772"/>
+        <location filename="../app/Main.qml" line="1534"/>
+        <location filename="../app/Main.qml" line="1779"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1534"/>
-        <location filename="../app/Main.qml" line="1563"/>
+        <location filename="../app/Main.qml" line="1541"/>
+        <location filename="../app/Main.qml" line="1570"/>
         <source>Update media database</source>
         <translation type="unfinished">تحديث قاعدة بيانات الوسائط</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1537"/>
-        <location filename="../app/Main.qml" line="1566"/>
+        <location filename="../app/Main.qml" line="1544"/>
+        <location filename="../app/Main.qml" line="1573"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">استخراج البيانات الوصفية</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1575"/>
-        <location filename="../app/Main.qml" line="1610"/>
+        <location filename="../app/Main.qml" line="1582"/>
+        <location filename="../app/Main.qml" line="1617"/>
         <source>Launch game</source>
         <translation>تشغيل اللعبة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Remove from favorites</source>
         <translation>إزالة من المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Add to favorites</source>
         <translation>أضف إلى المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1596"/>
+        <location filename="../app/Main.qml" line="1603"/>
         <source>Write to NFC token</source>
         <translation>الكتابة إلى رمز NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1600"/>
+        <location filename="../app/Main.qml" line="1607"/>
         <source>QR code</source>
         <translation>رمز QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Default</source>
         <translation type="unfinished">افتراضي</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2120"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2116"/>
+        <location filename="../app/Main.qml" line="2123"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2263"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2274"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2289"/>
         <source>Retry</source>
         <translation type="unfinished">إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2286"/>
+        <location filename="../app/Main.qml" line="2293"/>
         <source>Cancel</source>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3025"/>
+        <location filename="../app/Main.qml" line="3039"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3027"/>
+        <location filename="../app/Main.qml" line="3041"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3043"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3031"/>
+        <location filename="../app/Main.qml" line="3045"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3033"/>
+        <location filename="../app/Main.qml" line="3047"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3035"/>
+        <location filename="../app/Main.qml" line="3049"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3037"/>
+        <location filename="../app/Main.qml" line="3051"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -373,6 +373,10 @@ Euskara - devilschile2</source>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
+    <message>
+        <source>%1 entries</source>
+        <translation type="obsolete">%1 عناصر</translation>
+    </message>
 </context>
 <context>
     <name>FirstRunIndexModal</name>
@@ -710,37 +714,37 @@ Euskara - devilschile2</source>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3152"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3154"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3067"/>
+        <location filename="../app/Main.qml" line="3156"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3158"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3073"/>
+        <location filename="../app/Main.qml" line="3162"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3164"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -952,12 +952,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">جارٍ التحميل…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="452"/>
+        <location filename="../screens/MediaListScreen.qml" line="456"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 عناصر</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="453"/>
+        <location filename="../screens/MediaListScreen.qml" line="457"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -650,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3152"/>
+        <location filename="../app/Main.qml" line="3161"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3158"/>
+        <location filename="../app/Main.qml" line="3167"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3154"/>
+        <location filename="../app/Main.qml" line="3163"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
@@ -729,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3156"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3160"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3164"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -952,12 +952,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Wird geladen…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="452"/>
+        <location filename="../screens/MediaListScreen.qml" line="456"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 Einträge</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="453"/>
+        <location filename="../screens/MediaListScreen.qml" line="457"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -373,6 +373,10 @@ Euskara - devilschile2</source>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
+    <message>
+        <source>%1 entries</source>
+        <translation type="obsolete">%1 Einträge</translation>
+    </message>
 </context>
 <context>
     <name>FirstRunIndexModal</name>
@@ -646,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3152"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3158"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3154"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
@@ -725,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3067"/>
+        <location filename="../app/Main.qml" line="3156"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3073"/>
+        <location filename="../app/Main.qml" line="3162"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3164"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -443,34 +443,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="177"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="186"/>
         <source>%1 files</source>
         <translation>%1 Dateien</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="54"/>
+        <location filename="../screens/GamesScreen.qml" line="59"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
-        <location filename="../screens/GamesScreen.qml" line="178"/>
+        <location filename="../screens/GamesScreen.qml" line="155"/>
+        <location filename="../screens/GamesScreen.qml" line="187"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="49"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="151"/>
         <source>Loading more…</source>
         <translation>Mehr laden…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="53"/>
         <source>No games in this system</source>
         <translation>Keine Spiele in diesem System</translation>
     </message>
@@ -599,148 +599,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1518"/>
+        <location filename="../app/Main.qml" line="1525"/>
         <source>Launch core</source>
         <translation>Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1527"/>
-        <location filename="../app/Main.qml" line="1772"/>
+        <location filename="../app/Main.qml" line="1534"/>
+        <location filename="../app/Main.qml" line="1779"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Remove from favorites</source>
         <translation>Aus Favoriten entfernen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Add to favorites</source>
         <translation>Zu Favoriten hinzufügen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1596"/>
+        <location filename="../app/Main.qml" line="1603"/>
         <source>Write to NFC token</source>
         <translation>Auf NFC-Token schreiben</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1600"/>
+        <location filename="../app/Main.qml" line="1607"/>
         <source>QR code</source>
         <translation>QR-Code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1575"/>
-        <location filename="../app/Main.qml" line="1610"/>
+        <location filename="../app/Main.qml" line="1582"/>
+        <location filename="../app/Main.qml" line="1617"/>
         <source>Launch game</source>
         <translation>Spiel starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2120"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2116"/>
+        <location filename="../app/Main.qml" line="2123"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3025"/>
+        <location filename="../app/Main.qml" line="3039"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3031"/>
+        <location filename="../app/Main.qml" line="3045"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3027"/>
+        <location filename="../app/Main.qml" line="3041"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1534"/>
-        <location filename="../app/Main.qml" line="1563"/>
+        <location filename="../app/Main.qml" line="1541"/>
+        <location filename="../app/Main.qml" line="1570"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediendatenbank aktualisieren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1537"/>
-        <location filename="../app/Main.qml" line="1566"/>
+        <location filename="../app/Main.qml" line="1544"/>
+        <location filename="../app/Main.qml" line="1573"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadaten abrufen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Default</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2263"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2274"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2289"/>
         <source>Retry</source>
         <translation type="unfinished">Wiederholen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2286"/>
+        <location filename="../app/Main.qml" line="2293"/>
         <source>Cancel</source>
         <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3043"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3033"/>
+        <location filename="../app/Main.qml" line="3047"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3035"/>
+        <location filename="../app/Main.qml" line="3049"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3037"/>
+        <location filename="../app/Main.qml" line="3051"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -650,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3161"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3167"/>
+        <location filename="../app/Main.qml" line="3177"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
@@ -729,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3165"/>
+        <location filename="../app/Main.qml" line="3175"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3169"/>
+        <location filename="../app/Main.qml" line="3179"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3181"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3173"/>
+        <location filename="../app/Main.qml" line="3183"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -646,17 +646,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3039"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3045"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3041"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
@@ -725,22 +725,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3067"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3047"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3049"/>
+        <location filename="../app/Main.qml" line="3073"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3051"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -952,12 +952,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Φόρτωση…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="452"/>
+        <location filename="../screens/MediaListScreen.qml" line="456"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 εγγραφές</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="453"/>
+        <location filename="../screens/MediaListScreen.qml" line="457"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -646,17 +646,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3039"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3045"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3041"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
@@ -725,22 +725,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3067"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3047"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3049"/>
+        <location filename="../app/Main.qml" line="3073"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3051"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -650,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3161"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3167"/>
+        <location filename="../app/Main.qml" line="3177"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
@@ -729,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3165"/>
+        <location filename="../app/Main.qml" line="3175"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3169"/>
+        <location filename="../app/Main.qml" line="3179"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3181"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3173"/>
+        <location filename="../app/Main.qml" line="3183"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -443,34 +443,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="177"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="186"/>
         <source>%1 files</source>
         <translation>%1 αρχεία</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="54"/>
+        <location filename="../screens/GamesScreen.qml" line="59"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
-        <location filename="../screens/GamesScreen.qml" line="178"/>
+        <location filename="../screens/GamesScreen.qml" line="155"/>
+        <location filename="../screens/GamesScreen.qml" line="187"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="49"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="151"/>
         <source>Loading more…</source>
         <translation>Φόρτωση περισσότερων…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="53"/>
         <source>No games in this system</source>
         <translation>Δεν υπάρχουν παιχνίδια σε αυτό το σύστημα</translation>
     </message>
@@ -599,148 +599,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1518"/>
+        <location filename="../app/Main.qml" line="1525"/>
         <source>Launch core</source>
         <translation>Εκκίνηση Core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1527"/>
-        <location filename="../app/Main.qml" line="1772"/>
+        <location filename="../app/Main.qml" line="1534"/>
+        <location filename="../app/Main.qml" line="1779"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Remove from favorites</source>
         <translation>Αφαίρεση από αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Add to favorites</source>
         <translation>Προσθήκη στα αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1596"/>
+        <location filename="../app/Main.qml" line="1603"/>
         <source>Write to NFC token</source>
         <translation>Εγγραφή σε NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1600"/>
+        <location filename="../app/Main.qml" line="1607"/>
         <source>QR code</source>
         <translation>Κωδικός QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1575"/>
-        <location filename="../app/Main.qml" line="1610"/>
+        <location filename="../app/Main.qml" line="1582"/>
+        <location filename="../app/Main.qml" line="1617"/>
         <source>Launch game</source>
         <translation>Εκκίνηση παιχνιδιού</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2120"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2116"/>
+        <location filename="../app/Main.qml" line="2123"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3025"/>
+        <location filename="../app/Main.qml" line="3039"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3031"/>
+        <location filename="../app/Main.qml" line="3045"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3027"/>
+        <location filename="../app/Main.qml" line="3041"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1534"/>
-        <location filename="../app/Main.qml" line="1563"/>
+        <location filename="../app/Main.qml" line="1541"/>
+        <location filename="../app/Main.qml" line="1570"/>
         <source>Update media database</source>
         <translation type="unfinished">Ενημέρωση βάσης δεδομένων</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1537"/>
-        <location filename="../app/Main.qml" line="1566"/>
+        <location filename="../app/Main.qml" line="1544"/>
+        <location filename="../app/Main.qml" line="1573"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Ανάκτηση μεταδεδομένων</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Default</source>
         <translation type="unfinished">Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2263"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2274"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2289"/>
         <source>Retry</source>
         <translation type="unfinished">Επανάληψη</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2286"/>
+        <location filename="../app/Main.qml" line="2293"/>
         <source>Cancel</source>
         <translation type="unfinished">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3043"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3033"/>
+        <location filename="../app/Main.qml" line="3047"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3035"/>
+        <location filename="../app/Main.qml" line="3049"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3037"/>
+        <location filename="../app/Main.qml" line="3051"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -373,6 +373,10 @@ Euskara - devilschile2</source>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
+    <message>
+        <source>%1 entries</source>
+        <translation type="obsolete">%1 εγγραφές</translation>
+    </message>
 </context>
 <context>
     <name>FirstRunIndexModal</name>
@@ -646,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3152"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3158"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3154"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
@@ -725,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3067"/>
+        <location filename="../app/Main.qml" line="3156"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3073"/>
+        <location filename="../app/Main.qml" line="3162"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3164"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -650,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3152"/>
+        <location filename="../app/Main.qml" line="3161"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3158"/>
+        <location filename="../app/Main.qml" line="3167"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3154"/>
+        <location filename="../app/Main.qml" line="3163"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
@@ -729,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3156"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3160"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3164"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -634,17 +634,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3039"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3045"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3041"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -713,22 +713,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3067"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3047"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3049"/>
+        <location filename="../app/Main.qml" line="3073"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3051"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -638,17 +638,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3161"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3167"/>
+        <location filename="../app/Main.qml" line="3177"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -717,22 +717,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3165"/>
+        <location filename="../app/Main.qml" line="3175"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3169"/>
+        <location filename="../app/Main.qml" line="3179"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3181"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3173"/>
+        <location filename="../app/Main.qml" line="3183"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -638,17 +638,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3152"/>
+        <location filename="../app/Main.qml" line="3161"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3158"/>
+        <location filename="../app/Main.qml" line="3167"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3154"/>
+        <location filename="../app/Main.qml" line="3163"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -717,22 +717,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3156"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3160"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3164"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -423,34 +423,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="177"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="186"/>
         <source>%1 files</source>
         <translation>%1 files</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="54"/>
+        <location filename="../screens/GamesScreen.qml" line="59"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
-        <location filename="../screens/GamesScreen.qml" line="178"/>
+        <location filename="../screens/GamesScreen.qml" line="155"/>
+        <location filename="../screens/GamesScreen.qml" line="187"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="49"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="151"/>
         <source>Loading more…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="53"/>
         <source>No games in this system</source>
         <translation>No games in this system</translation>
     </message>
@@ -587,148 +587,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1518"/>
+        <location filename="../app/Main.qml" line="1525"/>
         <source>Launch core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1527"/>
-        <location filename="../app/Main.qml" line="1772"/>
+        <location filename="../app/Main.qml" line="1534"/>
+        <location filename="../app/Main.qml" line="1779"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Add to favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1596"/>
+        <location filename="../app/Main.qml" line="1603"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Write to NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1600"/>
+        <location filename="../app/Main.qml" line="1607"/>
         <source>QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1575"/>
-        <location filename="../app/Main.qml" line="1610"/>
+        <location filename="../app/Main.qml" line="1582"/>
+        <location filename="../app/Main.qml" line="1617"/>
         <source>Launch game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2120"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2116"/>
+        <location filename="../app/Main.qml" line="2123"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3025"/>
+        <location filename="../app/Main.qml" line="3039"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3031"/>
+        <location filename="../app/Main.qml" line="3045"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3027"/>
+        <location filename="../app/Main.qml" line="3041"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1534"/>
-        <location filename="../app/Main.qml" line="1563"/>
+        <location filename="../app/Main.qml" line="1541"/>
+        <location filename="../app/Main.qml" line="1570"/>
         <source>Update media database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1537"/>
-        <location filename="../app/Main.qml" line="1566"/>
+        <location filename="../app/Main.qml" line="1544"/>
+        <location filename="../app/Main.qml" line="1573"/>
         <source>Scrape metadata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2263"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2274"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2289"/>
         <source>Retry</source>
         <translation type="unfinished">Retry</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2286"/>
+        <location filename="../app/Main.qml" line="2293"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3043"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3033"/>
+        <location filename="../app/Main.qml" line="3047"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3035"/>
+        <location filename="../app/Main.qml" line="3049"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3037"/>
+        <location filename="../app/Main.qml" line="3051"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -353,6 +353,10 @@ Euskara - devilschile2</source>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>%1 entries</source>
+        <translation type="obsolete">%1 entries</translation>
+    </message>
 </context>
 <context>
     <name>FirstRunIndexModal</name>
@@ -634,17 +638,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3152"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3158"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3154"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -713,22 +717,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3067"/>
+        <location filename="../app/Main.qml" line="3156"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3073"/>
+        <location filename="../app/Main.qml" line="3162"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3164"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -936,12 +936,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Loading…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="452"/>
+        <location filename="../screens/MediaListScreen.qml" line="456"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 entries</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="453"/>
+        <location filename="../screens/MediaListScreen.qml" line="457"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -952,12 +952,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Cargando…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="452"/>
+        <location filename="../screens/MediaListScreen.qml" line="456"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 entradas</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="453"/>
+        <location filename="../screens/MediaListScreen.qml" line="457"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -650,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3161"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3167"/>
+        <location filename="../app/Main.qml" line="3177"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
@@ -729,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3165"/>
+        <location filename="../app/Main.qml" line="3175"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3169"/>
+        <location filename="../app/Main.qml" line="3179"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3181"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3173"/>
+        <location filename="../app/Main.qml" line="3183"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -443,34 +443,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="177"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="186"/>
         <source>%1 files</source>
         <translation>%1 archivos</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="54"/>
+        <location filename="../screens/GamesScreen.qml" line="59"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
-        <location filename="../screens/GamesScreen.qml" line="178"/>
+        <location filename="../screens/GamesScreen.qml" line="155"/>
+        <location filename="../screens/GamesScreen.qml" line="187"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="49"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="151"/>
         <source>Loading more…</source>
         <translation>Cargando más…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="53"/>
         <source>No games in this system</source>
         <translation>No hay juegos en este sistema</translation>
     </message>
@@ -599,148 +599,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1518"/>
+        <location filename="../app/Main.qml" line="1525"/>
         <source>Launch core</source>
         <translation>Lanzar core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1527"/>
-        <location filename="../app/Main.qml" line="1772"/>
+        <location filename="../app/Main.qml" line="1534"/>
+        <location filename="../app/Main.qml" line="1779"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Remove from favorites</source>
         <translation>Eliminar de favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Add to favorites</source>
         <translation>Agregar a favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1596"/>
+        <location filename="../app/Main.qml" line="1603"/>
         <source>Write to NFC token</source>
         <translation>Escribir en token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1600"/>
+        <location filename="../app/Main.qml" line="1607"/>
         <source>QR code</source>
         <translation>Código QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1575"/>
-        <location filename="../app/Main.qml" line="1610"/>
+        <location filename="../app/Main.qml" line="1582"/>
+        <location filename="../app/Main.qml" line="1617"/>
         <source>Launch game</source>
         <translation>Iniciar juego</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2120"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2116"/>
+        <location filename="../app/Main.qml" line="2123"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3025"/>
+        <location filename="../app/Main.qml" line="3039"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3031"/>
+        <location filename="../app/Main.qml" line="3045"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3027"/>
+        <location filename="../app/Main.qml" line="3041"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1534"/>
-        <location filename="../app/Main.qml" line="1563"/>
+        <location filename="../app/Main.qml" line="1541"/>
+        <location filename="../app/Main.qml" line="1570"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizar base de datos de medios</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1537"/>
-        <location filename="../app/Main.qml" line="1566"/>
+        <location filename="../app/Main.qml" line="1544"/>
+        <location filename="../app/Main.qml" line="1573"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extraer metadatos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Default</source>
         <translation type="unfinished">Por defecto</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2263"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2274"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2289"/>
         <source>Retry</source>
         <translation type="unfinished">Reintentar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2286"/>
+        <location filename="../app/Main.qml" line="2293"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3043"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3033"/>
+        <location filename="../app/Main.qml" line="3047"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3035"/>
+        <location filename="../app/Main.qml" line="3049"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3037"/>
+        <location filename="../app/Main.qml" line="3051"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -373,6 +373,10 @@ Euskara - devilschile2</source>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
+    <message>
+        <source>%1 entries</source>
+        <translation type="obsolete">%1 entradas</translation>
+    </message>
 </context>
 <context>
     <name>FirstRunIndexModal</name>
@@ -646,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3152"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3158"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3154"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
@@ -725,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3067"/>
+        <location filename="../app/Main.qml" line="3156"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3073"/>
+        <location filename="../app/Main.qml" line="3162"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3164"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -650,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3152"/>
+        <location filename="../app/Main.qml" line="3161"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3158"/>
+        <location filename="../app/Main.qml" line="3167"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3154"/>
+        <location filename="../app/Main.qml" line="3163"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
@@ -729,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3156"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3160"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3164"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -646,17 +646,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3039"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3045"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3041"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
@@ -725,22 +725,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3067"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3047"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3049"/>
+        <location filename="../app/Main.qml" line="3073"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3051"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -960,12 +960,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="452"/>
+        <location filename="../screens/MediaListScreen.qml" line="456"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 sarrera</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="453"/>
+        <location filename="../screens/MediaListScreen.qml" line="457"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -443,34 +443,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="177"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="186"/>
         <source>%1 files</source>
         <translation>%1 fitxategi</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="54"/>
+        <location filename="../screens/GamesScreen.qml" line="59"/>
         <source>Loading game…</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
-        <location filename="../screens/GamesScreen.qml" line="178"/>
+        <location filename="../screens/GamesScreen.qml" line="155"/>
+        <location filename="../screens/GamesScreen.qml" line="187"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="49"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading games…</source>
         <translation type="unfinished">Jokuak kargatzen</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="151"/>
         <source>Loading more…</source>
         <translation type="unfinished">Gehiago kargatzen...</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="53"/>
         <source>No games in this system</source>
         <translation>Sistema honek ez du jokurik</translation>
     </message>
@@ -607,148 +607,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1518"/>
+        <location filename="../app/Main.qml" line="1525"/>
         <source>Launch core</source>
         <translation type="unfinished">Exekutatu nukleoa</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1527"/>
-        <location filename="../app/Main.qml" line="1772"/>
+        <location filename="../app/Main.qml" line="1534"/>
+        <location filename="../app/Main.qml" line="1779"/>
         <source>Change launcher</source>
         <translation type="unfinished">Aldatu abiarazlea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Remove from favorites</source>
         <translation type="unfinished">Kendu gogokoetatik</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Add to favorites</source>
         <translation type="unfinished">Gehitu gogokoetan</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1596"/>
+        <location filename="../app/Main.qml" line="1603"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Idatzi NFC token-a</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1600"/>
+        <location filename="../app/Main.qml" line="1607"/>
         <source>QR code</source>
         <translation type="unfinished">QR kodea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1575"/>
-        <location filename="../app/Main.qml" line="1610"/>
+        <location filename="../app/Main.qml" line="1582"/>
+        <location filename="../app/Main.qml" line="1617"/>
         <source>Launch game</source>
         <translation type="unfinished">Abiarazi jokua</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2120"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2116"/>
+        <location filename="../app/Main.qml" line="2123"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3025"/>
+        <location filename="../app/Main.qml" line="3039"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3031"/>
+        <location filename="../app/Main.qml" line="3045"/>
         <source>Loading favorites…</source>
         <translation type="unfinished">Gogokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3027"/>
+        <location filename="../app/Main.qml" line="3041"/>
         <source>Loading games…</source>
         <translation type="unfinished">Jokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1534"/>
-        <location filename="../app/Main.qml" line="1563"/>
+        <location filename="../app/Main.qml" line="1541"/>
+        <location filename="../app/Main.qml" line="1570"/>
         <source>Update media database</source>
         <translation type="unfinished">Eguneratu multimedia datu-basea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1537"/>
-        <location filename="../app/Main.qml" line="1566"/>
+        <location filename="../app/Main.qml" line="1544"/>
+        <location filename="../app/Main.qml" line="1573"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadatuak scrapeatu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Default</source>
         <translation type="unfinished">Lehenetsia</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Current: %1</source>
         <translation type="unfinished">Unekoa: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2263"/>
         <source>Saving launcher</source>
         <translation type="unfinished">Abiarazlea gordetzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Saving…</source>
         <translation type="unfinished">Gordetzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2274"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Launcher update failed</source>
         <translation type="unfinished">Abiarazle egukeraketak huts egin du</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Error: %1</source>
         <translation type="unfinished">Errorea: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2289"/>
         <source>Retry</source>
         <translation type="unfinished">Berriro saiatu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2286"/>
+        <location filename="../app/Main.qml" line="2293"/>
         <source>Cancel</source>
         <translation type="unfinished">Utzi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3043"/>
         <source>Loading game…</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3033"/>
+        <location filename="../app/Main.qml" line="3047"/>
         <source>Loading recently played…</source>
         <translation type="unfinished">Duela gutxi jokatutakoak kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3035"/>
+        <location filename="../app/Main.qml" line="3049"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3037"/>
+        <location filename="../app/Main.qml" line="3051"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -373,6 +373,10 @@ Euskara - devilschile2</source>
         <source>Loading favorites…</source>
         <translation type="unfinished">Gogokoak kargatzen...</translation>
     </message>
+    <message>
+        <source>%1 entries</source>
+        <translation type="obsolete">%1 sarrera</translation>
+    </message>
 </context>
 <context>
     <name>FirstRunIndexModal</name>
@@ -654,17 +658,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3152"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3158"/>
         <source>Loading favorites…</source>
         <translation type="unfinished">Gogokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3154"/>
         <source>Loading games…</source>
         <translation type="unfinished">Jokoak kargatzen</translation>
     </message>
@@ -733,22 +737,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Utzi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3067"/>
+        <location filename="../app/Main.qml" line="3156"/>
         <source>Loading game…</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Loading recently played…</source>
         <translation type="unfinished">Duela gutxi jokatutakoak kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3073"/>
+        <location filename="../app/Main.qml" line="3162"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3164"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -658,17 +658,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3161"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3167"/>
+        <location filename="../app/Main.qml" line="3177"/>
         <source>Loading favorites…</source>
         <translation type="unfinished">Gogokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading games…</source>
         <translation type="unfinished">Jokoak kargatzen</translation>
     </message>
@@ -737,22 +737,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Utzi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3165"/>
+        <location filename="../app/Main.qml" line="3175"/>
         <source>Loading game…</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3169"/>
+        <location filename="../app/Main.qml" line="3179"/>
         <source>Loading recently played…</source>
         <translation type="unfinished">Duela gutxi jokatutakoak kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3181"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3173"/>
+        <location filename="../app/Main.qml" line="3183"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -654,17 +654,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3039"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3045"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Loading favorites…</source>
         <translation type="unfinished">Gogokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3041"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Loading games…</source>
         <translation type="unfinished">Jokoak kargatzen</translation>
     </message>
@@ -733,22 +733,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Utzi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3067"/>
         <source>Loading game…</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3047"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Loading recently played…</source>
         <translation type="unfinished">Duela gutxi jokatutakoak kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3049"/>
+        <location filename="../app/Main.qml" line="3073"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3051"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -658,17 +658,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3152"/>
+        <location filename="../app/Main.qml" line="3161"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3158"/>
+        <location filename="../app/Main.qml" line="3167"/>
         <source>Loading favorites…</source>
         <translation type="unfinished">Gogokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3154"/>
+        <location filename="../app/Main.qml" line="3163"/>
         <source>Loading games…</source>
         <translation type="unfinished">Jokoak kargatzen</translation>
     </message>
@@ -737,22 +737,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Utzi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3156"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Loading game…</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3160"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Loading recently played…</source>
         <translation type="unfinished">Duela gutxi jokatutakoak kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3164"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -443,34 +443,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="177"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="186"/>
         <source>%1 files</source>
         <translation>%1 קבצים</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="54"/>
+        <location filename="../screens/GamesScreen.qml" line="59"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
-        <location filename="../screens/GamesScreen.qml" line="178"/>
+        <location filename="../screens/GamesScreen.qml" line="155"/>
+        <location filename="../screens/GamesScreen.qml" line="187"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="53"/>
         <source>No games in this system</source>
         <translation>אין משחקים במערכת זו</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="49"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="151"/>
         <source>Loading more…</source>
         <translation>טוען עוד…</translation>
     </message>
@@ -599,148 +599,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1518"/>
+        <location filename="../app/Main.qml" line="1525"/>
         <source>Launch core</source>
         <translation>הפעל את הליבה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1527"/>
-        <location filename="../app/Main.qml" line="1772"/>
+        <location filename="../app/Main.qml" line="1534"/>
+        <location filename="../app/Main.qml" line="1779"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1534"/>
-        <location filename="../app/Main.qml" line="1563"/>
+        <location filename="../app/Main.qml" line="1541"/>
+        <location filename="../app/Main.qml" line="1570"/>
         <source>Update media database</source>
         <translation type="unfinished">עדכון מסד נתוני המדיה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1537"/>
-        <location filename="../app/Main.qml" line="1566"/>
+        <location filename="../app/Main.qml" line="1544"/>
+        <location filename="../app/Main.qml" line="1573"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">איסוף מטא-נתונים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1575"/>
-        <location filename="../app/Main.qml" line="1610"/>
+        <location filename="../app/Main.qml" line="1582"/>
+        <location filename="../app/Main.qml" line="1617"/>
         <source>Launch game</source>
         <translation>הפעל משחק</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Remove from favorites</source>
         <translation>הסר מהמועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Add to favorites</source>
         <translation>הוסף למועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1596"/>
+        <location filename="../app/Main.qml" line="1603"/>
         <source>Write to NFC token</source>
         <translation>כתוב לטוקן NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1600"/>
+        <location filename="../app/Main.qml" line="1607"/>
         <source>QR code</source>
         <translation>קוד QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Default</source>
         <translation type="unfinished">ברירת מחדל</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2120"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2116"/>
+        <location filename="../app/Main.qml" line="2123"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2263"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2274"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2289"/>
         <source>Retry</source>
         <translation type="unfinished">נסה שוב</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2286"/>
+        <location filename="../app/Main.qml" line="2293"/>
         <source>Cancel</source>
         <translation type="unfinished">ביטול</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3025"/>
+        <location filename="../app/Main.qml" line="3039"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3027"/>
+        <location filename="../app/Main.qml" line="3041"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3043"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3031"/>
+        <location filename="../app/Main.qml" line="3045"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3033"/>
+        <location filename="../app/Main.qml" line="3047"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3035"/>
+        <location filename="../app/Main.qml" line="3049"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3037"/>
+        <location filename="../app/Main.qml" line="3051"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -710,37 +710,37 @@ Euskara - devilschile2</source>
         <translation type="unfinished">ביטול</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3039"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3041"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3067"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3045"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3047"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3049"/>
+        <location filename="../app/Main.qml" line="3073"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3051"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -714,37 +714,37 @@ Euskara - devilschile2</source>
         <translation type="unfinished">ביטול</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3161"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3165"/>
+        <location filename="../app/Main.qml" line="3175"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3167"/>
+        <location filename="../app/Main.qml" line="3177"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3169"/>
+        <location filename="../app/Main.qml" line="3179"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3181"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3173"/>
+        <location filename="../app/Main.qml" line="3183"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -952,12 +952,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">טוען…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="452"/>
+        <location filename="../screens/MediaListScreen.qml" line="456"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 פריטים</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="453"/>
+        <location filename="../screens/MediaListScreen.qml" line="457"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -714,37 +714,37 @@ Euskara - devilschile2</source>
         <translation type="unfinished">ביטול</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3152"/>
+        <location filename="../app/Main.qml" line="3161"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3154"/>
+        <location filename="../app/Main.qml" line="3163"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3156"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3158"/>
+        <location filename="../app/Main.qml" line="3167"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3160"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3164"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -373,6 +373,10 @@ Euskara - devilschile2</source>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
+    <message>
+        <source>%1 entries</source>
+        <translation type="obsolete">%1 פריטים</translation>
+    </message>
 </context>
 <context>
     <name>FirstRunIndexModal</name>
@@ -710,37 +714,37 @@ Euskara - devilschile2</source>
         <translation type="unfinished">ביטול</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3152"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3154"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3067"/>
+        <location filename="../app/Main.qml" line="3156"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3158"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3073"/>
+        <location filename="../app/Main.qml" line="3162"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3164"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -443,34 +443,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="177"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="186"/>
         <source>%1 files</source>
         <translation>%1 फ़ाइलें</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="54"/>
+        <location filename="../screens/GamesScreen.qml" line="59"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
-        <location filename="../screens/GamesScreen.qml" line="178"/>
+        <location filename="../screens/GamesScreen.qml" line="155"/>
+        <location filename="../screens/GamesScreen.qml" line="187"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="53"/>
         <source>No games in this system</source>
         <translation>इस सिस्टम में कोई गेम नहीं है</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="49"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="151"/>
         <source>Loading more…</source>
         <translation>और लोड हो रहा है…</translation>
     </message>
@@ -599,148 +599,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1518"/>
+        <location filename="../app/Main.qml" line="1525"/>
         <source>Launch core</source>
         <translation>कोर चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1527"/>
-        <location filename="../app/Main.qml" line="1772"/>
+        <location filename="../app/Main.qml" line="1534"/>
+        <location filename="../app/Main.qml" line="1779"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1534"/>
-        <location filename="../app/Main.qml" line="1563"/>
+        <location filename="../app/Main.qml" line="1541"/>
+        <location filename="../app/Main.qml" line="1570"/>
         <source>Update media database</source>
         <translation type="unfinished">मीडिया डेटाबेस अपडेट करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1537"/>
-        <location filename="../app/Main.qml" line="1566"/>
+        <location filename="../app/Main.qml" line="1544"/>
+        <location filename="../app/Main.qml" line="1573"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">मेटाडेटा स्क्रैप करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1575"/>
-        <location filename="../app/Main.qml" line="1610"/>
+        <location filename="../app/Main.qml" line="1582"/>
+        <location filename="../app/Main.qml" line="1617"/>
         <source>Launch game</source>
         <translation>गेम चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Remove from favorites</source>
         <translation>पसंदीदा से हटाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Add to favorites</source>
         <translation>पसंदीदा में जोड़ें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1596"/>
+        <location filename="../app/Main.qml" line="1603"/>
         <source>Write to NFC token</source>
         <translation>NFC टोकन पर लिखें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1600"/>
+        <location filename="../app/Main.qml" line="1607"/>
         <source>QR code</source>
         <translation>QR कोड</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Default</source>
         <translation type="unfinished">डिफ़ॉल्ट</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2120"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2116"/>
+        <location filename="../app/Main.qml" line="2123"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2263"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2274"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2289"/>
         <source>Retry</source>
         <translation type="unfinished">फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2286"/>
+        <location filename="../app/Main.qml" line="2293"/>
         <source>Cancel</source>
         <translation type="unfinished">रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3025"/>
+        <location filename="../app/Main.qml" line="3039"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3027"/>
+        <location filename="../app/Main.qml" line="3041"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3043"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3031"/>
+        <location filename="../app/Main.qml" line="3045"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3033"/>
+        <location filename="../app/Main.qml" line="3047"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3035"/>
+        <location filename="../app/Main.qml" line="3049"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3037"/>
+        <location filename="../app/Main.qml" line="3051"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -714,37 +714,37 @@ Euskara - devilschile2</source>
         <translation type="unfinished">रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3152"/>
+        <location filename="../app/Main.qml" line="3161"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3154"/>
+        <location filename="../app/Main.qml" line="3163"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3156"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3158"/>
+        <location filename="../app/Main.qml" line="3167"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3160"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3164"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -952,12 +952,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">लोड हो रहा है…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="452"/>
+        <location filename="../screens/MediaListScreen.qml" line="456"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 प्रविष्टियाँ</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="453"/>
+        <location filename="../screens/MediaListScreen.qml" line="457"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -714,37 +714,37 @@ Euskara - devilschile2</source>
         <translation type="unfinished">रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3161"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3165"/>
+        <location filename="../app/Main.qml" line="3175"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3167"/>
+        <location filename="../app/Main.qml" line="3177"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3169"/>
+        <location filename="../app/Main.qml" line="3179"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3181"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3173"/>
+        <location filename="../app/Main.qml" line="3183"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -373,6 +373,10 @@ Euskara - devilschile2</source>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
+    <message>
+        <source>%1 entries</source>
+        <translation type="obsolete">%1 प्रविष्टियाँ</translation>
+    </message>
 </context>
 <context>
     <name>FirstRunIndexModal</name>
@@ -710,37 +714,37 @@ Euskara - devilschile2</source>
         <translation type="unfinished">रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3152"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3154"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3067"/>
+        <location filename="../app/Main.qml" line="3156"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3158"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3073"/>
+        <location filename="../app/Main.qml" line="3162"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3164"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -710,37 +710,37 @@ Euskara - devilschile2</source>
         <translation type="unfinished">रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3039"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3041"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3067"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3045"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3047"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3049"/>
+        <location filename="../app/Main.qml" line="3073"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3051"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -952,12 +952,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Caricamento…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="452"/>
+        <location filename="../screens/MediaListScreen.qml" line="456"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 elementi</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="453"/>
+        <location filename="../screens/MediaListScreen.qml" line="457"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -646,17 +646,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3039"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3045"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3041"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
@@ -725,22 +725,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Annulla</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3067"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3047"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3049"/>
+        <location filename="../app/Main.qml" line="3073"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3051"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -650,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3161"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3167"/>
+        <location filename="../app/Main.qml" line="3177"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
@@ -729,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Annulla</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3165"/>
+        <location filename="../app/Main.qml" line="3175"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3169"/>
+        <location filename="../app/Main.qml" line="3179"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3181"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3173"/>
+        <location filename="../app/Main.qml" line="3183"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -373,6 +373,10 @@ Euskara - devilschile2</source>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
+    <message>
+        <source>%1 entries</source>
+        <translation type="obsolete">%1 elementi</translation>
+    </message>
 </context>
 <context>
     <name>FirstRunIndexModal</name>
@@ -646,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3152"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3158"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3154"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
@@ -725,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Annulla</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3067"/>
+        <location filename="../app/Main.qml" line="3156"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3073"/>
+        <location filename="../app/Main.qml" line="3162"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3164"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -650,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3152"/>
+        <location filename="../app/Main.qml" line="3161"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3158"/>
+        <location filename="../app/Main.qml" line="3167"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3154"/>
+        <location filename="../app/Main.qml" line="3163"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
@@ -729,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Annulla</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3156"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3160"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3164"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -443,34 +443,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="177"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="186"/>
         <source>%1 files</source>
         <translation>%1 file</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="54"/>
+        <location filename="../screens/GamesScreen.qml" line="59"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
-        <location filename="../screens/GamesScreen.qml" line="178"/>
+        <location filename="../screens/GamesScreen.qml" line="155"/>
+        <location filename="../screens/GamesScreen.qml" line="187"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="49"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="151"/>
         <source>Loading more…</source>
         <translation>Caricamento altro…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="53"/>
         <source>No games in this system</source>
         <translation>Nessun gioco in questo sistema</translation>
     </message>
@@ -599,148 +599,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1518"/>
+        <location filename="../app/Main.qml" line="1525"/>
         <source>Launch core</source>
         <translation>Avvia core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1527"/>
-        <location filename="../app/Main.qml" line="1772"/>
+        <location filename="../app/Main.qml" line="1534"/>
+        <location filename="../app/Main.qml" line="1779"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Remove from favorites</source>
         <translation>Rimuovi dai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Add to favorites</source>
         <translation>Aggiungi ai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1596"/>
+        <location filename="../app/Main.qml" line="1603"/>
         <source>Write to NFC token</source>
         <translation>Scrivi sul token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1600"/>
+        <location filename="../app/Main.qml" line="1607"/>
         <source>QR code</source>
         <translation>Codice QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1575"/>
-        <location filename="../app/Main.qml" line="1610"/>
+        <location filename="../app/Main.qml" line="1582"/>
+        <location filename="../app/Main.qml" line="1617"/>
         <source>Launch game</source>
         <translation>Avvia gioco</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2120"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2116"/>
+        <location filename="../app/Main.qml" line="2123"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3025"/>
+        <location filename="../app/Main.qml" line="3039"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3031"/>
+        <location filename="../app/Main.qml" line="3045"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3027"/>
+        <location filename="../app/Main.qml" line="3041"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1534"/>
-        <location filename="../app/Main.qml" line="1563"/>
+        <location filename="../app/Main.qml" line="1541"/>
+        <location filename="../app/Main.qml" line="1570"/>
         <source>Update media database</source>
         <translation type="unfinished">Aggiorna database multimediale</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1537"/>
-        <location filename="../app/Main.qml" line="1566"/>
+        <location filename="../app/Main.qml" line="1544"/>
+        <location filename="../app/Main.qml" line="1573"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Recupera metadati</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Default</source>
         <translation type="unfinished">Predefinito</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2263"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2274"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2289"/>
         <source>Retry</source>
         <translation type="unfinished">Riprova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2286"/>
+        <location filename="../app/Main.qml" line="2293"/>
         <source>Cancel</source>
         <translation type="unfinished">Annulla</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3043"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3033"/>
+        <location filename="../app/Main.qml" line="3047"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3035"/>
+        <location filename="../app/Main.qml" line="3049"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3037"/>
+        <location filename="../app/Main.qml" line="3051"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -650,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3161"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3167"/>
+        <location filename="../app/Main.qml" line="3177"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
@@ -729,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3165"/>
+        <location filename="../app/Main.qml" line="3175"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3169"/>
+        <location filename="../app/Main.qml" line="3179"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3181"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3173"/>
+        <location filename="../app/Main.qml" line="3183"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -952,12 +952,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="452"/>
+        <location filename="../screens/MediaListScreen.qml" line="456"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 件</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="453"/>
+        <location filename="../screens/MediaListScreen.qml" line="457"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -443,34 +443,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="177"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="186"/>
         <source>%1 files</source>
         <translation>%1 ファイル</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="54"/>
+        <location filename="../screens/GamesScreen.qml" line="59"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
-        <location filename="../screens/GamesScreen.qml" line="178"/>
+        <location filename="../screens/GamesScreen.qml" line="155"/>
+        <location filename="../screens/GamesScreen.qml" line="187"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="49"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="151"/>
         <source>Loading more…</source>
         <translation>さらに読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="53"/>
         <source>No games in this system</source>
         <translation>このシステムにゲームはありません</translation>
     </message>
@@ -599,148 +599,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1518"/>
+        <location filename="../app/Main.qml" line="1525"/>
         <source>Launch core</source>
         <translation>コアを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1527"/>
-        <location filename="../app/Main.qml" line="1772"/>
+        <location filename="../app/Main.qml" line="1534"/>
+        <location filename="../app/Main.qml" line="1779"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Remove from favorites</source>
         <translation>お気に入りから削除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Add to favorites</source>
         <translation>お気に入りに追加</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1596"/>
+        <location filename="../app/Main.qml" line="1603"/>
         <source>Write to NFC token</source>
         <translation>NFC トークンに書き込む</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1600"/>
+        <location filename="../app/Main.qml" line="1607"/>
         <source>QR code</source>
         <translation>QR コード</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1575"/>
-        <location filename="../app/Main.qml" line="1610"/>
+        <location filename="../app/Main.qml" line="1582"/>
+        <location filename="../app/Main.qml" line="1617"/>
         <source>Launch game</source>
         <translation>ゲームを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2120"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2116"/>
+        <location filename="../app/Main.qml" line="2123"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3025"/>
+        <location filename="../app/Main.qml" line="3039"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3031"/>
+        <location filename="../app/Main.qml" line="3045"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3027"/>
+        <location filename="../app/Main.qml" line="3041"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1534"/>
-        <location filename="../app/Main.qml" line="1563"/>
+        <location filename="../app/Main.qml" line="1541"/>
+        <location filename="../app/Main.qml" line="1570"/>
         <source>Update media database</source>
         <translation type="unfinished">メディアデータベースを更新</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1537"/>
-        <location filename="../app/Main.qml" line="1566"/>
+        <location filename="../app/Main.qml" line="1544"/>
+        <location filename="../app/Main.qml" line="1573"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">メタデータをスクレイピング</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Default</source>
         <translation type="unfinished">デフォルト</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2263"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2274"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2289"/>
         <source>Retry</source>
         <translation type="unfinished">再試行</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2286"/>
+        <location filename="../app/Main.qml" line="2293"/>
         <source>Cancel</source>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3043"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3033"/>
+        <location filename="../app/Main.qml" line="3047"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3035"/>
+        <location filename="../app/Main.qml" line="3049"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3037"/>
+        <location filename="../app/Main.qml" line="3051"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -650,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3152"/>
+        <location filename="../app/Main.qml" line="3161"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3158"/>
+        <location filename="../app/Main.qml" line="3167"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3154"/>
+        <location filename="../app/Main.qml" line="3163"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
@@ -729,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3156"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3160"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3164"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -373,6 +373,10 @@ Euskara - devilschile2</source>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
+    <message>
+        <source>%1 entries</source>
+        <translation type="obsolete">%1 件</translation>
+    </message>
 </context>
 <context>
     <name>FirstRunIndexModal</name>
@@ -646,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3152"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3158"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3154"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
@@ -725,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3067"/>
+        <location filename="../app/Main.qml" line="3156"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3073"/>
+        <location filename="../app/Main.qml" line="3162"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3164"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -646,17 +646,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3039"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3045"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3041"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
@@ -725,22 +725,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3067"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3047"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3049"/>
+        <location filename="../app/Main.qml" line="3073"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3051"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -952,12 +952,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="452"/>
+        <location filename="../screens/MediaListScreen.qml" line="456"/>
         <source>%1 entries</source>
         <translation type="unfinished">항목 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="453"/>
+        <location filename="../screens/MediaListScreen.qml" line="457"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -714,37 +714,37 @@ Euskara - devilschile2</source>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3152"/>
+        <location filename="../app/Main.qml" line="3161"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3154"/>
+        <location filename="../app/Main.qml" line="3163"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3156"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3158"/>
+        <location filename="../app/Main.qml" line="3167"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3160"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3164"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -443,34 +443,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="177"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="186"/>
         <source>%1 files</source>
         <translation>파일 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="54"/>
+        <location filename="../screens/GamesScreen.qml" line="59"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
-        <location filename="../screens/GamesScreen.qml" line="178"/>
+        <location filename="../screens/GamesScreen.qml" line="155"/>
+        <location filename="../screens/GamesScreen.qml" line="187"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="53"/>
         <source>No games in this system</source>
         <translation>이 시스템에는 게임이 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="49"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="151"/>
         <source>Loading more…</source>
         <translation>더 불러오는 중…</translation>
     </message>
@@ -599,148 +599,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1518"/>
+        <location filename="../app/Main.qml" line="1525"/>
         <source>Launch core</source>
         <translation>코어 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1527"/>
-        <location filename="../app/Main.qml" line="1772"/>
+        <location filename="../app/Main.qml" line="1534"/>
+        <location filename="../app/Main.qml" line="1779"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1534"/>
-        <location filename="../app/Main.qml" line="1563"/>
+        <location filename="../app/Main.qml" line="1541"/>
+        <location filename="../app/Main.qml" line="1570"/>
         <source>Update media database</source>
         <translation type="unfinished">미디어 데이터베이스 업데이트</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1537"/>
-        <location filename="../app/Main.qml" line="1566"/>
+        <location filename="../app/Main.qml" line="1544"/>
+        <location filename="../app/Main.qml" line="1573"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">메타데이터 수집</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1575"/>
-        <location filename="../app/Main.qml" line="1610"/>
+        <location filename="../app/Main.qml" line="1582"/>
+        <location filename="../app/Main.qml" line="1617"/>
         <source>Launch game</source>
         <translation>게임 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Remove from favorites</source>
         <translation>즐겨찾기에서 제거</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Add to favorites</source>
         <translation>즐겨찾기에 추가</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1596"/>
+        <location filename="../app/Main.qml" line="1603"/>
         <source>Write to NFC token</source>
         <translation>NFC 토큰에 쓰기</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1600"/>
+        <location filename="../app/Main.qml" line="1607"/>
         <source>QR code</source>
         <translation>QR 코드</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Default</source>
         <translation type="unfinished">기본값</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2120"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2116"/>
+        <location filename="../app/Main.qml" line="2123"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2263"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2274"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2289"/>
         <source>Retry</source>
         <translation type="unfinished">다시 시도</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2286"/>
+        <location filename="../app/Main.qml" line="2293"/>
         <source>Cancel</source>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3025"/>
+        <location filename="../app/Main.qml" line="3039"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3027"/>
+        <location filename="../app/Main.qml" line="3041"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3043"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3031"/>
+        <location filename="../app/Main.qml" line="3045"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3033"/>
+        <location filename="../app/Main.qml" line="3047"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3035"/>
+        <location filename="../app/Main.qml" line="3049"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3037"/>
+        <location filename="../app/Main.qml" line="3051"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -710,37 +710,37 @@ Euskara - devilschile2</source>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3039"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3041"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3067"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3045"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3047"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3049"/>
+        <location filename="../app/Main.qml" line="3073"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3051"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -714,37 +714,37 @@ Euskara - devilschile2</source>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3161"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3165"/>
+        <location filename="../app/Main.qml" line="3175"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3167"/>
+        <location filename="../app/Main.qml" line="3177"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3169"/>
+        <location filename="../app/Main.qml" line="3179"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3181"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3173"/>
+        <location filename="../app/Main.qml" line="3183"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -373,6 +373,10 @@ Euskara - devilschile2</source>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
+    <message>
+        <source>%1 entries</source>
+        <translation type="obsolete">항목 %1개</translation>
+    </message>
 </context>
 <context>
     <name>FirstRunIndexModal</name>
@@ -710,37 +714,37 @@ Euskara - devilschile2</source>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3152"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3154"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3067"/>
+        <location filename="../app/Main.qml" line="3156"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3158"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3073"/>
+        <location filename="../app/Main.qml" line="3162"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3164"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -650,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3152"/>
+        <location filename="../app/Main.qml" line="3161"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3158"/>
+        <location filename="../app/Main.qml" line="3167"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3154"/>
+        <location filename="../app/Main.qml" line="3163"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
@@ -729,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3156"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3160"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3164"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -373,6 +373,10 @@ Euskara - devilschile2</source>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
+    <message>
+        <source>%1 entries</source>
+        <translation type="obsolete">%1 items</translation>
+    </message>
 </context>
 <context>
     <name>FirstRunIndexModal</name>
@@ -646,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3152"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3158"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3154"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
@@ -725,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3067"/>
+        <location filename="../app/Main.qml" line="3156"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3073"/>
+        <location filename="../app/Main.qml" line="3162"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3164"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -646,17 +646,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3039"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3045"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3041"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
@@ -725,22 +725,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3067"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3047"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3049"/>
+        <location filename="../app/Main.qml" line="3073"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3051"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -650,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3161"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3167"/>
+        <location filename="../app/Main.qml" line="3177"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
@@ -729,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3165"/>
+        <location filename="../app/Main.qml" line="3175"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3169"/>
+        <location filename="../app/Main.qml" line="3179"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3181"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3173"/>
+        <location filename="../app/Main.qml" line="3183"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -952,12 +952,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Laden…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="452"/>
+        <location filename="../screens/MediaListScreen.qml" line="456"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 items</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="453"/>
+        <location filename="../screens/MediaListScreen.qml" line="457"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -443,34 +443,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="177"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="186"/>
         <source>%1 files</source>
         <translation>%1 bestanden</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="54"/>
+        <location filename="../screens/GamesScreen.qml" line="59"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
-        <location filename="../screens/GamesScreen.qml" line="178"/>
+        <location filename="../screens/GamesScreen.qml" line="155"/>
+        <location filename="../screens/GamesScreen.qml" line="187"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="49"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="151"/>
         <source>Loading more…</source>
         <translation>Meer laden…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="53"/>
         <source>No games in this system</source>
         <translation>Geen games in dit systeem</translation>
     </message>
@@ -599,148 +599,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1518"/>
+        <location filename="../app/Main.qml" line="1525"/>
         <source>Launch core</source>
         <translation>Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1527"/>
-        <location filename="../app/Main.qml" line="1772"/>
+        <location filename="../app/Main.qml" line="1534"/>
+        <location filename="../app/Main.qml" line="1779"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Remove from favorites</source>
         <translation>Uit favorieten verwijderen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Add to favorites</source>
         <translation>Aan favorieten toevoegen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1596"/>
+        <location filename="../app/Main.qml" line="1603"/>
         <source>Write to NFC token</source>
         <translation>Naar NFC-token schrijven</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1600"/>
+        <location filename="../app/Main.qml" line="1607"/>
         <source>QR code</source>
         <translation>QR-code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1575"/>
-        <location filename="../app/Main.qml" line="1610"/>
+        <location filename="../app/Main.qml" line="1582"/>
+        <location filename="../app/Main.qml" line="1617"/>
         <source>Launch game</source>
         <translation>Game starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2120"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2116"/>
+        <location filename="../app/Main.qml" line="2123"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3025"/>
+        <location filename="../app/Main.qml" line="3039"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3031"/>
+        <location filename="../app/Main.qml" line="3045"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3027"/>
+        <location filename="../app/Main.qml" line="3041"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1534"/>
-        <location filename="../app/Main.qml" line="1563"/>
+        <location filename="../app/Main.qml" line="1541"/>
+        <location filename="../app/Main.qml" line="1570"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediadatabase bijwerken</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1537"/>
-        <location filename="../app/Main.qml" line="1566"/>
+        <location filename="../app/Main.qml" line="1544"/>
+        <location filename="../app/Main.qml" line="1573"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadata ophalen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Default</source>
         <translation type="unfinished">Standaard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2263"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2274"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2289"/>
         <source>Retry</source>
         <translation type="unfinished">Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2286"/>
+        <location filename="../app/Main.qml" line="2293"/>
         <source>Cancel</source>
         <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3043"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3033"/>
+        <location filename="../app/Main.qml" line="3047"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3035"/>
+        <location filename="../app/Main.qml" line="3049"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3037"/>
+        <location filename="../app/Main.qml" line="3051"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -443,34 +443,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="177"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="186"/>
         <source>%1 files</source>
         <translation>%1 fișiere</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="54"/>
+        <location filename="../screens/GamesScreen.qml" line="59"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
-        <location filename="../screens/GamesScreen.qml" line="178"/>
+        <location filename="../screens/GamesScreen.qml" line="155"/>
+        <location filename="../screens/GamesScreen.qml" line="187"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="49"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="151"/>
         <source>Loading more…</source>
         <translation>Se încarcă mai multe…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="53"/>
         <source>No games in this system</source>
         <translation>Niciun joc în acest sistem</translation>
     </message>
@@ -599,148 +599,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1518"/>
+        <location filename="../app/Main.qml" line="1525"/>
         <source>Launch core</source>
         <translation>Lansare core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1527"/>
-        <location filename="../app/Main.qml" line="1772"/>
+        <location filename="../app/Main.qml" line="1534"/>
+        <location filename="../app/Main.qml" line="1779"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Remove from favorites</source>
         <translation>Elimină din favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Add to favorites</source>
         <translation>Adaugă la favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1596"/>
+        <location filename="../app/Main.qml" line="1603"/>
         <source>Write to NFC token</source>
         <translation>Scriere pe token NFC</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1600"/>
+        <location filename="../app/Main.qml" line="1607"/>
         <source>QR code</source>
         <translation>Cod QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1575"/>
-        <location filename="../app/Main.qml" line="1610"/>
+        <location filename="../app/Main.qml" line="1582"/>
+        <location filename="../app/Main.qml" line="1617"/>
         <source>Launch game</source>
         <translation>Lansare joc</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2120"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2116"/>
+        <location filename="../app/Main.qml" line="2123"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3025"/>
+        <location filename="../app/Main.qml" line="3039"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3031"/>
+        <location filename="../app/Main.qml" line="3045"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3027"/>
+        <location filename="../app/Main.qml" line="3041"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1534"/>
-        <location filename="../app/Main.qml" line="1563"/>
+        <location filename="../app/Main.qml" line="1541"/>
+        <location filename="../app/Main.qml" line="1570"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizare bază de date media</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1537"/>
-        <location filename="../app/Main.qml" line="1566"/>
+        <location filename="../app/Main.qml" line="1544"/>
+        <location filename="../app/Main.qml" line="1573"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extragere metadate</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Default</source>
         <translation type="unfinished">Implicit</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2263"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2274"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2289"/>
         <source>Retry</source>
         <translation type="unfinished">Reîncercare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2286"/>
+        <location filename="../app/Main.qml" line="2293"/>
         <source>Cancel</source>
         <translation type="unfinished">Anulare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3043"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3033"/>
+        <location filename="../app/Main.qml" line="3047"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3035"/>
+        <location filename="../app/Main.qml" line="3049"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3037"/>
+        <location filename="../app/Main.qml" line="3051"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -646,17 +646,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3039"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3045"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3041"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
@@ -725,22 +725,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Anulare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3067"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3047"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3049"/>
+        <location filename="../app/Main.qml" line="3073"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3051"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -952,12 +952,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Se încarcă…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="452"/>
+        <location filename="../screens/MediaListScreen.qml" line="456"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 intrări</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="453"/>
+        <location filename="../screens/MediaListScreen.qml" line="457"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -373,6 +373,10 @@ Euskara - devilschile2</source>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
+    <message>
+        <source>%1 entries</source>
+        <translation type="obsolete">%1 intrări</translation>
+    </message>
 </context>
 <context>
     <name>FirstRunIndexModal</name>
@@ -646,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3152"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3158"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3154"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
@@ -725,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Anulare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3067"/>
+        <location filename="../app/Main.qml" line="3156"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3073"/>
+        <location filename="../app/Main.qml" line="3162"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3164"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -650,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3161"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3167"/>
+        <location filename="../app/Main.qml" line="3177"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
@@ -729,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Anulare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3165"/>
+        <location filename="../app/Main.qml" line="3175"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3169"/>
+        <location filename="../app/Main.qml" line="3179"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3181"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3173"/>
+        <location filename="../app/Main.qml" line="3183"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -650,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3152"/>
+        <location filename="../app/Main.qml" line="3161"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3158"/>
+        <location filename="../app/Main.qml" line="3167"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3154"/>
+        <location filename="../app/Main.qml" line="3163"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
@@ -729,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Anulare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3156"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3160"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3164"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -650,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3161"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3167"/>
+        <location filename="../app/Main.qml" line="3177"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
@@ -729,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3165"/>
+        <location filename="../app/Main.qml" line="3175"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3169"/>
+        <location filename="../app/Main.qml" line="3179"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3181"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3173"/>
+        <location filename="../app/Main.qml" line="3183"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -443,34 +443,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="177"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="186"/>
         <source>%1 files</source>
         <translation>%1 súborov</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="54"/>
+        <location filename="../screens/GamesScreen.qml" line="59"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
-        <location filename="../screens/GamesScreen.qml" line="178"/>
+        <location filename="../screens/GamesScreen.qml" line="155"/>
+        <location filename="../screens/GamesScreen.qml" line="187"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="49"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="151"/>
         <source>Loading more…</source>
         <translation>Načítava sa viac…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="53"/>
         <source>No games in this system</source>
         <translation>V tomto systéme nie sú žiadne hry</translation>
     </message>
@@ -599,148 +599,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1518"/>
+        <location filename="../app/Main.qml" line="1525"/>
         <source>Launch core</source>
         <translation>Spustiť core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1527"/>
-        <location filename="../app/Main.qml" line="1772"/>
+        <location filename="../app/Main.qml" line="1534"/>
+        <location filename="../app/Main.qml" line="1779"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Remove from favorites</source>
         <translation>Odstrániť z obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Add to favorites</source>
         <translation>Pridať do obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1596"/>
+        <location filename="../app/Main.qml" line="1603"/>
         <source>Write to NFC token</source>
         <translation>Zapísať na NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1600"/>
+        <location filename="../app/Main.qml" line="1607"/>
         <source>QR code</source>
         <translation>QR kód</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1575"/>
-        <location filename="../app/Main.qml" line="1610"/>
+        <location filename="../app/Main.qml" line="1582"/>
+        <location filename="../app/Main.qml" line="1617"/>
         <source>Launch game</source>
         <translation>Spustiť hru</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2120"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2116"/>
+        <location filename="../app/Main.qml" line="2123"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3025"/>
+        <location filename="../app/Main.qml" line="3039"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3031"/>
+        <location filename="../app/Main.qml" line="3045"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3027"/>
+        <location filename="../app/Main.qml" line="3041"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1534"/>
-        <location filename="../app/Main.qml" line="1563"/>
+        <location filename="../app/Main.qml" line="1541"/>
+        <location filename="../app/Main.qml" line="1570"/>
         <source>Update media database</source>
         <translation type="unfinished">Aktualizovať databázu médií</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1537"/>
-        <location filename="../app/Main.qml" line="1566"/>
+        <location filename="../app/Main.qml" line="1544"/>
+        <location filename="../app/Main.qml" line="1573"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Získať metadáta</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Default</source>
         <translation type="unfinished">Predvolené</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2263"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2274"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2289"/>
         <source>Retry</source>
         <translation type="unfinished">Skúsiť znova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2286"/>
+        <location filename="../app/Main.qml" line="2293"/>
         <source>Cancel</source>
         <translation type="unfinished">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3043"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3033"/>
+        <location filename="../app/Main.qml" line="3047"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3035"/>
+        <location filename="../app/Main.qml" line="3049"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3037"/>
+        <location filename="../app/Main.qml" line="3051"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -952,12 +952,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Načítanie…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="452"/>
+        <location filename="../screens/MediaListScreen.qml" line="456"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 položiek</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="453"/>
+        <location filename="../screens/MediaListScreen.qml" line="457"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -646,17 +646,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3039"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3045"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3041"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
@@ -725,22 +725,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3067"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3047"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3049"/>
+        <location filename="../app/Main.qml" line="3073"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3051"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -373,6 +373,10 @@ Euskara - devilschile2</source>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
+    <message>
+        <source>%1 entries</source>
+        <translation type="obsolete">%1 položiek</translation>
+    </message>
 </context>
 <context>
     <name>FirstRunIndexModal</name>
@@ -646,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3152"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3158"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3154"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
@@ -725,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3067"/>
+        <location filename="../app/Main.qml" line="3156"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3073"/>
+        <location filename="../app/Main.qml" line="3162"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3164"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -650,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3152"/>
+        <location filename="../app/Main.qml" line="3161"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3158"/>
+        <location filename="../app/Main.qml" line="3167"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3154"/>
+        <location filename="../app/Main.qml" line="3163"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
@@ -729,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3156"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3160"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3164"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -373,6 +373,10 @@ Euskara - devilschile2</source>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
+    <message>
+        <source>%1 entries</source>
+        <translation type="obsolete">%1 записів</translation>
+    </message>
 </context>
 <context>
     <name>FirstRunIndexModal</name>
@@ -646,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3152"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3158"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3154"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
@@ -725,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3067"/>
+        <location filename="../app/Main.qml" line="3156"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3073"/>
+        <location filename="../app/Main.qml" line="3162"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3164"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -650,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3161"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3167"/>
+        <location filename="../app/Main.qml" line="3177"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
@@ -729,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3165"/>
+        <location filename="../app/Main.qml" line="3175"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3169"/>
+        <location filename="../app/Main.qml" line="3179"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3181"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3173"/>
+        <location filename="../app/Main.qml" line="3183"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -650,17 +650,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3152"/>
+        <location filename="../app/Main.qml" line="3161"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3158"/>
+        <location filename="../app/Main.qml" line="3167"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3154"/>
+        <location filename="../app/Main.qml" line="3163"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
@@ -729,22 +729,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3156"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3160"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3164"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -443,34 +443,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="177"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="186"/>
         <source>%1 files</source>
         <translation>%1 файлів</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="54"/>
+        <location filename="../screens/GamesScreen.qml" line="59"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
-        <location filename="../screens/GamesScreen.qml" line="178"/>
+        <location filename="../screens/GamesScreen.qml" line="155"/>
+        <location filename="../screens/GamesScreen.qml" line="187"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="49"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="151"/>
         <source>Loading more…</source>
         <translation>Завантаження ще…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="53"/>
         <source>No games in this system</source>
         <translation>У цій системі немає ігор</translation>
     </message>
@@ -599,148 +599,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1518"/>
+        <location filename="../app/Main.qml" line="1525"/>
         <source>Launch core</source>
         <translation>Запустити core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1527"/>
-        <location filename="../app/Main.qml" line="1772"/>
+        <location filename="../app/Main.qml" line="1534"/>
+        <location filename="../app/Main.qml" line="1779"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Remove from favorites</source>
         <translation>Видалити з вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Add to favorites</source>
         <translation>Додати до вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1596"/>
+        <location filename="../app/Main.qml" line="1603"/>
         <source>Write to NFC token</source>
         <translation>Записати на NFC-токен</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1600"/>
+        <location filename="../app/Main.qml" line="1607"/>
         <source>QR code</source>
         <translation>QR-код</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1575"/>
-        <location filename="../app/Main.qml" line="1610"/>
+        <location filename="../app/Main.qml" line="1582"/>
+        <location filename="../app/Main.qml" line="1617"/>
         <source>Launch game</source>
         <translation>Запустити гру</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2120"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2116"/>
+        <location filename="../app/Main.qml" line="2123"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3025"/>
+        <location filename="../app/Main.qml" line="3039"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3031"/>
+        <location filename="../app/Main.qml" line="3045"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3027"/>
+        <location filename="../app/Main.qml" line="3041"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1534"/>
-        <location filename="../app/Main.qml" line="1563"/>
+        <location filename="../app/Main.qml" line="1541"/>
+        <location filename="../app/Main.qml" line="1570"/>
         <source>Update media database</source>
         <translation type="unfinished">Оновити базу медіа</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1537"/>
-        <location filename="../app/Main.qml" line="1566"/>
+        <location filename="../app/Main.qml" line="1544"/>
+        <location filename="../app/Main.qml" line="1573"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Отримати метадані</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Default</source>
         <translation type="unfinished">Типовий</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2263"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2274"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2289"/>
         <source>Retry</source>
         <translation type="unfinished">Повторити</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2286"/>
+        <location filename="../app/Main.qml" line="2293"/>
         <source>Cancel</source>
         <translation type="unfinished">Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3043"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3033"/>
+        <location filename="../app/Main.qml" line="3047"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3035"/>
+        <location filename="../app/Main.qml" line="3049"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3037"/>
+        <location filename="../app/Main.qml" line="3051"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -646,17 +646,17 @@ Euskara - devilschile2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3039"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3045"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3041"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
@@ -725,22 +725,22 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3067"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3047"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3049"/>
+        <location filename="../app/Main.qml" line="3073"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3051"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -952,12 +952,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">Завантаження…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="452"/>
+        <location filename="../screens/MediaListScreen.qml" line="456"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 записів</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="453"/>
+        <location filename="../screens/MediaListScreen.qml" line="457"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -373,6 +373,10 @@ Euskara - devilschile2</source>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
+    <message>
+        <source>%1 entries</source>
+        <translation type="obsolete">%1 个条目</translation>
+    </message>
 </context>
 <context>
     <name>FirstRunIndexModal</name>
@@ -710,37 +714,37 @@ Euskara - devilschile2</source>
         <translation type="unfinished">取消</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3152"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3154"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3067"/>
+        <location filename="../app/Main.qml" line="3156"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3158"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3073"/>
+        <location filename="../app/Main.qml" line="3162"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3164"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -952,12 +952,12 @@ Euskara - devilschile2</source>
         <translation type="unfinished">正在加载…</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="452"/>
+        <location filename="../screens/MediaListScreen.qml" line="456"/>
         <source>%1 entries</source>
         <translation type="unfinished">%1 个条目</translation>
     </message>
     <message>
-        <location filename="../screens/MediaListScreen.qml" line="453"/>
+        <location filename="../screens/MediaListScreen.qml" line="457"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -443,34 +443,34 @@ Euskara - devilschile2</source>
 <context>
     <name>GamesScreen</name>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="137"/>
-        <location filename="../screens/GamesScreen.qml" line="177"/>
+        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="186"/>
         <source>%1 files</source>
         <translation>%1 个文件</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="54"/>
+        <location filename="../screens/GamesScreen.qml" line="59"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="146"/>
-        <location filename="../screens/GamesScreen.qml" line="178"/>
+        <location filename="../screens/GamesScreen.qml" line="155"/>
+        <location filename="../screens/GamesScreen.qml" line="187"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="48"/>
+        <location filename="../screens/GamesScreen.qml" line="53"/>
         <source>No games in this system</source>
         <translation>此系统中没有游戏</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="49"/>
+        <location filename="../screens/GamesScreen.qml" line="54"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="142"/>
+        <location filename="../screens/GamesScreen.qml" line="151"/>
         <source>Loading more…</source>
         <translation>正在加载更多…</translation>
     </message>
@@ -599,148 +599,148 @@ Euskara - devilschile2</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1518"/>
+        <location filename="../app/Main.qml" line="1525"/>
         <source>Launch core</source>
         <translation>启动核心</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1527"/>
-        <location filename="../app/Main.qml" line="1772"/>
+        <location filename="../app/Main.qml" line="1534"/>
+        <location filename="../app/Main.qml" line="1779"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1534"/>
-        <location filename="../app/Main.qml" line="1563"/>
+        <location filename="../app/Main.qml" line="1541"/>
+        <location filename="../app/Main.qml" line="1570"/>
         <source>Update media database</source>
         <translation type="unfinished">更新媒体数据库</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1537"/>
-        <location filename="../app/Main.qml" line="1566"/>
+        <location filename="../app/Main.qml" line="1544"/>
+        <location filename="../app/Main.qml" line="1573"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">抓取元数据</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1542"/>
-        <location filename="../app/Main.qml" line="1551"/>
+        <location filename="../app/Main.qml" line="1549"/>
+        <location filename="../app/Main.qml" line="1558"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1575"/>
-        <location filename="../app/Main.qml" line="1610"/>
+        <location filename="../app/Main.qml" line="1582"/>
+        <location filename="../app/Main.qml" line="1617"/>
         <source>Launch game</source>
         <translation>启动游戏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Remove from favorites</source>
         <translation>从收藏中移除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1591"/>
+        <location filename="../app/Main.qml" line="1598"/>
         <source>Add to favorites</source>
         <translation>添加到收藏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1596"/>
+        <location filename="../app/Main.qml" line="1603"/>
         <source>Write to NFC token</source>
         <translation>写入 NFC 令牌</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1600"/>
+        <location filename="../app/Main.qml" line="1607"/>
         <source>QR code</source>
         <translation>二维码</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Default</source>
         <translation type="unfinished">默认</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1768"/>
+        <location filename="../app/Main.qml" line="1775"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2120"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2116"/>
+        <location filename="../app/Main.qml" line="2123"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2263"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2274"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2289"/>
         <source>Retry</source>
         <translation type="unfinished">重试</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2286"/>
+        <location filename="../app/Main.qml" line="2293"/>
         <source>Cancel</source>
         <translation type="unfinished">取消</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3025"/>
+        <location filename="../app/Main.qml" line="3039"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3027"/>
+        <location filename="../app/Main.qml" line="3041"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3043"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3031"/>
+        <location filename="../app/Main.qml" line="3045"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3033"/>
+        <location filename="../app/Main.qml" line="3047"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3035"/>
+        <location filename="../app/Main.qml" line="3049"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3037"/>
+        <location filename="../app/Main.qml" line="3051"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -714,37 +714,37 @@ Euskara - devilschile2</source>
         <translation type="unfinished">取消</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3161"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3165"/>
+        <location filename="../app/Main.qml" line="3175"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3167"/>
+        <location filename="../app/Main.qml" line="3177"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3169"/>
+        <location filename="../app/Main.qml" line="3179"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3181"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3173"/>
+        <location filename="../app/Main.qml" line="3183"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -710,37 +710,37 @@ Euskara - devilschile2</source>
         <translation type="unfinished">取消</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3039"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3041"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3067"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3045"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3047"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3049"/>
+        <location filename="../app/Main.qml" line="3073"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3051"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -714,37 +714,37 @@ Euskara - devilschile2</source>
         <translation type="unfinished">取消</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3152"/>
+        <location filename="../app/Main.qml" line="3161"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3154"/>
+        <location filename="../app/Main.qml" line="3163"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3156"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3158"/>
+        <location filename="../app/Main.qml" line="3167"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3160"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3164"/>
+        <location filename="../app/Main.qml" line="3173"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -10,6 +10,7 @@ import QtQuick
 import QtTest
 import Zaparoo.App
 import Zaparoo.Browse as Browse
+import Zaparoo.Screens
 import Zaparoo.Theme
 
 // Exercises the hub ↔ systems ↔ games navigation state machine defined
@@ -57,6 +58,11 @@ TestCase {
         main._stopRepeat();
         main._resetRapidNavigation();
         main._stopPageTurbo();
+        // Singleton state survives across TestCases in this binary; a
+        // modal left open by an earlier suite would trip the turbo's
+        // input gate and fail the paging tests for reasons unrelated
+        // to navigation.
+        ScreenManager.modalStack = [];
     }
 
     function cleanup(): void {

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -56,6 +56,7 @@ TestCase {
         // next test if we didn't reset it here.
         main._stopRepeat();
         main._resetRapidNavigation();
+        main._stopPageTurbo();
     }
 
     function cleanup(): void {
@@ -522,6 +523,41 @@ TestCase {
         // therefore exits on the chain window.
         wait(main._rapidNavigationChainQuietMs + 40);
         compare(main.rapidNavigationActive, false);
+    }
+
+    // Page turbo. The pad bridge delivers held page buttons as discrete
+    // press/release pairs, so the third chained press hands paging to a
+    // self-driven tick (see Main.qml's _notePageTurboPress). handleKey
+    // is called directly, which bypasses the Keys-level duplicate
+    // guard, so back-to-back presses chain without waits.
+    function test_page_turbo_engages_on_third_chained_press(): void {
+        main.handleKey(Qt.Key_PageDown);
+        compare(main._pageTurboChainCount, 1);
+        verify(!main.pageTurboRunning, "one press must not start turbo");
+        main.handleKey(Qt.Key_PageDown);
+        verify(!main.pageTurboRunning, "two presses must not start turbo");
+        main.handleKey(Qt.Key_PageDown);
+        verify(main.pageTurboRunning, "third chained press should start turbo");
+        compare(main.rapidNavigationActive, true, "turbo forces rapid mode so cover work pauses");
+    }
+
+    function test_page_turbo_stops_on_other_action(): void {
+        main.handleKey(Qt.Key_PageDown);
+        main.handleKey(Qt.Key_PageDown);
+        main.handleKey(Qt.Key_PageDown);
+        verify(main.pageTurboRunning);
+        main.handleKey(Qt.Key_Down);
+        verify(!main.pageTurboRunning, "a non-page action must stop turbo immediately");
+    }
+
+    function test_page_turbo_direction_flip_stops_and_pages_normally(): void {
+        main.handleKey(Qt.Key_PageDown);
+        main.handleKey(Qt.Key_PageDown);
+        main.handleKey(Qt.Key_PageDown);
+        verify(main.pageTurboRunning);
+        main.handleKey(Qt.Key_PageUp);
+        verify(!main.pageTurboRunning, "flipping direction must stop the old turbo");
+        compare(main._pageTurboChainCount, 1, "the flip press starts a fresh chain");
     }
 
     // Duplicate-input guard. The Keys.onPressed handler collapses a

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -529,35 +529,56 @@ TestCase {
     // press/release pairs, so the third chained press hands paging to a
     // self-driven tick (see Main.qml's _notePageTurboPress). handleKey
     // is called directly, which bypasses the Keys-level duplicate
-    // guard, so back-to-back presses chain without waits.
+    // guard, so back-to-back presses chain without waits. Each
+    // simulated press is followed by its release, matching the bridge's
+    // real pair shape, so the hold-repeat machinery disarms exactly as
+    // it does on device.
+    function _bridgePagePress(key: int): void {
+        main.handleKey(key);
+        main.handleKeyRelease(key);
+    }
+
     function test_page_turbo_engages_on_third_chained_press(): void {
-        main.handleKey(Qt.Key_PageDown);
+        _bridgePagePress(Qt.Key_PageDown);
         compare(main._pageTurboChainCount, 1);
         verify(!main.pageTurboRunning, "one press must not start turbo");
-        main.handleKey(Qt.Key_PageDown);
+        _bridgePagePress(Qt.Key_PageDown);
         verify(!main.pageTurboRunning, "two presses must not start turbo");
-        main.handleKey(Qt.Key_PageDown);
+        _bridgePagePress(Qt.Key_PageDown);
         verify(main.pageTurboRunning, "third chained press should start turbo");
         compare(main.rapidNavigationActive, true, "turbo forces rapid mode so cover work pauses");
+        compare(main._heldAction, "", "hold-repeat must be disarmed while turbo drives");
     }
 
     function test_page_turbo_stops_on_other_action(): void {
-        main.handleKey(Qt.Key_PageDown);
-        main.handleKey(Qt.Key_PageDown);
-        main.handleKey(Qt.Key_PageDown);
+        _bridgePagePress(Qt.Key_PageDown);
+        _bridgePagePress(Qt.Key_PageDown);
+        _bridgePagePress(Qt.Key_PageDown);
         verify(main.pageTurboRunning);
         main.handleKey(Qt.Key_Down);
         verify(!main.pageTurboRunning, "a non-page action must stop turbo immediately");
     }
 
     function test_page_turbo_direction_flip_stops_and_pages_normally(): void {
-        main.handleKey(Qt.Key_PageDown);
-        main.handleKey(Qt.Key_PageDown);
-        main.handleKey(Qt.Key_PageDown);
+        _bridgePagePress(Qt.Key_PageDown);
+        _bridgePagePress(Qt.Key_PageDown);
+        _bridgePagePress(Qt.Key_PageDown);
         verify(main.pageTurboRunning);
-        main.handleKey(Qt.Key_PageUp);
+        _bridgePagePress(Qt.Key_PageUp);
         verify(!main.pageTurboRunning, "flipping direction must stop the old turbo");
         compare(main._pageTurboChainCount, 1, "the flip press starts a fresh chain");
+    }
+
+    // Gated input must not feed turbo: presses swallowed by an
+    // in-flight transition would otherwise start a tick that pages the
+    // destination screen once it becomes ready.
+    function test_page_turbo_does_not_engage_while_transition_pending(): void {
+        main.pendingTransition = "games";
+        _bridgePagePress(Qt.Key_PageDown);
+        _bridgePagePress(Qt.Key_PageDown);
+        _bridgePagePress(Qt.Key_PageDown);
+        verify(!main.pageTurboRunning, "gated presses must not start turbo");
+        main.pendingTransition = "";
     }
 
     // Duplicate-input guard. The Keys.onPressed handler collapses a

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -460,12 +460,19 @@ TestCase {
         compare(main._repeatPending, true, "Re-arm restarts the initial-delay timer");
     }
 
-    function test_rapid_navigation_taps_activate_on_second_press(): void {
+    function test_rapid_navigation_taps_activate_at_threshold(): void {
+        // A quick skip (two-to-four taps) must never gate the detail
+        // cover; only a sustained burst reaching the threshold engages
+        // rapid mode.
         main._noteRapidNavigationAction("down", false);
         compare(main.rapidNavigationAction, "down", "rapid action tracks latest rapid input even before active mode");
-        compare(main.rapidNavigationActive, false, "single isolated press should not enter rapid mode");
+        for (var i = 2; i < main._rapidNavigationTapThreshold; i++) {
+            main._noteRapidNavigationAction("down", false);
+            compare(main.rapidNavigationActive, false,
+                    "press " + i + " of a burst below the threshold must not enter rapid mode");
+        }
         main._noteRapidNavigationAction("down", false);
-        compare(main.rapidNavigationActive, true, "second press inside quiet window enters rapid mode");
+        compare(main.rapidNavigationActive, true, "threshold press enters rapid mode");
         wait(main._rapidNavigationQuietMs + 40);
         compare(main.rapidNavigationActive, false, "rapid mode clears after quiet window");
         compare(main.rapidNavigationAction, "", "quiet reset clears rapid action");

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -473,9 +473,28 @@ TestCase {
         }
         main._noteRapidNavigationAction("down", false);
         compare(main.rapidNavigationActive, true, "threshold press enters rapid mode");
-        wait(main._rapidNavigationQuietMs + 40);
+        // Without an established QML hold-repeat the quiet timer runs at
+        // the chain interval, so the exit wait keys off that value.
+        wait(main._rapidNavigationChainQuietMs + 40);
         compare(main.rapidNavigationActive, false, "rapid mode clears after quiet window");
         compare(main.rapidNavigationAction, "", "quiet reset clears rapid action");
+    }
+
+    function test_rapid_navigation_chains_discrete_repeats(): void {
+        // Gamepad input stacks deliver a held dpad as separate
+        // press/release pairs at their own cadence. Slower than the
+        // held-key quiet window, those repeats must still chain into one
+        // burst through the wider chain window, or rapid mode never
+        // engages during a pad hold and cover work churns through it.
+        for (var i = 1; i < main._rapidNavigationTapThreshold; i++) {
+            main._noteRapidNavigationAction("page_next", false);
+            compare(main.rapidNavigationActive, false,
+                    "press " + i + " below the threshold must not enter rapid mode");
+            wait(150);
+        }
+        main._noteRapidNavigationAction("page_next", false);
+        compare(main.rapidNavigationActive, true,
+                "spaced discrete repeats chain to the threshold and enter rapid mode");
     }
 
     function test_rapid_navigation_ignores_non_rapid_action(): void {
@@ -496,7 +515,12 @@ TestCase {
         compare(main.rapidNavigationActive, true, "held page action should enter rapid mode on first repeat tick");
         compare(main.rapidNavigationIndicatorActive, true, "held page action should show rapid indicator on first repeat tick");
         main._stopRepeat();
-        wait(main._rapidNavigationQuietMs + 40);
+        // The forced tick note is followed by the action router's own
+        // non-forced note for the same action, which re-arms the wider
+        // chain window; only from the second tick onward (repeat tick
+        // established) does the tight window stick. A single-tick hold
+        // therefore exits on the chain window.
+        wait(main._rapidNavigationChainQuietMs + 40);
         compare(main.rapidNavigationActive, false);
     }
 

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -587,6 +587,18 @@ TestCase {
         main.pendingTransition = "";
     }
 
+    // Held-repeat cadence. Pure-helper test: a genuinely held
+    // Left/Right on the games list repeats whole pages, so it must
+    // tick at the page-turbo cadence; row actions and other contexts
+    // keep the row cadence.
+    function test_held_repeat_cadence_pages_at_turbo_rate(): void {
+        compare(main._heldRepeatIntervalFor("right", main.screenGames, "list"), main._pageTurboTickMs, "held right on the games list repeats at the page cadence");
+        compare(main._heldRepeatIntervalFor("left", main.screenGames, "list"), main._pageTurboTickMs, "held left on the games list repeats at the page cadence");
+        compare(main._heldRepeatIntervalFor("down", main.screenGames, "list"), main._repeatTickMs, "the row walk keeps the row cadence");
+        compare(main._heldRepeatIntervalFor("right", main.screenGames, "grid"), main._repeatTickMs, "grid cell moves keep the row cadence");
+        compare(main._heldRepeatIntervalFor("right", main.screenSystems, "list"), main._repeatTickMs, "other screens keep the row cadence");
+    }
+
     // Duplicate-input guard. The Keys.onPressed handler collapses a
     // second delivery of the same key while the guard window is open
     // (controller / input-stack double send). The decision is a pure

--- a/tests/ui/tst_paged_grid.qml
+++ b/tests/ui/tst_paged_grid.qml
@@ -102,7 +102,7 @@ TestCase {
     }
 
     // Suspended delegates: the grid must keep reporting itemCount from
-    // the model's own count with zero delegates materialised, so list
+    // the model's own count with zero delegates materialized, so list
     // layout can use the grid as cursor authority without paying the
     // per-row instantiation cost on every insert.
     function test_suspended_delegates_track_model_count(): void {

--- a/tests/ui/tst_paged_grid.qml
+++ b/tests/ui/tst_paged_grid.qml
@@ -83,6 +83,35 @@ TestCase {
         loadMoreSpy.clear();
     }
 
+    ListModel {
+        id: suspendModel
+        ListElement { name: "a"; coverKey: ""; favorite: 0; hidden: false; disambiguatingTags: "" }
+        ListElement { name: "b"; coverKey: ""; favorite: 0; hidden: false; disambiguatingTags: "" }
+        ListElement { name: "c"; coverKey: ""; favorite: 0; hidden: false; disambiguatingTags: "" }
+    }
+
+    PagedGrid {
+        id: suspendProbe
+        suspendDelegates: true
+        model: suspendModel
+        delegate: Item {}
+        columnsOverride: 3
+        rowsOverride: 3
+        width: 300
+        height: 300
+    }
+
+    // Suspended delegates: the grid must keep reporting itemCount from
+    // the model's own count with zero delegates materialised, so list
+    // layout can use the grid as cursor authority without paying the
+    // per-row instantiation cost on every insert.
+    function test_suspended_delegates_track_model_count(): void {
+        suspendProbe.model = suspendModel;
+        compare(suspendProbe.itemCount, 3, "itemCount must come from model.count while suspended");
+        suspendModel.append({"name": "d", "coverKey": "", "favorite": 0, "hidden": false, "disambiguatingTags": ""});
+        compare(suspendProbe.itemCount, 4, "itemCount must track model growth while suspended");
+    }
+
     function test_geometry_matches_pinned_resolution(): void {
         compare(grid.columns, 4, "expected 4 columns at 480px height");
         compare(grid.rows, 3, "expected 3 rows at 480px height");


### PR DESCRIPTION
## Summary

Implements and extends the direction agreed in #359: on MiSTer, the
frontend reads state Core already maintains directly from the media
database instead of paying a round trip per request. The first phase
(previously reviewed here) did it for cover artwork; the second phase
extends the same contract to folder listings and makes the model cheap
enough to receive them, which together take entering a large folder
from ~4.5 s to ~0.5 s and remove the "Loading more…" interruption from
fast scrolling entirely.

For review orientation: the artwork phase is the commit set up to
`f0e88e0`, which was already reviewed; the listings phase is every
commit after it.

## Still one boundary (hole in the abstraction)

The artwork phase shipped under the two conditions from #359:

- **MiSTer only, images only.** The module activates only when the MiSTer
  data directory exists; desktop and every other platform behave as
  before. It queries image properties and nothing else, read-only
  (`SQLITE_OPEN_READ_ONLY`), and a schema guard verifies the four tables
  it touches at open — if a future Core renames them the layer disables
  itself loudly and every cover goes through the RPC path exactly as
  today. A runtime kill switch (`ZAPAROO_FRONTEND_DB_ART=0`) is included
  for A/B comparison.
- **No second caches or thumbnail stores.** Nothing is written anywhere.
  The existing in-memory cache remains the only cache; the direct read is
  a resolution fast path, not a store.

Working with that boundary since, I think what actually makes it sound
was never the media type. It was the direction of the operation:

- **Reads follow the data.** On MiSTer the frontend and Core share the
  same SD card. For pure reads of state Core already maintains, the
  frontend consumes the database in place: read-only connection, WAL
  reader, schema-guarded, no second cache, no derived storage.
- **Writes and management follow Core.** Indexing, scraping, favorites,
  launching, history, configuration: everything that changes state goes
  through the API, without exception. Core stays the single writer and
  the single owner of the business logic.

The listings phase does not introduce a second hole through the
abstraction. It asks to name the one hole that already exists
precisely: on MiSTer, the frontend is a read-only consumer of the
database Core maintains. Artwork was the first instance of that rule;
listings are the second instance of the same rule. The practical
benefit of naming it is that it stops the drift toward per-feature
carve-outs: any future read view either fits the stated contract
(read-only, schema-guarded, RPC fallback, Core remains authoritative)
or it does not go in, and no write path ever qualifies.

## Phase 1: artwork (previously reviewed)

- `media_art_db`: resolves a cover key (media id, else canonical path) to
  ranked artwork-file candidates: requested type first, media-level before
  title-level, the keyed row before rows sharing the same file path. The
  caller tries candidates in order, so a database row pointing at a file
  that no longer exists degrades to the next candidate instead of a miss.
  The path-twin step also gives the v2.16 arcade classification systems
  (CPS1/CPS2/Neo Geo MVS/...) working artwork: Core indexes the same file
  under a second system with no art bound, and the gamelist scraper has no
  folder mapping for those systems, so borrowing from the twin is the only
  place the art can come from today.
- Fetch workers go from 2 to 8 for the local path, while a semaphore keeps
  the original limit of 2 concurrent `media.image` RPCs, so Core sees no
  additional pressure.
- The rapid-navigation gate now engages on a sustained burst (5 presses)
  rather than the 2nd press, and its quiet window drops from 260 ms to
  120 ms (still above the 90 ms held-key repeat tick, so holds cannot
  flicker). With covers loading in milliseconds the old gate was hiding
  speed the frontend now has: a quick double-tap skip pays no artificial
  delay, and held-key scrolling keeps its suppression via the forced path.

**Artwork measurements (MiSTer, Cyclone V, debug-log timings):** cover
fetch went from 100 ms+ per cover through Core's serialised image RPC to
a ~7 ms median database lookup plus a ~26 ms file read, workers in
parallel. Sessions run with zero image RPCs.

## Phase 2: folder listings

Entering a folder now runs one read-only SQLite query against Core's
own tables and hands the complete listing to the model: a small
first-page apply paints immediately, the remainder lands as bulk
inserts behind the paint, and the whole folder is local moments later.
The RPC path is untouched and remains the only path everywhere else,
and on MiSTer whenever the direct read cannot answer with full
confidence.

Core already maintains everything a listing needs as indexed tables:
`BrowseDirs`/`BrowseDirCounts` (the pre-computed directory tree behind
the browse cache), `Media.ParentDir`/`SortName`/`IsMissing` behind
`idx_media_browse_sort`, the `user:favorite` projection in `MediaTags`,
and the image property tags that back `hasCover`. The queries mirror
`sql_browse.go`'s cache path, including the `BrowseIndexVersion`
serveability gate: if Core would not serve from its own cache, neither
do we, and the RPC answers.

**Listings measurements** (same device and folder shapes, before/after
logs available; "before" is the current release behavior over the RPC):

Entering a large folder (roughly two thousand entries):

| | before | after |
|---|---|---|
| "Loading games…" to a usable list | ~4.5 s (double-load included) | **~0.5 s** |
| full folder available locally | never (paged on demand) | **~1 s after entry** |

The direct read itself returns the complete listing in under 200 ms
warm. The rest of the win came from making delivery cheap: the paged
grid used to materialize one delegate per model row even while hidden
behind the list layout, which cost roughly 3 ms per row on the software
renderer, so bulk inserts of a thousand rows blocked the UI thread for
about 3 seconds. With delegates suspended in list layout, the same
inserts take **5 to 7 ms**, several hundred times less, and folder
entry no longer starves the cover gate.

Fast scrolling ("Loading more…" and paging):

- Over the RPC, paging raced a `media.browse` round trip and lost
  routinely: a page past the loaded edge blocked on "Loading more…"
  for ~0.5 s per small chunk, and multi-second for large ones, and
  chunk cost grows superlinearly with size, so bigger requests made
  stalls worse, not better.
- With the listing fully local, there is nothing left to fetch while
  browsing: **the "Loading more…" interruption is gone** in list
  browsing, along with the background fill churn that used to compete
  with input on the UI thread.
- Held paging previously advanced at the pad bridge's autofire beat
  (~2 pages per second, fixed, regardless of how fast the user
  pressed). A press-stream turbo now detects held page buttons,
  including Left/Right where the list layout routes them to paging,
  drives paging at its own tick with rapid mode engaged (cover work
  paused), and sustains roughly **66 rows per second** of travel,
  about six times the held line-scroll rate.

**Known remaining limit:** the visual beat of a full-page flip is ~3
per second on the software renderer, as ten rows re-bind and re-layout
per landing. Throughput is no longer the bottleneck; a pre-laid-out
page swap could close the remaining gap to raw-framebuffer menus and
is left as follow-up work.

## Phase 3: favorites, recents, and detail metadata

Completes the read map under the same boundary: three more read-only
consumers of the databases Core maintains, each with the contract the
first two phases established (read-only connection, schema guard that
disables the layer loudly on any mismatch, per-domain kill switch, RPC
fallback on any miss). Writes still never come near any of this.

- **Favorites** (`media_favorites_db`, `ZAPAROO_FRONTEND_DB_FAVORITES`):
  the complete favorite set in one media.db query, tens of milliseconds
  for a few hundred entries. The screen paints direct-first on cold
  entry; every store Ready triggers a local re-read whose result
  replaces the page content, so the endpoint subscription remains the
  freshness signal and favorite toggles keep refetching exactly as
  today. The paged default view and the full-set scoped views stop
  being different worlds, which also dissolves the "Show: All loads a
  few pages then more on scroll" report at the root.
- **Recents** (`media_history_db`, `ZAPAROO_FRONTEND_DB_HISTORY`): the
  deduplicated play history from `user.db`, the same contract applied
  to Core's second database file. Latest event per media path via a
  window query, timestamps in the wire's RFC3339 form, open sessions
  keeping `endedAt` null so Resume semantics are untouched. Media ids
  resolve through a correlated scalar subquery against the attached
  media database, keyed on path plus system so classification twins
  cannot duplicate an entry (regression-tested).
- **Detail metadata** (`media_meta_db`, `ZAPAROO_FRONTEND_DB_META`):
  tags, scraped properties, the title record, and available image
  types from indexed point lookups, tried before every `media.meta`
  RPC including the prefetch cache. With the round trip gone, the
  detail settle debounce drops from 220 ms to 40 ms (exposed to QML as
  `AppStatus.direct_meta`), so the detail pane tracks the cursor
  essentially live.

**Phase 3 measurements** (same device and method as above):

| | before | after |
|---|---|---|
| favorites cold entry | ~1 s (network first page) | **effectively instant** |
| favorites full set | chained RPC pages | **tens of ms, one query** |
| recents cold entry | ~0.5 to 1 s | **effectively instant** |
| detail metadata | ~60 to 70 ms per settle | **~2 ms median** |
| detail pane response after stopping | ~280 ms | **~40 ms** |

With phase 3 in place, steady-state browsing performs **zero RPCs**:
the WebSocket carries writes, launches, and notifications.

Known divergences for this phase, same spirit as the listings list:
`zapScript` is not populated on direct favorites entries (it is not
stored in the database; launching uses the media path, which is the
primary launch text, and portable card-write text falls back to the
path), tag labels are empty (they come from Core's tag registry; every
consumer falls back to the tag value), and direct favorites order by
`SortName` rather than Core's search order, which the view's own sort
modes sit on top of either way.

For review orientation: phase 3 is the last four commits (the three
`feat(mister)` reads plus the review-round fix).

## Listings guard rails (same contract as the artwork path)

- Strictly read-only: `SQLITE_OPEN_READ_ONLY`, short busy timeout, no
  writes, no checkpoints, no pragma tuning. WAL readers do not block
  Core's writer.
- No second cache and no derived storage; the database is read in
  place, per the condition agreed for the artwork path.
- Schema guard at open: every table the module touches is verified, and
  any mismatch disables the layer loudly, leaving the RPC as the sole
  source.
- Scope: folder listings only. Root browsing (which needs Core's
  launcher routes), the letter index, search, meta, and all writes
  (favorites) remain on the RPC.
- `ZAPAROO_FRONTEND_DB_BROWSE=0` disables the layer at runtime; the
  artwork layer has the equivalent switch. The A/B numbers above were
  taken with it.

## Known divergences from `media.browse` deemed acceptable

- No singleton media-container aliasing (`ZipsAsDirs`): affected
  folders render as plain directories; drilling in shows the single
  item. Could be added later with the same resolution query Core uses.
- No rank/date prefix sort-mode detection: listings always use Core's
  default `SortName` order. Could be ported if wanted.
- No `disambiguatingTags` variant badges at browse level; the detail
  pane still gets full tags via `media.meta`.
- A reindex completing while the user sits inside a folder does not
  live-refresh that folder (the RPC path's store subscription does);
  re-entering the folder re-reads fresh data.

Each of these trades a rarely-visible feature for the elimination of
every listing round trip.

## Why making `media.browse` faster in Core is not the real solution

Worth doing too, and it would help every client. But even an instant
server still pays serialization, transport, client deserialize, and
per-page model delivery. For the frontend that lives on the same SD
card as the database, one indexed query straight into the model is a
structurally lower floor, in the same way the artwork direct read was.
The delivery-side fixes in this PR (split apply, delegate suspension,
the paging turbo) stand on their own and benefit the RPC path too.

## Motivation (speed and responsiveness)

Newer frontends, Console Mode being the most visible example, feel instant
because they read local data directly. Zaparoo is the better product by
a wide margin, and after the artwork fast path the listings were the last
place the difference showed. The aim of this PR is simply that
Zaparoo Frontend feels fast during use on MiSTer, with Core keeping full
ownership of everything that writes.

## Testing

- Unit tests cover the artwork candidate ranking and the listing query
  against a synthetic schema: dirs-before-files ordering, per-system
  filtering, favorite and has-cover flags (media- and title-level),
  `SortName` fallback, missing-row exclusion, cache-gate refusal,
  unknown-path refusal.
- QML tests cover the delegate-suspension contract (item count served
  from the model with zero delegates) and the paging turbo state
  machine (threshold engagement, absorption, direction flip, stop on
  other input).
- A/B on device via the env switches: identical folders, RPC vs
  direct, from the same binary and debug log.
- Full Rust suite, QML lint, and the UI suite pass; favorites, artwork
  bindings, and RPC fallback verified on device.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Faster browsing with local media listings, metadata, artwork, favorites, and history.
- Added rapid navigation, page turbo, and expanded prefetching for large collections.

## Performance
- Reduced rendering overhead during rapid scrolling while preserving counts and selection.
- Improved artwork loading with responsive local access and remote fallback.

## Bug Fixes
- Improved cancellation, recovery, fallback handling, and missing-file filtering.
- Preserved search and favorites updates without unnecessary browse refreshes.

## Localization
- Updated translation references across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->