### PR TITLE
fix(input): toggle View menu with View button

### DIFF
--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -2399,6 +2399,10 @@ MainLayout {
             ScreenManager.popModal();
     }
 
+    function _isViewListPicker(fieldId: string): bool {
+        return fieldId === "page_menu" || fieldId === "page_menu_favorites" || fieldId === "page_menu_favorite_systems";
+    }
+
     // Open the page/list-scoped operations menu (West button), the "View"
     // counterpart to North's item-scoped "Options". Go to... stays
     // pre-focused so common path is fixed West-then-Accept chord. Letter
@@ -3014,7 +3018,9 @@ MainLayout {
                 if (root.settingNeedsRestartModal !== null)
                     root.settingNeedsRestartModal.handleAction(action);
             } else if (ScreenManager.topModal === root.modalListPicker) {
-                if (root.listPickerModal !== null)
+                if (action === "page_menu" && root._isViewListPicker(root.listPickerFieldId))
+                    root.closeListPickerModal();
+                else if (root.listPickerModal !== null)
                     root.listPickerModal.handleAction(action);
             } else if (ScreenManager.topModal === root.modalLetterJump) {
                 if (root.letterJumpModal !== null)

--- a/src/ui/components/ListPickerModal.qml
+++ b/src/ui/components/ListPickerModal.qml
@@ -131,7 +131,7 @@ Item {
         } else if (action === "accept") {
             if (modal.currentIndex >= 0 && modal.currentIndex < modal.entries.length)
                 modal._commitAccept(modal.entries[modal.currentIndex].id);
-        } else if (action === "cancel" || action === "page_menu") {
+        } else if (action === "cancel") {
             modal.closeRequested();
         }
     }

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -715,8 +715,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2509"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2513"/>
         <source>Default</source>
         <translation type="unfinished">افتراضي</translation>
     </message>
@@ -726,7 +726,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2415"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -735,52 +735,52 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1796"/>
         <location filename="../app/Main.qml" line="1813"/>
         <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2419"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2446"/>
         <source>Favorites</source>
         <translation type="unfinished">المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
-        <location filename="../app/Main.qml" line="2466"/>
-        <location filename="../app/Main.qml" line="2476"/>
+        <location filename="../app/Main.qml" line="2431"/>
+        <location filename="../app/Main.qml" line="2470"/>
+        <location filename="../app/Main.qml" line="2480"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2455"/>
+        <location filename="../app/Main.qml" line="2459"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2517"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2442"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2521"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2446"/>
+        <location filename="../app/Main.qml" line="2450"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -790,95 +790,95 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
-        <location filename="../app/Main.qml" line="2473"/>
+        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2477"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2467"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2495"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2487"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2491"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2494"/>
+        <location filename="../app/Main.qml" line="2498"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2654"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2658"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2672"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2676"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
+        <location filename="../app/Main.qml" line="2680"/>
         <source>Retry</source>
         <translation type="unfinished">إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
         <translation type="unfinished">إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3524"/>
+        <location filename="../app/Main.qml" line="3530"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3526"/>
+        <location filename="../app/Main.qml" line="3532"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3528"/>
+        <location filename="../app/Main.qml" line="3534"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3531"/>
+        <location filename="../app/Main.qml" line="3537"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3533"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3535"/>
+        <location filename="../app/Main.qml" line="3541"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -678,34 +678,34 @@ Français - Wilfried</source>
         <translation>Spiel starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2415"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
-        <location filename="../app/Main.qml" line="2466"/>
-        <location filename="../app/Main.qml" line="2476"/>
+        <location filename="../app/Main.qml" line="2431"/>
+        <location filename="../app/Main.qml" line="2470"/>
+        <location filename="../app/Main.qml" line="2480"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2467"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3524"/>
+        <location filename="../app/Main.qml" line="3530"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3531"/>
+        <location filename="../app/Main.qml" line="3537"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3526"/>
+        <location filename="../app/Main.qml" line="3532"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
@@ -735,8 +735,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2509"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2513"/>
         <source>Default</source>
         <translation type="unfinished">Standard</translation>
     </message>
@@ -750,39 +750,39 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1796"/>
         <location filename="../app/Main.qml" line="1813"/>
         <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2419"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2455"/>
+        <location filename="../app/Main.qml" line="2459"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2517"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2442"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2521"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2446"/>
+        <location filename="../app/Main.qml" line="2450"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -792,81 +792,81 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2446"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoriten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
-        <location filename="../app/Main.qml" line="2473"/>
+        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2477"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2495"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2487"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2491"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2494"/>
+        <location filename="../app/Main.qml" line="2498"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2654"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2658"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2672"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2676"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
+        <location filename="../app/Main.qml" line="2680"/>
         <source>Retry</source>
         <translation type="unfinished">Wiederholen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
         <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3528"/>
+        <location filename="../app/Main.qml" line="3534"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3533"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3535"/>
+        <location filename="../app/Main.qml" line="3541"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -678,34 +678,34 @@ Français - Wilfried</source>
         <translation>Εκκίνηση παιχνιδιού</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2415"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
-        <location filename="../app/Main.qml" line="2466"/>
-        <location filename="../app/Main.qml" line="2476"/>
+        <location filename="../app/Main.qml" line="2431"/>
+        <location filename="../app/Main.qml" line="2470"/>
+        <location filename="../app/Main.qml" line="2480"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2467"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3524"/>
+        <location filename="../app/Main.qml" line="3530"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3531"/>
+        <location filename="../app/Main.qml" line="3537"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3526"/>
+        <location filename="../app/Main.qml" line="3532"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
@@ -735,8 +735,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2509"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2513"/>
         <source>Default</source>
         <translation type="unfinished">Προεπιλογή</translation>
     </message>
@@ -750,39 +750,39 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1796"/>
         <location filename="../app/Main.qml" line="1813"/>
         <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2419"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2455"/>
+        <location filename="../app/Main.qml" line="2459"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2517"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2442"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2521"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2446"/>
+        <location filename="../app/Main.qml" line="2450"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -792,81 +792,81 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2446"/>
         <source>Favorites</source>
         <translation type="unfinished">Αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
-        <location filename="../app/Main.qml" line="2473"/>
+        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2477"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2495"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2487"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2491"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2494"/>
+        <location filename="../app/Main.qml" line="2498"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2654"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2658"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2672"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2676"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
+        <location filename="../app/Main.qml" line="2680"/>
         <source>Retry</source>
         <translation type="unfinished">Επανάληψη</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
         <translation type="unfinished">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3528"/>
+        <location filename="../app/Main.qml" line="3534"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3533"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3535"/>
+        <location filename="../app/Main.qml" line="3541"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -630,34 +630,34 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2415"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
-        <location filename="../app/Main.qml" line="2466"/>
-        <location filename="../app/Main.qml" line="2476"/>
+        <location filename="../app/Main.qml" line="2431"/>
+        <location filename="../app/Main.qml" line="2470"/>
+        <location filename="../app/Main.qml" line="2480"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2467"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3524"/>
+        <location filename="../app/Main.qml" line="3530"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3531"/>
+        <location filename="../app/Main.qml" line="3537"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3526"/>
+        <location filename="../app/Main.qml" line="3532"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -687,8 +687,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2509"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2513"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
@@ -702,39 +702,39 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1796"/>
         <location filename="../app/Main.qml" line="1813"/>
         <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2419"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2455"/>
+        <location filename="../app/Main.qml" line="2459"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2517"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2442"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2521"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2446"/>
+        <location filename="../app/Main.qml" line="2450"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -744,81 +744,81 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2446"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorites</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
-        <location filename="../app/Main.qml" line="2473"/>
+        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2477"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2495"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2487"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2491"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2494"/>
+        <location filename="../app/Main.qml" line="2498"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2654"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2658"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2672"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2676"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
+        <location filename="../app/Main.qml" line="2680"/>
         <source>Retry</source>
         <translation type="unfinished">Retry</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3528"/>
+        <location filename="../app/Main.qml" line="3534"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3533"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3535"/>
+        <location filename="../app/Main.qml" line="3541"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -678,34 +678,34 @@ Français - Wilfried</source>
         <translation>Iniciar juego</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2415"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
-        <location filename="../app/Main.qml" line="2466"/>
-        <location filename="../app/Main.qml" line="2476"/>
+        <location filename="../app/Main.qml" line="2431"/>
+        <location filename="../app/Main.qml" line="2470"/>
+        <location filename="../app/Main.qml" line="2480"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2467"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3524"/>
+        <location filename="../app/Main.qml" line="3530"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3531"/>
+        <location filename="../app/Main.qml" line="3537"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3526"/>
+        <location filename="../app/Main.qml" line="3532"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
@@ -735,8 +735,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2509"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2513"/>
         <source>Default</source>
         <translation type="unfinished">Por defecto</translation>
     </message>
@@ -750,39 +750,39 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1796"/>
         <location filename="../app/Main.qml" line="1813"/>
         <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2419"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2455"/>
+        <location filename="../app/Main.qml" line="2459"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2517"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2442"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2521"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2446"/>
+        <location filename="../app/Main.qml" line="2450"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -792,81 +792,81 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2446"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
-        <location filename="../app/Main.qml" line="2473"/>
+        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2477"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2495"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2487"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2491"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2494"/>
+        <location filename="../app/Main.qml" line="2498"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2654"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2658"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2672"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2676"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
+        <location filename="../app/Main.qml" line="2680"/>
         <source>Retry</source>
         <translation type="unfinished">Reintentar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3528"/>
+        <location filename="../app/Main.qml" line="3534"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3533"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3535"/>
+        <location filename="../app/Main.qml" line="3541"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -690,34 +690,34 @@ Français - Wilfried</source>
         <translation type="unfinished">Abiarazi jokua</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2415"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
-        <location filename="../app/Main.qml" line="2466"/>
-        <location filename="../app/Main.qml" line="2476"/>
+        <location filename="../app/Main.qml" line="2431"/>
+        <location filename="../app/Main.qml" line="2470"/>
+        <location filename="../app/Main.qml" line="2480"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2467"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3524"/>
+        <location filename="../app/Main.qml" line="3530"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3531"/>
+        <location filename="../app/Main.qml" line="3537"/>
         <source>Loading favorites…</source>
         <translation type="unfinished">Gogokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3526"/>
+        <location filename="../app/Main.qml" line="3532"/>
         <source>Loading games…</source>
         <translation type="unfinished">Jokoak kargatzen</translation>
     </message>
@@ -747,8 +747,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2509"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2513"/>
         <source>Default</source>
         <translation type="unfinished">Lehenetsia</translation>
     </message>
@@ -762,39 +762,39 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1796"/>
         <location filename="../app/Main.qml" line="1813"/>
         <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2419"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2455"/>
+        <location filename="../app/Main.qml" line="2459"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2517"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2442"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2521"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2446"/>
+        <location filename="../app/Main.qml" line="2450"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -804,81 +804,81 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2446"/>
         <source>Favorites</source>
         <translation type="unfinished">Gogokoak</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
-        <location filename="../app/Main.qml" line="2473"/>
+        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2477"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2495"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2487"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2491"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2494"/>
+        <location filename="../app/Main.qml" line="2498"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2654"/>
         <source>Saving launcher</source>
         <translation type="unfinished">Abiarazlea gordetzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2658"/>
         <source>Saving…</source>
         <translation type="unfinished">Gordetzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2672"/>
         <source>Launcher update failed</source>
         <translation type="unfinished">Abiarazle egukeraketak huts egin du</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2676"/>
         <source>Error: %1</source>
         <translation type="unfinished">Errorea: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
+        <location filename="../app/Main.qml" line="2680"/>
         <source>Retry</source>
         <translation type="unfinished">Berriro saiatu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
         <translation type="unfinished">Utzi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3528"/>
+        <location filename="../app/Main.qml" line="3534"/>
         <source>Loading game…</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3533"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>Loading recently played…</source>
         <translation type="unfinished">Duela gutxi jokatutakoak kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3535"/>
+        <location filename="../app/Main.qml" line="3541"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>

--- a/src/ui/translations/frontend_fr.ts
+++ b/src/ui/translations/frontend_fr.ts
@@ -669,29 +669,29 @@ Français - Wilfried</translation>
         <translation>Lancer le jeu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2415"/>
         <source>Go to...</source>
         <translation>Aller à...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
-        <location filename="../app/Main.qml" line="2466"/>
-        <location filename="../app/Main.qml" line="2476"/>
+        <location filename="../app/Main.qml" line="2431"/>
+        <location filename="../app/Main.qml" line="2470"/>
+        <location filename="../app/Main.qml" line="2480"/>
         <source>View</source>
         <translation>Afficher</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3524"/>
+        <location filename="../app/Main.qml" line="3530"/>
         <source>Loading systems…</source>
         <translation>Chargement des systèmes…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3531"/>
+        <location filename="../app/Main.qml" line="3537"/>
         <source>Loading favorites…</source>
         <translation>Chargement des favoris…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3526"/>
+        <location filename="../app/Main.qml" line="3532"/>
         <source>Loading games…</source>
         <translation>Chargement des jeux…</translation>
     </message>
@@ -721,8 +721,8 @@ Français - Wilfried</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2509"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2513"/>
         <source>Default</source>
         <translation>Par défaut</translation>
     </message>
@@ -736,7 +736,7 @@ Français - Wilfried</translation>
         <location filename="../app/Main.qml" line="1796"/>
         <location filename="../app/Main.qml" line="1813"/>
         <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2419"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
@@ -746,118 +746,118 @@ Français - Wilfried</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2446"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoris</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2442"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2446"/>
+        <location filename="../app/Main.qml" line="2450"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2455"/>
+        <location filename="../app/Main.qml" line="2459"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
-        <location filename="../app/Main.qml" line="2473"/>
+        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2477"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2467"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2495"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2487"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2491"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2494"/>
+        <location filename="../app/Main.qml" line="2498"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2517"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2521"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2654"/>
         <source>Saving launcher</source>
         <translation>Enregistrement du lanceur</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2658"/>
         <source>Saving…</source>
         <translation>Enregistrement…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2672"/>
         <source>Launcher update failed</source>
         <translation>Échec de la mise à jour du lanceur</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2676"/>
         <source>Error: %1</source>
         <translation>Erreur&#xa0;: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
+        <location filename="../app/Main.qml" line="2680"/>
         <source>Retry</source>
         <translation>Réessayer</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3528"/>
+        <location filename="../app/Main.qml" line="3534"/>
         <source>Loading game…</source>
         <translation>Chargement du jeu…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3533"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>Loading recently played…</source>
         <translation>Chargement des jeux récents…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3535"/>
+        <location filename="../app/Main.qml" line="3541"/>
         <source>Loading settings…</source>
         <translation>Chargement des réglages…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>Loading…</source>
         <translation>Chargement…</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -703,8 +703,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2509"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2513"/>
         <source>Default</source>
         <translation type="unfinished">ברירת מחדל</translation>
     </message>
@@ -714,7 +714,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2415"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -723,52 +723,52 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1796"/>
         <location filename="../app/Main.qml" line="1813"/>
         <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2419"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2446"/>
         <source>Favorites</source>
         <translation type="unfinished">מועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
-        <location filename="../app/Main.qml" line="2466"/>
-        <location filename="../app/Main.qml" line="2476"/>
+        <location filename="../app/Main.qml" line="2431"/>
+        <location filename="../app/Main.qml" line="2470"/>
+        <location filename="../app/Main.qml" line="2480"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2455"/>
+        <location filename="../app/Main.qml" line="2459"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2517"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2442"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2521"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2446"/>
+        <location filename="../app/Main.qml" line="2450"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -778,95 +778,95 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
-        <location filename="../app/Main.qml" line="2473"/>
+        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2477"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2467"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2495"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2487"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2491"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2494"/>
+        <location filename="../app/Main.qml" line="2498"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2654"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2658"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2672"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2676"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
+        <location filename="../app/Main.qml" line="2680"/>
         <source>Retry</source>
         <translation type="unfinished">נסה שוב</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
         <translation type="unfinished">ביטול</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3524"/>
+        <location filename="../app/Main.qml" line="3530"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3526"/>
+        <location filename="../app/Main.qml" line="3532"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3528"/>
+        <location filename="../app/Main.qml" line="3534"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3531"/>
+        <location filename="../app/Main.qml" line="3537"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3533"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3535"/>
+        <location filename="../app/Main.qml" line="3541"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -703,8 +703,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2509"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2513"/>
         <source>Default</source>
         <translation type="unfinished">डिफ़ॉल्ट</translation>
     </message>
@@ -714,7 +714,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2415"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -723,52 +723,52 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1796"/>
         <location filename="../app/Main.qml" line="1813"/>
         <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2419"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2446"/>
         <source>Favorites</source>
         <translation type="unfinished">पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
-        <location filename="../app/Main.qml" line="2466"/>
-        <location filename="../app/Main.qml" line="2476"/>
+        <location filename="../app/Main.qml" line="2431"/>
+        <location filename="../app/Main.qml" line="2470"/>
+        <location filename="../app/Main.qml" line="2480"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2455"/>
+        <location filename="../app/Main.qml" line="2459"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2517"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2442"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2521"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2446"/>
+        <location filename="../app/Main.qml" line="2450"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -778,95 +778,95 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
-        <location filename="../app/Main.qml" line="2473"/>
+        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2477"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2467"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2495"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2487"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2491"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2494"/>
+        <location filename="../app/Main.qml" line="2498"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2654"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2658"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2672"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2676"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
+        <location filename="../app/Main.qml" line="2680"/>
         <source>Retry</source>
         <translation type="unfinished">फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
         <translation type="unfinished">रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3524"/>
+        <location filename="../app/Main.qml" line="3530"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3526"/>
+        <location filename="../app/Main.qml" line="3532"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3528"/>
+        <location filename="../app/Main.qml" line="3534"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3531"/>
+        <location filename="../app/Main.qml" line="3537"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3533"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3535"/>
+        <location filename="../app/Main.qml" line="3541"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -678,34 +678,34 @@ Français - Wilfried</source>
         <translation>Avvia gioco</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2415"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
-        <location filename="../app/Main.qml" line="2466"/>
-        <location filename="../app/Main.qml" line="2476"/>
+        <location filename="../app/Main.qml" line="2431"/>
+        <location filename="../app/Main.qml" line="2470"/>
+        <location filename="../app/Main.qml" line="2480"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2467"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3524"/>
+        <location filename="../app/Main.qml" line="3530"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3531"/>
+        <location filename="../app/Main.qml" line="3537"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3526"/>
+        <location filename="../app/Main.qml" line="3532"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
@@ -735,8 +735,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2509"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2513"/>
         <source>Default</source>
         <translation type="unfinished">Predefinito</translation>
     </message>
@@ -750,39 +750,39 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1796"/>
         <location filename="../app/Main.qml" line="1813"/>
         <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2419"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2455"/>
+        <location filename="../app/Main.qml" line="2459"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2517"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2442"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2521"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2446"/>
+        <location filename="../app/Main.qml" line="2450"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -792,81 +792,81 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2446"/>
         <source>Favorites</source>
         <translation type="unfinished">Preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
-        <location filename="../app/Main.qml" line="2473"/>
+        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2477"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2495"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2487"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2491"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2494"/>
+        <location filename="../app/Main.qml" line="2498"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2654"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2658"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2672"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2676"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
+        <location filename="../app/Main.qml" line="2680"/>
         <source>Retry</source>
         <translation type="unfinished">Riprova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
         <translation type="unfinished">Annulla</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3528"/>
+        <location filename="../app/Main.qml" line="3534"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3533"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3535"/>
+        <location filename="../app/Main.qml" line="3541"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -675,34 +675,34 @@ Français - Wilfried</source>
         <translation>ゲームを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2415"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
-        <location filename="../app/Main.qml" line="2466"/>
-        <location filename="../app/Main.qml" line="2476"/>
+        <location filename="../app/Main.qml" line="2431"/>
+        <location filename="../app/Main.qml" line="2470"/>
+        <location filename="../app/Main.qml" line="2480"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2467"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3524"/>
+        <location filename="../app/Main.qml" line="3530"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3531"/>
+        <location filename="../app/Main.qml" line="3537"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3526"/>
+        <location filename="../app/Main.qml" line="3532"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
@@ -732,8 +732,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2509"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2513"/>
         <source>Default</source>
         <translation type="unfinished">デフォルト</translation>
     </message>
@@ -747,39 +747,39 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1796"/>
         <location filename="../app/Main.qml" line="1813"/>
         <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2419"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2455"/>
+        <location filename="../app/Main.qml" line="2459"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2517"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2442"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2521"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2446"/>
+        <location filename="../app/Main.qml" line="2450"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -789,81 +789,81 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2446"/>
         <source>Favorites</source>
         <translation type="unfinished">お気に入り</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
-        <location filename="../app/Main.qml" line="2473"/>
+        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2477"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2495"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2487"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2491"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2494"/>
+        <location filename="../app/Main.qml" line="2498"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2654"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2658"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2672"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2676"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
+        <location filename="../app/Main.qml" line="2680"/>
         <source>Retry</source>
         <translation type="unfinished">再試行</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
         <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3528"/>
+        <location filename="../app/Main.qml" line="3534"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3533"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3535"/>
+        <location filename="../app/Main.qml" line="3541"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -700,8 +700,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2509"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2513"/>
         <source>Default</source>
         <translation type="unfinished">기본값</translation>
     </message>
@@ -711,7 +711,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2415"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -720,52 +720,52 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1796"/>
         <location filename="../app/Main.qml" line="1813"/>
         <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2419"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2446"/>
         <source>Favorites</source>
         <translation type="unfinished">즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
-        <location filename="../app/Main.qml" line="2466"/>
-        <location filename="../app/Main.qml" line="2476"/>
+        <location filename="../app/Main.qml" line="2431"/>
+        <location filename="../app/Main.qml" line="2470"/>
+        <location filename="../app/Main.qml" line="2480"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2455"/>
+        <location filename="../app/Main.qml" line="2459"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2517"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2442"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2521"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2446"/>
+        <location filename="../app/Main.qml" line="2450"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -775,95 +775,95 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
-        <location filename="../app/Main.qml" line="2473"/>
+        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2477"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2467"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2495"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2487"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2491"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2494"/>
+        <location filename="../app/Main.qml" line="2498"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2654"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2658"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2672"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2676"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
+        <location filename="../app/Main.qml" line="2680"/>
         <source>Retry</source>
         <translation type="unfinished">다시 시도</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
         <translation type="unfinished">취소</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3524"/>
+        <location filename="../app/Main.qml" line="3530"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3526"/>
+        <location filename="../app/Main.qml" line="3532"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3528"/>
+        <location filename="../app/Main.qml" line="3534"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3531"/>
+        <location filename="../app/Main.qml" line="3537"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3533"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3535"/>
+        <location filename="../app/Main.qml" line="3541"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -678,34 +678,34 @@ Français - Wilfried</source>
         <translation>Game starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2415"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
-        <location filename="../app/Main.qml" line="2466"/>
-        <location filename="../app/Main.qml" line="2476"/>
+        <location filename="../app/Main.qml" line="2431"/>
+        <location filename="../app/Main.qml" line="2470"/>
+        <location filename="../app/Main.qml" line="2480"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2467"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3524"/>
+        <location filename="../app/Main.qml" line="3530"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3531"/>
+        <location filename="../app/Main.qml" line="3537"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3526"/>
+        <location filename="../app/Main.qml" line="3532"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
@@ -735,8 +735,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2509"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2513"/>
         <source>Default</source>
         <translation type="unfinished">Standaard</translation>
     </message>
@@ -750,39 +750,39 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1796"/>
         <location filename="../app/Main.qml" line="1813"/>
         <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2419"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2455"/>
+        <location filename="../app/Main.qml" line="2459"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2517"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2442"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2521"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2446"/>
+        <location filename="../app/Main.qml" line="2450"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -792,81 +792,81 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2446"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorieten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
-        <location filename="../app/Main.qml" line="2473"/>
+        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2477"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2495"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2487"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2491"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2494"/>
+        <location filename="../app/Main.qml" line="2498"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2654"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2658"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2672"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2676"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
+        <location filename="../app/Main.qml" line="2680"/>
         <source>Retry</source>
         <translation type="unfinished">Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
         <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3528"/>
+        <location filename="../app/Main.qml" line="3534"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3533"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3535"/>
+        <location filename="../app/Main.qml" line="3541"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -681,34 +681,34 @@ Français - Wilfried</source>
         <translation>Lansare joc</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2415"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
-        <location filename="../app/Main.qml" line="2466"/>
-        <location filename="../app/Main.qml" line="2476"/>
+        <location filename="../app/Main.qml" line="2431"/>
+        <location filename="../app/Main.qml" line="2470"/>
+        <location filename="../app/Main.qml" line="2480"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2467"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3524"/>
+        <location filename="../app/Main.qml" line="3530"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3531"/>
+        <location filename="../app/Main.qml" line="3537"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3526"/>
+        <location filename="../app/Main.qml" line="3532"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
@@ -738,8 +738,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2509"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2513"/>
         <source>Default</source>
         <translation type="unfinished">Implicit</translation>
     </message>
@@ -753,39 +753,39 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1796"/>
         <location filename="../app/Main.qml" line="1813"/>
         <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2419"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2455"/>
+        <location filename="../app/Main.qml" line="2459"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2517"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2442"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2521"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2446"/>
+        <location filename="../app/Main.qml" line="2450"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -795,81 +795,81 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2446"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
-        <location filename="../app/Main.qml" line="2473"/>
+        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2477"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2495"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2487"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2491"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2494"/>
+        <location filename="../app/Main.qml" line="2498"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2654"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2658"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2672"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2676"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
+        <location filename="../app/Main.qml" line="2680"/>
         <source>Retry</source>
         <translation type="unfinished">Reîncercare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
         <translation type="unfinished">Anulare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3528"/>
+        <location filename="../app/Main.qml" line="3534"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3533"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3535"/>
+        <location filename="../app/Main.qml" line="3541"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -681,34 +681,34 @@ Français - Wilfried</source>
         <translation>Spustiť hru</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2415"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
-        <location filename="../app/Main.qml" line="2466"/>
-        <location filename="../app/Main.qml" line="2476"/>
+        <location filename="../app/Main.qml" line="2431"/>
+        <location filename="../app/Main.qml" line="2470"/>
+        <location filename="../app/Main.qml" line="2480"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2467"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3524"/>
+        <location filename="../app/Main.qml" line="3530"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3531"/>
+        <location filename="../app/Main.qml" line="3537"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3526"/>
+        <location filename="../app/Main.qml" line="3532"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
@@ -738,8 +738,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2509"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2513"/>
         <source>Default</source>
         <translation type="unfinished">Predvolené</translation>
     </message>
@@ -753,39 +753,39 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1796"/>
         <location filename="../app/Main.qml" line="1813"/>
         <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2419"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2455"/>
+        <location filename="../app/Main.qml" line="2459"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2517"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2442"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2521"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2446"/>
+        <location filename="../app/Main.qml" line="2450"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -795,81 +795,81 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2446"/>
         <source>Favorites</source>
         <translation type="unfinished">Obľúbené</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
-        <location filename="../app/Main.qml" line="2473"/>
+        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2477"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2495"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2487"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2491"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2494"/>
+        <location filename="../app/Main.qml" line="2498"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2654"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2658"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2672"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2676"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
+        <location filename="../app/Main.qml" line="2680"/>
         <source>Retry</source>
         <translation type="unfinished">Skúsiť znova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
         <translation type="unfinished">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3528"/>
+        <location filename="../app/Main.qml" line="3534"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3533"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3535"/>
+        <location filename="../app/Main.qml" line="3541"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -681,34 +681,34 @@ Français - Wilfried</source>
         <translation>Запустити гру</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2415"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
-        <location filename="../app/Main.qml" line="2466"/>
-        <location filename="../app/Main.qml" line="2476"/>
+        <location filename="../app/Main.qml" line="2431"/>
+        <location filename="../app/Main.qml" line="2470"/>
+        <location filename="../app/Main.qml" line="2480"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2467"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3524"/>
+        <location filename="../app/Main.qml" line="3530"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3531"/>
+        <location filename="../app/Main.qml" line="3537"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3526"/>
+        <location filename="../app/Main.qml" line="3532"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
@@ -738,8 +738,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2509"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2513"/>
         <source>Default</source>
         <translation type="unfinished">Типовий</translation>
     </message>
@@ -753,39 +753,39 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1796"/>
         <location filename="../app/Main.qml" line="1813"/>
         <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2419"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2455"/>
+        <location filename="../app/Main.qml" line="2459"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2517"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2442"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2521"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2446"/>
+        <location filename="../app/Main.qml" line="2450"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -795,81 +795,81 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2446"/>
         <source>Favorites</source>
         <translation type="unfinished">Вибране</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
-        <location filename="../app/Main.qml" line="2473"/>
+        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2477"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2495"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2487"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2491"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2494"/>
+        <location filename="../app/Main.qml" line="2498"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2654"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2658"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2672"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2676"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
+        <location filename="../app/Main.qml" line="2680"/>
         <source>Retry</source>
         <translation type="unfinished">Повторити</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
         <translation type="unfinished">Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3528"/>
+        <location filename="../app/Main.qml" line="3534"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3533"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3535"/>
+        <location filename="../app/Main.qml" line="3541"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -700,8 +700,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2509"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2513"/>
         <source>Default</source>
         <translation type="unfinished">默认</translation>
     </message>
@@ -711,7 +711,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2415"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -720,52 +720,52 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1796"/>
         <location filename="../app/Main.qml" line="1813"/>
         <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2419"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2446"/>
         <source>Favorites</source>
         <translation type="unfinished">收藏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
-        <location filename="../app/Main.qml" line="2466"/>
-        <location filename="../app/Main.qml" line="2476"/>
+        <location filename="../app/Main.qml" line="2431"/>
+        <location filename="../app/Main.qml" line="2470"/>
+        <location filename="../app/Main.qml" line="2480"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2455"/>
+        <location filename="../app/Main.qml" line="2459"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2502"/>
+        <location filename="../app/Main.qml" line="2517"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2425"/>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2442"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2521"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2446"/>
+        <location filename="../app/Main.qml" line="2450"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -775,95 +775,95 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
-        <location filename="../app/Main.qml" line="2473"/>
+        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2477"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
+        <location filename="../app/Main.qml" line="2467"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2495"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2480"/>
-        <location filename="../app/Main.qml" line="2487"/>
+        <location filename="../app/Main.qml" line="2484"/>
+        <location filename="../app/Main.qml" line="2491"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2494"/>
+        <location filename="../app/Main.qml" line="2498"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2654"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2658"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2672"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2676"/>
         <source>Error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
+        <location filename="../app/Main.qml" line="2680"/>
         <source>Retry</source>
         <translation type="unfinished">重试</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
         <translation type="unfinished">取消</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3524"/>
+        <location filename="../app/Main.qml" line="3530"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3526"/>
+        <location filename="../app/Main.qml" line="3532"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3528"/>
+        <location filename="../app/Main.qml" line="3534"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3531"/>
+        <location filename="../app/Main.qml" line="3537"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3533"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3535"/>
+        <location filename="../app/Main.qml" line="3541"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>

--- a/tests/ui/tst_list_picker_modal.qml
+++ b/tests/ui/tst_list_picker_modal.qml
@@ -156,11 +156,12 @@ TestCase {
         compare(closeSpy.count, 1);
     }
 
-    function test_handle_action_page_menu_toggles_picker_closed(): void {
+    function test_handle_action_page_menu_is_ignored(): void {
         picker.entries = _entries(3);
         picker.open = true;
         picker.handleAction("page_menu");
-        compare(closeSpy.count, 1);
+        compare(closeSpy.count, 0);
+        compare(picker.open, true);
     }
 
     function test_reopen_recomputes_initial_index(): void {

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -902,6 +902,55 @@ TestCase {
         main.closeListPickerModal();
     }
 
+    function test_page_menu_action_toggles_only_view_pickers(): void {
+        const pickers = [
+            {
+                open: () => main.openPageMenu(),
+                fieldId: "page_menu"
+            },
+            {
+                open: () => main.openFavoritesPageMenu(),
+                fieldId: "page_menu_favorites"
+            },
+            {
+                open: () => main.openFavoriteSystemsPageMenu(),
+                fieldId: "page_menu_favorite_systems"
+            }
+        ];
+        for (let i = 0; i < pickers.length; i++) {
+            pickers[i].open();
+            tryCompare(main, "listPickerModalVisible", true);
+            compare(main.listPickerFieldId, pickers[i].fieldId);
+            main.handleAction("page_menu");
+            tryCompare(main, "listPickerModalVisible", false);
+        }
+
+        main.openListPickerModal("Orientation", [{
+            id: "horizontal",
+            label: "Horizontal"
+        }], "horizontal", "orientation");
+        tryCompare(main, "listPickerModalVisible", true);
+        main.handleAction("page_menu");
+        compare(main.listPickerModalVisible, true, "View must not close an unrelated list picker");
+        compare(main.listPickerFieldId, "orientation");
+        main.handleAction("cancel");
+        tryCompare(main, "listPickerModalVisible", false);
+    }
+
+    function test_view_toggle_restores_input_to_underlying_screen(): void {
+        main.activeScreen = main.screenGames;
+        main.openPageMenu();
+        tryCompare(main, "listPickerModalVisible", true);
+        main.handleAction("page_menu");
+        tryCompare(main, "listPickerModalVisible", false);
+
+        main.handleKey(Qt.Key_Escape);
+        compare(main.pendingTransition, "");
+        compare(main.activeScreen, main.screenSystems);
+        main.activeScreen = main.screenHub;
+        Browse.AppState.active_screen = "";
+    }
+
     function test_random_launch_failure_is_reported(): void {
         // Harness has no browse scope, so model rejects before issuing RPC.
         Browse.GamesModel.launch_random();


### PR DESCRIPTION
## Summary
- route View-button dismissal only to top-level View pickers
- keep unrelated list pickers open while preserving Back dismissal
- add modal-routing and underlying-input regression coverage

## Tests
- `just lint`
- `just test-qml`
- `just test`

Closes #310

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the Page Menu action so it closes game, favorite, and system view pickers as expected.
  - Prevented the Page Menu action from unintentionally closing unrelated list pickers.
  - Restored keyboard input to the underlying screen after closing a view picker.

- **Localization**
  - Refreshed translation catalog references to keep navigation, sorting, filtering, grouping, favorite, launcher, and loading messages synchronized across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->