### PR TITLE
fix(errors): show readable failures in modals

### DIFF
--- a/rust/frontend/build.rs
+++ b/rust/frontend/build.rs
@@ -5,6 +5,7 @@
 use cxx_qt_build::{CxxQtBuilder, QmlModule};
 
 const MODEL_FILES: &[&str] = &[
+    "src/models/action_error.rs",
     "src/models/alternate_versions.rs",
     "src/models/categories.rs",
     "src/models/crt_video.rs",

--- a/rust/frontend/src/models/action_error.rs
+++ b/rust/frontend/src/models/action_error.rs
@@ -1,0 +1,142 @@
+// Zaparoo Frontend
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+use cxx_qt::{Initialize, Threading};
+use cxx_qt_lib::{QString, QStringList};
+use std::collections::VecDeque;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Mutex, OnceLock};
+use tokio::sync::{oneshot, Notify};
+
+#[derive(Clone)]
+struct ActionErrorEvent {
+    sequence: i32,
+    kind: String,
+    context: String,
+}
+
+#[derive(Default)]
+pub struct ActionErrorRust {
+    sequence: i32,
+    kind: QString,
+    context: QString,
+    event_sequences: QStringList,
+    event_kinds: QStringList,
+    event_contexts: QStringList,
+}
+
+#[derive(Default)]
+struct ActionErrorBus {
+    queue: Mutex<VecDeque<ActionErrorEvent>>,
+    notify: Notify,
+}
+
+static NEXT_SEQUENCE: AtomicU32 = AtomicU32::new(0);
+static EVENTS: OnceLock<ActionErrorBus> = OnceLock::new();
+
+fn event_bus() -> &'static ActionErrorBus {
+    EVENTS.get_or_init(ActionErrorBus::default)
+}
+
+/// Publish a user-action failure after its full technical detail has been
+/// logged at the call site. QML maps the stable kind to localized, user-safe
+/// copy and uses sequence as an event edge even when consecutive kinds match.
+pub fn report_action_error(kind: &str, context: impl Into<String>) {
+    let sequence = NEXT_SEQUENCE.fetch_add(1, Ordering::SeqCst).wrapping_add(1) as i32;
+    let bus = event_bus();
+    bus.queue
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .push_back(ActionErrorEvent {
+            sequence,
+            kind: kind.to_owned(),
+            context: context.into(),
+        });
+    bus.notify.notify_one();
+}
+
+#[cxx_qt::bridge]
+pub mod ffi {
+    unsafe extern "C++" {
+        include!("model_includes.h");
+
+        type QString = cxx_qt_lib::QString;
+        type QStringList = cxx_qt_lib::QStringList;
+    }
+
+    unsafe extern "RustQt" {
+        #[qobject]
+        #[qml_element]
+        #[qml_singleton]
+        #[qproperty(i32, sequence)]
+        #[qproperty(QString, kind)]
+        #[qproperty(QString, context)]
+        #[qproperty(QStringList, event_sequences)]
+        #[qproperty(QStringList, event_kinds)]
+        #[qproperty(QStringList, event_contexts)]
+        type ActionError = super::ActionErrorRust;
+    }
+
+    impl cxx_qt::Threading for ActionError {}
+    impl cxx_qt::Initialize for ActionError {}
+}
+
+impl Initialize for ffi::ActionError {
+    fn initialize(self: Pin<&mut Self>) {
+        let qt_thread = self.qt_thread();
+        crate::models::global_handle().spawn(async move {
+            let bus = event_bus();
+            loop {
+                bus.notify.notified().await;
+
+                // Drain on the Qt callback, not before queueing it. Every report
+                // that lands before this callback runs joins the same retained
+                // batch, so coalesced wakeups cannot drop an event.
+                let (applied_tx, applied_rx) = oneshot::channel();
+                if qt_thread
+                    .queue(move |model| {
+                        let events = bus
+                            .queue
+                            .lock()
+                            .unwrap_or_else(std::sync::PoisonError::into_inner)
+                            .drain(..)
+                            .collect::<Vec<_>>();
+                        apply_events(model, &events);
+                        let _ = applied_tx.send(());
+                    })
+                    .is_err()
+                {
+                    return;
+                }
+                if applied_rx.await.is_err() {
+                    return;
+                }
+            }
+        });
+    }
+}
+
+fn apply_events(mut model: Pin<&mut ffi::ActionError>, events: &[ActionErrorEvent]) {
+    let Some(last) = events.last() else {
+        return;
+    };
+    let mut sequences = QStringList::default();
+    let mut kinds = QStringList::default();
+    let mut contexts = QStringList::default();
+    for event in events {
+        sequences.append(QString::from(event.sequence.to_string().as_str()));
+        kinds.append(QString::from(event.kind.as_str()));
+        contexts.append(QString::from(event.context.as_str()));
+    }
+    model.as_mut().set_kind(QString::from(last.kind.as_str()));
+    model
+        .as_mut()
+        .set_context(QString::from(last.context.as_str()));
+    model.as_mut().set_event_kinds(kinds);
+    model.as_mut().set_event_contexts(contexts);
+    model.as_mut().set_event_sequences(sequences);
+    // Set sequence last: its scalar NOTIFY edge is the batch-ready signal.
+    model.as_mut().set_sequence(last.sequence);
+}

--- a/rust/frontend/src/models/action_error.rs
+++ b/rust/frontend/src/models/action_error.rs
@@ -44,16 +44,20 @@ fn event_bus() -> &'static ActionErrorBus {
 /// logged at the call site. QML maps the stable kind to localized, user-safe
 /// copy and uses sequence as an event edge even when consecutive kinds match.
 pub fn report_action_error(kind: &str, context: impl Into<String>) {
-    let sequence = NEXT_SEQUENCE.fetch_add(1, Ordering::SeqCst).wrapping_add(1) as i32;
+    let kind = kind.to_owned();
+    let context = context.into();
     let bus = event_bus();
-    bus.queue
+    let mut queue = bus
+        .queue
         .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .push_back(ActionErrorEvent {
-            sequence,
-            kind: kind.to_owned(),
-            context: context.into(),
-        });
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let sequence = NEXT_SEQUENCE.fetch_add(1, Ordering::SeqCst).wrapping_add(1) as i32;
+    queue.push_back(ActionErrorEvent {
+        sequence,
+        kind,
+        context,
+    });
+    drop(queue);
     bus.notify.notify_one();
 }
 

--- a/rust/frontend/src/models/alternate_versions.rs
+++ b/rust/frontend/src/models/alternate_versions.rs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
+use crate::models::action_error::report_action_error;
 use crate::models::{global_handle, global_store};
 use cxx_qt::{CxxQtType, Initialize, Threading};
 use cxx_qt_lib::QString;
@@ -111,6 +112,7 @@ impl ffi::AlternateVersions {
                     }
                     Err(message) => {
                         warn!("discover alternate versions failed: {message}");
+                        report_action_error("alternate_discovery", "");
                         model.as_mut().rust_mut().entries.clear();
                         model.as_mut().rust_mut().count = 0;
                         model.as_mut().count_changed();
@@ -151,6 +153,7 @@ impl ffi::AlternateVersions {
         global_handle().spawn(async move {
             if let Err(e) = store.run_mutation::<RunMutation>(RunParams { text }).await {
                 warn!("run failed for alternate {name}: {}", e.message);
+                report_action_error("launch", name);
             }
         });
     }

--- a/rust/frontend/src/models/crt_video.rs
+++ b/rust/frontend/src/models/crt_video.rs
@@ -27,6 +27,8 @@
 //     through the frontend.toml mirror. `commit_offsets` persists the
 //     current values; the calibration screen calls it on exit.
 
+#[cfg(zaparoo_runtime = "mister")]
+use crate::models::action_error::report_action_error;
 use crate::models::settings::{mirror_settings_to_config, persist_settings};
 use crate::models::with_persist_read;
 use cxx_qt::{CxxQtType, Initialize};
@@ -208,6 +210,7 @@ impl ffi::CrtVideo {
             Ok(()) => true,
             Err(e) => {
                 tracing::warn!("could not write {CRT_ENABLE_FILE}: {e}");
+                report_action_error("setting", "");
                 false
             }
         }

--- a/rust/frontend/src/models/favorites.rs
+++ b/rust/frontend/src/models/favorites.rs
@@ -18,6 +18,7 @@ use crate::media_image_cache::{global_media_image_cache, MediaImageCache, MediaK
 use crate::media_meta_cache::{
     fetch_media_meta_with_path_fallback, global_media_meta_cache, MetaLookup,
 };
+use crate::models::action_error::report_action_error;
 use crate::models::nav_timing::NavTiming;
 use crate::models::tag_utils::{
     disambiguating_tag_labels, sibling_disambiguation_displays, tag_display_value,
@@ -227,6 +228,9 @@ pub mod ffi {
 
         #[qinvokable]
         fn fetch_more(self: Pin<&mut FavoritesModel>);
+
+        #[qinvokable]
+        fn retry(self: Pin<&mut FavoritesModel>);
 
         #[qinvokable]
         fn set_sort_mode(self: Pin<&mut FavoritesModel>, value: &QString);
@@ -553,6 +557,7 @@ impl ffi::FavoritesModel {
         }
         if let Err(error) = save_favorites_sort(&config_file_path(), normalized) {
             warn!("could not persist favorites sort: {error}");
+            report_action_error("setting", "");
         }
         self.as_mut().rust_mut().sort_mode = QString::from(normalized);
         self.as_mut().sort_mode_changed();
@@ -619,6 +624,10 @@ impl ffi::FavoritesModel {
         h
     }
 
+    fn retry(mut self: Pin<&mut Self>) {
+        self.as_mut().start_subscription();
+    }
+
     fn fetch_more(mut self: Pin<&mut Self>) {
         if self.loading_more || !self.has_next_page {
             return;
@@ -674,6 +683,7 @@ impl ffi::FavoritesModel {
         global_handle().spawn(async move {
             if let Err(e) = store.run_mutation::<RunMutation>(RunParams { text }).await {
                 warn!("run failed for {name}: {}", e.message);
+                report_action_error("launch", name);
             }
         });
     }
@@ -756,6 +766,7 @@ impl ffi::FavoritesModel {
                 "favorite update skipped: missing media identity for {}",
                 entry.name
             );
+            report_action_error("favorite", entry.name.clone());
             return;
         };
         let name = entry.name.clone();
@@ -778,7 +789,10 @@ impl ffi::FavoritesModel {
                         );
                     });
                 }
-                Err(e) => warn!("favorite update failed for {name}: {}", e.message),
+                Err(e) => {
+                    warn!("favorite update failed for {name}: {}", e.message);
+                    report_action_error("favorite", name);
+                }
             }
         });
     }

--- a/rust/frontend/src/models/favorites.rs
+++ b/rust/frontend/src/models/favorites.rs
@@ -625,6 +625,11 @@ impl ffi::FavoritesModel {
     }
 
     fn retry(mut self: Pin<&mut Self>) {
+        let sort = core_sort_for_mode(&self.sort_mode.to_string());
+        let systems = favorites_system_scope(&self.current_system_id.to_string());
+        global_store()
+            .subscribe::<MediaFavoritesEndpoint>(FavoritesArgs::new(PAGE_SIZE, sort, systems))
+            .refetch();
         self.as_mut().start_subscription();
     }
 

--- a/rust/frontend/src/models/game_info.rs
+++ b/rust/frontend/src/models/game_info.rs
@@ -15,7 +15,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::broadcast::error::RecvError;
 use tokio::task::JoinHandle;
-use tracing::debug;
+use tracing::warn;
 use zaparoo_core::media_types::{MediaMeta, MediaMetaParams};
 
 #[derive(Default)]
@@ -132,7 +132,7 @@ impl ffi::GameInfo {
                         );
                     }
                     Err(e) => {
-                        debug!("game info fetch failed for {path}: {}", e.message);
+                        warn!("game info fetch failed for {path}: {}", e.message);
                         model
                             .as_mut()
                             .set_error_message(QString::from(e.message.as_str()));

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -34,6 +34,7 @@ use crate::media_image_cache::{global_media_image_cache, MediaImageCache, MediaK
 use crate::media_meta_cache::{
     fetch_media_meta_with_path_fallback, global_media_meta_cache, MetaLookup,
 };
+use crate::models::action_error::report_action_error;
 use crate::models::nav_timing::NavTiming;
 use crate::models::tag_utils::{
     disambiguating_tag_labels, sibling_disambiguation_displays, tag_display_value,
@@ -951,10 +952,12 @@ impl ffi::GamesModel {
             };
             let Some(text) = text else {
                 warn!("media-capable directory launch fallback unavailable for {name}; not launching container path");
+                report_action_error("launch", name);
                 return;
             };
             if let Err(e) = store.run_mutation::<RunMutation>(RunParams { text }).await {
                 warn!("run failed for {name}: {}", e.message);
+                report_action_error("launch", name);
             }
         });
     }
@@ -1086,6 +1089,7 @@ impl ffi::GamesModel {
                 "favorite update skipped: missing media identity for {}",
                 entry.name
             );
+            report_action_error("favorite", entry.name.clone());
             return;
         };
         let name = entry.name.clone();
@@ -1108,7 +1112,10 @@ impl ffi::GamesModel {
                         );
                     });
                 }
-                Err(e) => warn!("favorite update failed for {name}: {}", e.message),
+                Err(e) => {
+                    warn!("favorite update failed for {name}: {}", e.message);
+                    report_action_error("favorite", name);
+                }
             }
         });
     }

--- a/rust/frontend/src/models/media_status.rs
+++ b/rust/frontend/src/models/media_status.rs
@@ -24,6 +24,7 @@
 // errors are logged but not surfaced as a Q_PROPERTY because the
 // notification stream is the source of truth for what the UI renders.
 
+use crate::models::action_error::report_action_error;
 use cxx_qt::{Initialize, Threading};
 use cxx_qt_lib::{QString, QStringList};
 use std::pin::Pin;
@@ -242,6 +243,7 @@ impl ffi::MediaStatus {
         crate::models::global_handle().spawn(async move {
             if let Err(e) = resource.start_index(MediaIndexParams::default()).await {
                 warn!("media_status: start_index failed: {}", e.message);
+                report_action_error("media_index", "");
             }
         });
     }
@@ -259,6 +261,7 @@ impl ffi::MediaStatus {
             };
             if let Err(e) = resource.start_index(params).await {
                 warn!("media_status: start_index_for_system failed: {}", e.message);
+                report_action_error("media_index", "");
             }
         });
     }
@@ -268,6 +271,7 @@ impl ffi::MediaStatus {
         crate::models::global_handle().spawn(async move {
             if let Err(e) = resource.cancel_index().await {
                 warn!("media_status: cancel_index failed: {}", e.message);
+                report_action_error("media_cancel", "");
             }
         });
     }
@@ -291,6 +295,7 @@ impl ffi::MediaStatus {
             };
             if let Err(e) = resource.start_scrape(params).await {
                 warn!("media_status: start_scrape failed: {}", e.message);
+                report_action_error("media_scrape", "");
             }
         });
     }
@@ -313,6 +318,7 @@ impl ffi::MediaStatus {
                     "media_status: start_scrape_for_system failed: {}",
                     e.message
                 );
+                report_action_error("media_scrape", "");
             }
         });
     }
@@ -335,6 +341,7 @@ impl ffi::MediaStatus {
                     "media_status: start_index_for_systems failed: {}",
                     e.message
                 );
+                report_action_error("media_index", "");
             }
         });
     }
@@ -361,6 +368,7 @@ impl ffi::MediaStatus {
                     "media_status: start_scrape_for_systems failed: {}",
                     e.message
                 );
+                report_action_error("media_scrape", "");
             }
         });
     }
@@ -370,6 +378,7 @@ impl ffi::MediaStatus {
         crate::models::global_handle().spawn(async move {
             if let Err(e) = resource.cancel_scrape().await {
                 warn!("media_status: cancel_scrape failed: {}", e.message);
+                report_action_error("media_cancel", "");
             }
         });
     }

--- a/rust/frontend/src/models/mod.rs
+++ b/rust/frontend/src/models/mod.rs
@@ -23,6 +23,7 @@
     reason = "process-local init invariants: any violation is a wiring bug and must be fatal"
 )]
 
+pub mod action_error;
 pub mod alternate_versions;
 pub mod app_state;
 pub mod app_status;
@@ -208,6 +209,7 @@ pub fn with_hidden_browse_prefs_mut<R>(f: impl FnOnce(&mut HiddenBrowsePrefs) ->
         &guard.hidden_system_ids,
     ) {
         warn!("could not save hidden browse prefs: {e}");
+        action_error::report_action_error("setting", "");
     }
     result
 }

--- a/rust/frontend/src/models/notice.rs
+++ b/rust/frontend/src/models/notice.rs
@@ -16,6 +16,7 @@
 // "I understand" button; that flips the flag and writes it back
 // atomically.
 
+use crate::models::action_error::report_action_error;
 use cxx_qt::{CxxQtType, Initialize};
 use std::pin::Pin;
 use tracing::warn;
@@ -80,6 +81,7 @@ impl ffi::Notice {
                 "could not persist commercial notice ack to {}: {e}",
                 path.display()
             );
+            report_action_error("setting", "");
         }
         self.as_mut().rust_mut().commercial_ack = true;
         self.as_mut().commercial_ack_changed();

--- a/rust/frontend/src/models/qr_code.rs
+++ b/rust/frontend/src/models/qr_code.rs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
+use crate::models::action_error::report_action_error;
 use cxx_qt::CxxQtType;
 use cxx_qt_lib::QString;
 use qrcode::{Color, QrCode as RustQrCode};
@@ -43,6 +44,9 @@ impl ffi::QrCode {
     fn generate(mut self: Pin<&mut Self>, content: QString) {
         let content_string = content.to_string();
         let rows = generate_rows(&content_string);
+        if rows.is_empty() && !content_string.is_empty() {
+            report_action_error("qr_code", "");
+        }
         let size = rows.len() as i32;
         self.as_mut().set_content(content);
         self.as_mut().rust_mut().rows = rows;

--- a/rust/frontend/src/models/recents.rs
+++ b/rust/frontend/src/models/recents.rs
@@ -27,6 +27,7 @@ use crate::media_image_cache::{global_media_image_cache, MediaImageCache, MediaK
 use crate::media_meta_cache::{
     fetch_media_meta_with_path_fallback, global_media_meta_cache, MetaLookup,
 };
+use crate::models::action_error::report_action_error;
 use crate::models::nav_timing::NavTiming;
 use crate::models::tag_utils::tag_display_value;
 use crate::models::{global_handle, global_store};
@@ -236,6 +237,9 @@ pub mod ffi {
 
         #[qinvokable]
         fn fetch_more(self: Pin<&mut RecentsModel>);
+
+        #[qinvokable]
+        fn retry(self: Pin<&mut RecentsModel>);
 
         #[qinvokable]
         fn launch_at(self: Pin<&mut RecentsModel>, index: i32);
@@ -714,6 +718,11 @@ impl ffi::RecentsModel {
                 apply_resume_latest_result(model, result);
             });
         });
+    }
+
+    fn retry(mut self: Pin<&mut Self>) {
+        self.as_mut().rust_mut().history_requested = false;
+        self.as_mut().ensure_loaded();
     }
 
     fn fetch_more(mut self: Pin<&mut Self>) {
@@ -1655,10 +1664,12 @@ fn launch_entry(entry: &MediaHistoryEntry) {
     if text.is_empty() {
         return;
     }
+    let name = entry.media_name.clone();
     let store = global_store();
     global_handle().spawn(async move {
         if let Err(e) = store.run_mutation::<RunMutation>(RunParams { text }).await {
-            warn!("run failed: {}", e.message);
+            warn!("run failed for {name}: {}", e.message);
+            report_action_error("launch", name);
         }
     });
 }

--- a/rust/frontend/src/models/settings.rs
+++ b/rust/frontend/src/models/settings.rs
@@ -72,6 +72,7 @@
 // MiSTer arcade alternates, and language still takes effect on the next launch
 // because Qt installs translators only at startup.
 
+use crate::models::action_error::report_action_error;
 use crate::models::{with_persist_mut, with_persist_read};
 use cxx_qt::{CxxQtType, Initialize};
 use cxx_qt_lib::{QString, QStringList};
@@ -646,6 +647,7 @@ pub(super) fn mirror_settings_to_config(config_path: &std::path::Path, settings:
             "could not save settings mirror to {}: {e}",
             config_path.display()
         );
+        report_action_error("setting", "");
     }
 }
 

--- a/rust/frontend/src/models/systems.rs
+++ b/rust/frontend/src/models/systems.rs
@@ -2,6 +2,7 @@
 // Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 // SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 
+use crate::models::action_error::report_action_error;
 use crate::models::{
     global_handle, global_store, with_hidden_browse_prefs_read, with_persist_read,
 };
@@ -152,6 +153,9 @@ pub mod ffi {
 
         #[qinvokable]
         fn set_category(self: Pin<&mut SystemsModel>, category: QString);
+
+        #[qinvokable]
+        fn retry(self: Pin<&mut SystemsModel>);
 
         #[qinvokable]
         fn system_id_at(self: &SystemsModel, index: i32) -> QString;
@@ -454,11 +458,8 @@ impl ffi::SystemsModel {
         // re-call recover from a stale-but-empty model — e.g. the
         // catalog refetched and the previously-current category now
         // has no systems, and a caller wants to retry the same value.
-        // The `error_message.is_empty()` guard is the [OK] RETRY path:
-        // when the catalog errored after a successful fill, `systems`
-        // is non-empty (apply_state's error branch leaves prior rows
-        // alone), so without this clause the retry would short-circuit
-        // and the surfaced error would never clear.
+        // An errored current category may still be set again by restoration
+        // paths, so do not short-circuit while an error is present.
         if self.rust().current_category == category
             && !self.rust().systems.is_empty()
             && self.rust().error_message.is_empty()
@@ -550,6 +551,23 @@ impl ffi::SystemsModel {
             });
         });
         self.as_mut().rust_mut().pending_task = Some(handle);
+    }
+
+    fn retry(mut self: Pin<&mut Self>) {
+        if self.current_category.is_empty() {
+            return;
+        }
+        if let Some(handle) = self.as_mut().rust_mut().pending_task.take() {
+            handle.abort();
+        }
+        self.rust().seq.fetch_add(1, Ordering::SeqCst);
+        if !self.loading {
+            self.as_mut().set_loading(true);
+        }
+        if !self.error_message.is_empty() {
+            self.as_mut().set_error_message(QString::default());
+        }
+        global_store().subscribe::<CatalogEndpoint>(()).refetch();
     }
 
     fn system_id_at(&self, index: i32) -> QString {
@@ -648,6 +666,7 @@ impl ffi::SystemsModel {
         global_handle().spawn(async move {
             if let Err(e) = store.run_mutation::<RunMutation>(RunParams { text }).await {
                 warn!("run failed for {name}: {}", e.message);
+                report_action_error("launch", name);
             }
         });
     }
@@ -726,6 +745,7 @@ impl ffi::SystemsModel {
         global_handle().spawn(async move {
             if let Err(e) = store.run_mutation::<RunMutation>(RunParams { text }).await {
                 warn!("run failed for {name}: {}", e.message);
+                report_action_error("launch", name);
             }
         });
     }

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -2352,8 +2352,10 @@ MainLayout {
             buttonLabel: buttonLabel !== "" ? buttonLabel : qsTr("OK"),
             accepted: accepted
         };
-        if (root.actionErrorModalVisible) {
+        if (root.actionErrorModalVisible || root._actionErrorQueue.length > 0) {
             root._actionErrorQueue = root._actionErrorQueue.concat([entry]);
+            if (!root.actionErrorModalVisible)
+                actionErrorQueueTimer.restart();
             return;
         }
         root._showActionError(entry);

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -38,6 +38,7 @@ MainLayout {
     readonly property string modalQrCode: "qr_code"
     readonly property string modalCommercialNotice: "commercial_notice"
     readonly property string modalCoreVersion: "core_version_warning"
+    readonly property string modalActionError: "action_error"
     readonly property string modalRandomFailed: "random_failed"
     // Sentinel id for the favorites "default order" row; maps to an empty
     // sort mode. Must never be "" — see openFavoritesSortMenu.
@@ -74,6 +75,12 @@ MainLayout {
     property string _pendingLauncherSystemId: ""
     property string _pendingLauncherSelectionId: ""
     property string cardWriteOwner: ""
+    property int _cardWriteIndex: -1
+    property string _gameInfoOwner: ""
+    property int _gameInfoIndex: -1
+    property var _actionErrorAcceptedCallback: null
+    property var _actionErrorQueue: []
+    property int _lastActionErrorSequence: 0
     property string contextMenuMode: "main"
     property string contextMenuOwner: ""
     property int contextMenuIndex: -1
@@ -275,6 +282,8 @@ MainLayout {
             root.commercialNoticeModalRequested = true;
         else if (modal === root.modalCoreVersion)
             root.coreVersionModalRequested = true;
+        else if (modal === root.modalActionError)
+            root.actionErrorModalRequested = true;
         else if (modal === root.modalRandomFailed)
             root.randomFailedModalRequested = true;
         else if (modal === root.modalLogUpload)
@@ -1514,6 +1523,9 @@ MainLayout {
         function onRequestAccept(category: string): void {
             root._navigateFromHub(category);
         }
+        function onRequestRetry(): void {
+            Browse.CategoriesModel.refresh();
+        }
         function onRequestQuit(): void {
             root.openQuitConfirmModal();
         }
@@ -1619,9 +1631,7 @@ MainLayout {
             // screen layer (no signal emitted), so this branch only
             // sees user intent on a non-Ready state.
             if (systemId === "") {
-                const cat = Browse.SystemsModel.current_category;
-                if (cat !== "")
-                    Browse.SystemsModel.set_category(cat);
+                Browse.SystemsModel.retry();
                 return;
             }
             // Launch-only (virtual) systems carry a zapScript and have no
@@ -1699,6 +1709,7 @@ MainLayout {
     onCancelCardWriteRequested: root.cancelCardWrite()
     onCloseGameInfoRequested: root.closeGameInfoModal()
     onCloseQrCodeRequested: root.closeQrCodeModal()
+    onActionErrorAccepted: root.closeActionErrorModal(true)
     onContextMenuCloseRequested: root.handleContextMenuCloseRequested()
     onContextMenuAccepted: id => root.handleContextMenuAccepted(id)
     Connections {
@@ -2119,20 +2130,21 @@ MainLayout {
             root.openGameInfo(owner, targetIndex);
         } else if (id === "write_card") {
             if (owner === "systems") {
-                root.beginCardWrite("systems");
+                root.beginCardWrite("systems", targetIndex);
                 Browse.SystemsModel.write_card_at(targetIndex);
             } else if (owner === "games") {
-                root.beginCardWrite("games");
+                root.beginCardWrite("games", targetIndex);
                 Browse.GamesModel.write_card_at(targetIndex);
             } else if (owner === "favorites") {
-                root.beginCardWrite("favorites");
+                root.beginCardWrite("favorites", targetIndex);
                 Browse.FavoritesModel.write_card_at(targetIndex);
             }
         } else if (id === "qr_code") {
             const text = owner === "systems" ? Browse.SystemsModel.launch_text_at(targetIndex) : owner === "games" ? Browse.GamesModel.launch_text_at(targetIndex) : owner === "favorites" ? Browse.FavoritesModel.launch_text_at(targetIndex) : "";
             if (text !== "") {
                 Browse.QrCode.generate(root._buildQrPayload(text));
-                root.openQrCodeModal();
+                if (Browse.QrCode.size > 0)
+                    root.openQrCodeModal();
             }
         } else if (id === "discover_unavailable" || id === "discover_loading") {
             return;
@@ -2158,6 +2170,8 @@ MainLayout {
         }
         if (systemId === "" || path === "")
             return;
+        root._gameInfoOwner = owner;
+        root._gameInfoIndex = index;
         Browse.GameInfo.load(systemId, path, title);
         root._requestModal(root.modalGameInfo);
         root.gameInfoModalVisible = true;
@@ -2168,8 +2182,28 @@ MainLayout {
     function closeGameInfoModal(): void {
         root.gameInfoModalVisible = false;
         Browse.GameInfo.clear();
+        root._gameInfoOwner = "";
+        root._gameInfoIndex = -1;
         if (ScreenManager.topModal === root.modalGameInfo)
             ScreenManager.popModal();
+    }
+
+    function handleGameInfoError(): void {
+        if (!root.gameInfoModalVisible || (Browse.GameInfo.error_message ?? "") === "")
+            return;
+        const owner = root._gameInfoOwner;
+        const index = root._gameInfoIndex;
+        root.closeGameInfoModal();
+        root.presentActionError("game_info:" + owner, qsTr("Details unavailable"), qsTr("Could not load details for this item. Check Zaparoo Core and try again."), qsTr("Retry"), function () {
+            root.openGameInfo(owner, index);
+        });
+    }
+
+    Connections {
+        target: Browse.GameInfo
+        function onError_messageChanged(): void {
+            root.handleGameInfoError();
+        }
     }
 
     function openQrCodeModal(): void {
@@ -2289,20 +2323,132 @@ MainLayout {
             ScreenManager.popModal();
     }
 
+    function _showActionError(entry): void {
+        root._requestModal(root.modalActionError);
+        root.actionErrorKey = entry.key;
+        root.actionErrorTitle = entry.title;
+        root.actionErrorBody = entry.body;
+        root.actionErrorButtonLabel = entry.buttonLabel;
+        root._actionErrorAcceptedCallback = entry.accepted;
+        root.randomFailedModalVisible = entry.key === "random";
+        root.actionErrorModalVisible = true;
+        if (ScreenManager.topModal !== root.modalActionError)
+            ScreenManager.pushModal(root.modalActionError);
+    }
+
+    function presentActionError(key: string, title: string, body: string, buttonLabel: string, accepted): void {
+        if (key === "")
+            return;
+        if (root.actionErrorModalVisible && root.actionErrorKey === key)
+            return;
+        for (let i = 0; i < root._actionErrorQueue.length; i++) {
+            if (root._actionErrorQueue[i].key === key)
+                return;
+        }
+        const entry = {
+            key: key,
+            title: title,
+            body: body,
+            buttonLabel: buttonLabel !== "" ? buttonLabel : qsTr("OK"),
+            accepted: accepted
+        };
+        if (root.actionErrorModalVisible) {
+            root._actionErrorQueue = root._actionErrorQueue.concat([entry]);
+            return;
+        }
+        root._showActionError(entry);
+    }
+
+    function closeActionErrorModal(runAccepted: bool): void {
+        if (!root.actionErrorModalVisible)
+            return;
+        const accepted = root._actionErrorAcceptedCallback;
+        const wasRandom = root.actionErrorKey === "random";
+        root.actionErrorModalVisible = false;
+        root.randomFailedModalVisible = false;
+        root.actionErrorKey = "";
+        root.actionErrorTitle = "";
+        root.actionErrorBody = "";
+        root.actionErrorButtonLabel = qsTr("OK");
+        root._actionErrorAcceptedCallback = null;
+        if (ScreenManager.topModal === root.modalActionError)
+            ScreenManager.popModal();
+        if (wasRandom) {
+            Browse.GamesModel.clear_random_error();
+            Browse.FavoritesModel.clear_random_error();
+            Browse.SystemsModel.clear_random_error();
+        }
+        if (runAccepted && typeof accepted === "function")
+            accepted();
+        if (root._actionErrorQueue.length > 0)
+            actionErrorQueueTimer.restart();
+    }
+
+    function _showNextActionError(): void {
+        if (root.actionErrorModalVisible || root._actionErrorQueue.length === 0)
+            return;
+        const entry = root._actionErrorQueue[0];
+        root._actionErrorQueue = root._actionErrorQueue.slice(1);
+        root._showActionError(entry);
+    }
+
     function openRandomFailedModal(): void {
-        root._requestModal(root.modalRandomFailed);
-        root.randomFailedModalVisible = true;
-        if (ScreenManager.topModal !== root.modalRandomFailed)
-            ScreenManager.pushModal(root.modalRandomFailed);
+        root.presentActionError("random", qsTr("Random game"), qsTr("No matching games found."), qsTr("OK"), null);
     }
 
     function closeRandomFailedModal(): void {
-        root.randomFailedModalVisible = false;
-        Browse.GamesModel.clear_random_error();
-        Browse.FavoritesModel.clear_random_error();
-        Browse.SystemsModel.clear_random_error();
-        if (ScreenManager.topModal === root.modalRandomFailed)
-            ScreenManager.popModal();
+        if (root.actionErrorModalVisible && root.actionErrorKey === "random")
+            root.closeActionErrorModal(false);
+    }
+
+    function _presentReportedActionError(kind: string, context: string): void {
+        let title = qsTr("Action failed");
+        let body = qsTr("The action could not be completed. Check Zaparoo Core and try again.");
+        if (kind === "launch") {
+            title = qsTr("Launch failed");
+            body = context !== "" ? qsTr("Could not start %1. Check Zaparoo Core and try again.").arg(context) : qsTr("Could not start this item. Check Zaparoo Core and try again.");
+        } else if (kind === "favorite") {
+            title = qsTr("Favorite update failed");
+            body = qsTr("Could not update this favorite. Check Zaparoo Core and try again.");
+        } else if (kind === "media_index") {
+            title = qsTr("Media update failed");
+            body = qsTr("Could not start the media database update. Check Zaparoo Core and try again.");
+        } else if (kind === "media_scrape") {
+            title = qsTr("Metadata scrape failed");
+            body = qsTr("Could not start metadata scraping. Check Zaparoo Core and try again.");
+        } else if (kind === "media_cancel") {
+            title = qsTr("Cancel failed");
+            body = qsTr("Could not cancel the media operation. Check Zaparoo Core and try again.");
+        } else if (kind === "launcher") {
+            title = qsTr("Launcher update failed");
+            body = qsTr("Could not change the launcher. Check Zaparoo Core and try again.");
+        } else if (kind === "alternate_discovery") {
+            title = qsTr("Alternate versions unavailable");
+            body = qsTr("Could not find alternate versions. Check Zaparoo Core and try again.");
+        } else if (kind === "qr_code") {
+            title = qsTr("QR code failed");
+            body = qsTr("Could not create the QR code for this item.");
+        } else if (kind === "setting") {
+            title = qsTr("Setting not saved");
+            body = qsTr("Could not save this setting. Try again.");
+        }
+        root.presentActionError(kind + ":" + context, title, body, qsTr("OK"), null);
+    }
+
+    Connections {
+        target: Browse.ActionError
+        function onSequenceChanged(): void {
+            const sequences = Browse.ActionError.event_sequences;
+            const kinds = Browse.ActionError.event_kinds;
+            const contexts = Browse.ActionError.event_contexts;
+            for (let i = 0; i < sequences.length; i++) {
+                const sequence = Number(sequences[i]);
+                if (sequence <= 0 || sequence === root._lastActionErrorSequence)
+                    continue;
+                root._lastActionErrorSequence = sequence;
+                root._presentReportedActionError(kinds[i] ?? "", contexts[i] ?? "");
+            }
+        }
     }
 
     Connections {
@@ -2348,6 +2494,24 @@ MainLayout {
         root.logUploadModalVisible = false;
         if (ScreenManager.topModal === root.modalLogUpload)
             ScreenManager.popModal();
+    }
+
+    function handleLogUploadError(): void {
+        // LogUpload state 3 is terminal failure; full detail is already logged
+        // by the Rust model. Replace the phase view with standard error chrome.
+        if (!root.logUploadModalVisible || Browse.LogUpload.state !== 3)
+            return;
+        root.closeLogUploadModal();
+        root.presentActionError("log_upload", qsTr("Log upload failed"), qsTr("Could not upload the logs. Check the network connection and try again."), qsTr("Retry"), function () {
+            root.openLogUploadModal();
+        });
+    }
+
+    Connections {
+        target: Browse.LogUpload
+        function onStateChanged(): void {
+            root.handleLogUploadError();
+        }
     }
 
     onCloseLogUploadRequested: root.closeLogUploadModal()
@@ -2668,31 +2832,31 @@ MainLayout {
         root._pendingLauncherSelectionId = "";
     }
 
-    function showSystemLauncherUpdateError(): void {
-        root.listPickerTitle = qsTr("Launcher update failed");
-        root.listPickerEntries = [
+    function retrySystemLauncherUpdate(systemId: string, selectedId: string): void {
+        root.openListPickerModal(qsTr("Saving launcher"), [
             {
-                id: "error",
-                label: qsTr("Error: %1").arg(Browse.SystemLaunchers.update_error)
-            },
-            {
-                id: "retry",
-                label: qsTr("Retry")
-            },
-            {
-                id: "cancel",
-                label: qsTr("Cancel")
+                id: "saving",
+                label: qsTr("Saving…")
             }
-        ];
-        root.listPickerInitialId = "retry";
-        root.listPickerFieldId = "system_launcher_error";
+        ], "saving", "system_launcher_pending");
+        root._pendingLauncherSystemId = systemId;
+        root._pendingLauncherSelectionId = selectedId;
+        Browse.SystemLaunchers.set_system_launcher(systemId, selectedId);
+    }
+
+    function showSystemLauncherUpdateError(): void {
+        const systemId = root._pendingLauncherSystemId;
+        const selectedId = root._pendingLauncherSelectionId;
+        root.closeListPickerModal();
+        root.clearPendingLauncherUpdate();
+        root.presentActionError("launcher:" + systemId, qsTr("Launcher update failed"), qsTr("Could not change the launcher. Check Zaparoo Core and try again."), qsTr("Retry"), function () {
+            root.retrySystemLauncherUpdate(systemId, selectedId);
+        });
     }
 
     function handleListPickerCloseRequested(): void {
         if (root.listPickerFieldId === "system_launcher_pending")
             return;
-        if (root.listPickerFieldId === "system_launcher_error")
-            root.clearPendingLauncherUpdate();
         root.closeListPickerModal();
     }
 
@@ -2751,17 +2915,6 @@ MainLayout {
         }
         if (fieldId === "system_launcher_pending")
             return;
-        if (fieldId === "system_launcher_error") {
-            if (selectedId === "error")
-                return;
-            if (selectedId === "retry" && root._pendingLauncherSystemId !== "")
-                root.beginSystemLauncherUpdate(root._pendingLauncherSystemId, root._pendingLauncherSelectionId);
-            else {
-                root.clearPendingLauncherUpdate();
-                root.closeListPickerModal();
-            }
-            return;
-        }
         if (fieldId.startsWith("system_launcher:")) {
             root.beginSystemLauncherUpdate(fieldId.slice("system_launcher:".length), selectedId);
             return;
@@ -2900,7 +3053,7 @@ MainLayout {
     onCloseCoreVersionRequested: root.closeCoreVersionModal()
     onCloseRandomFailedRequested: root.closeRandomFailedModal()
 
-    function beginCardWrite(owner: string): void {
+    function beginCardWrite(owner: string, index: int): void {
         if (owner === "systems")
             Browse.SystemsModel.cancel_card_write();
         else if (owner === "games")
@@ -2908,12 +3061,24 @@ MainLayout {
         else if (owner === "favorites")
             Browse.FavoritesModel.cancel_card_write();
         root.cardWriteOwner = owner;
+        root._cardWriteIndex = index;
         root.cardWriteFailed = false;
         root._requestModal(root.modalCardWrite);
         root.cardWriteModalVisible = true;
-        cardWriteFailureTimer.stop();
         if (ScreenManager.topModal !== root.modalCardWrite)
             ScreenManager.pushModal(root.modalCardWrite);
+    }
+
+    function retryCardWrite(owner: string, index: int): void {
+        if (index < 0)
+            return;
+        root.beginCardWrite(owner, index);
+        if (owner === "systems")
+            Browse.SystemsModel.write_card_at(index);
+        else if (owner === "games")
+            Browse.GamesModel.write_card_at(index);
+        else if (owner === "favorites")
+            Browse.FavoritesModel.write_card_at(index);
     }
 
     function handleCardWriteStatus(): void {
@@ -2922,8 +3087,12 @@ MainLayout {
         if (root.activeCardWritePending)
             return;
         if (root.activeCardWriteError !== "") {
-            root.cardWriteFailed = true;
-            cardWriteFailureTimer.restart();
+            const owner = root.cardWriteOwner;
+            const index = root._cardWriteIndex;
+            root.hideCardWriteModal();
+            root.presentActionError("card_write:" + owner, qsTr("Card write failed"), qsTr("Could not write to this card. Check that it is writable and try again."), qsTr("Retry"), function () {
+                root.retryCardWrite(owner, index);
+            });
         } else {
             root.hideCardWriteModal();
         }
@@ -2940,10 +3109,10 @@ MainLayout {
     }
 
     function hideCardWriteModal(): void {
-        cardWriteFailureTimer.stop();
         root.cardWriteModalVisible = false;
         root.cardWriteFailed = false;
         root.cardWriteOwner = "";
+        root._cardWriteIndex = -1;
         if (ScreenManager.topModal === root.modalCardWrite)
             ScreenManager.popModal();
     }
@@ -2988,7 +3157,12 @@ MainLayout {
             // pending kill the write the user actually wanted; on
             // success/error the modal auto-dismisses via
             // handleCardWriteStatus, so accept has nothing to do here.
-            if (ScreenManager.topModal === root.modalCardWrite && action === "cancel") {
+            if (ScreenManager.topModal === root.modalActionError) {
+                if (action === "cancel")
+                    root.closeActionErrorModal(false);
+                else if (root.actionErrorModal !== null)
+                    root.actionErrorModal.handleAction(action);
+            } else if (ScreenManager.topModal === root.modalCardWrite && action === "cancel") {
                 root.cancelCardWrite();
             } else if (ScreenManager.topModal === root.modalQrCode && action === "cancel") {
                 root.closeQrCodeModal();
@@ -3005,7 +3179,8 @@ MainLayout {
                 if (root.coreVersionModal !== null)
                     root.coreVersionModal.handleAction(action);
             } else if (ScreenManager.topModal === root.modalRandomFailed) {
-                // Accept or Back both dismiss one-button notice.
+                // Legacy stack id retained for sessions restored across a hot
+                // reload; new failures use the shared action-error modal.
                 if (action === "accept" || action === "cancel")
                     root.closeRandomFailedModal();
             } else if (ScreenManager.topModal === root.modalLogUpload) {
@@ -3407,10 +3582,10 @@ MainLayout {
     }
 
     Timer {
-        id: cardWriteFailureTimer
-        interval: 1500
+        id: actionErrorQueueTimer
+        interval: 0
         repeat: false
-        onTriggered: root.hideCardWriteModal()
+        onTriggered: root._showNextActionError()
     }
 
     Timer {

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -105,6 +105,7 @@ ApplicationWindow {
     property bool gameInfoModalRequested: false
     property bool commercialNoticeModalRequested: false
     property bool coreVersionModalRequested: false
+    property bool actionErrorModalRequested: false
     property bool randomFailedModalRequested: false
     property bool logUploadModalRequested: false
     property bool quitConfirmModalRequested: false
@@ -292,6 +293,7 @@ ApplicationWindow {
     property var qrCodeModal: qrCodeModalLoader.item
     property var commercialNoticeModal: commercialNoticeModalLoader.item
     property var coreVersionModal: coreVersionModalLoader.item
+    property var actionErrorModal: actionErrorModalLoader.item
     property var gameInfoModal: gameInfoModalLoader.item
     property var logUploadModal: logUploadModalLoader.item
     property var quitConfirmModal: quitConfirmModalLoader.item
@@ -311,6 +313,11 @@ ApplicationWindow {
     property bool qrCodeModalVisible: false
     property bool commercialNoticeModalVisible: false
     property bool coreVersionModalVisible: false
+    property bool actionErrorModalVisible: false
+    property string actionErrorKey: ""
+    property string actionErrorTitle: ""
+    property string actionErrorBody: ""
+    property string actionErrorButtonLabel: qsTr("OK")
     property bool randomFailedModalVisible: false
     property bool gameInfoModalVisible: false
     property bool logUploadModalVisible: false
@@ -445,6 +452,7 @@ ApplicationWindow {
     signal closeQrCodeRequested
     signal closeCommercialNoticeRequested
     signal closeCoreVersionRequested
+    signal actionErrorAccepted
     signal closeRandomFailedRequested
     signal closeLogUploadRequested
     signal closeQuitConfirmRequested
@@ -865,17 +873,17 @@ ApplicationWindow {
             }
 
             Loader {
-                id: randomFailedModalLoader
+                id: actionErrorModalLoader
                 anchors.fill: parent
-                active: root.randomFailedModalRequested
+                active: root.actionErrorModalRequested
                 sourceComponent: Component {
                     Modal {
-                        open: root.randomFailedModalVisible
+                        open: root.actionErrorModalVisible
                         kind: "action_error"
-                        title: qsTr("Random game")
-                        body: qsTr("No matching games found.")
-                        buttonLabel: qsTr("OK")
-                        onAccepted: root.closeRandomFailedRequested()
+                        title: root.actionErrorTitle
+                        body: root.actionErrorBody
+                        buttonLabel: root.actionErrorButtonLabel
+                        onAccepted: root.actionErrorAccepted()
                     }
                 }
             }
@@ -1179,6 +1187,17 @@ ApplicationWindow {
                                 label: qsTr("I understand")
                             }
                         ];
+                    if (root.actionErrorModalVisible)
+                        return [
+                            {
+                                button: "ButtonA",
+                                label: root.actionErrorButtonLabel
+                            },
+                            {
+                                button: "ButtonB",
+                                label: qsTr("Close")
+                            }
+                        ];
                     if (root.coreVersionModalVisible || root.randomFailedModalVisible)
                         return [
                             {
@@ -1223,7 +1242,8 @@ ApplicationWindow {
                         // and misses the Settings tile entirely. Category
                         // Real category tiles and Favorites action tile expose
                         // Options; placeholders and other actions do not.
-                        const categoryOptionsAvailable = root.hubScreen !== null && root.hubScreen.currentRow === 0 && Browse.CategoriesModel.count > 0;
+                        const categoryErrorFocused = root.hubScreen !== null && root.hubScreen.currentRow === 0 && (Browse.CategoriesModel.error_message ?? "") !== "";
+                        const categoryOptionsAvailable = root.hubScreen !== null && root.hubScreen.currentRow === 0 && !categoryErrorFocused && Browse.CategoriesModel.count > 0;
                         const favoritesOptionsAvailable = root.hubScreen !== null && root.hubScreen.currentRow === 1 && root.hubScreen.actionEntries[root.hubScreen.currentIndex]?.id === "favorites";
                         let row = [
                             {
@@ -1232,7 +1252,7 @@ ApplicationWindow {
                             },
                             {
                                 button: "ButtonA",
-                                label: qsTr("Open")
+                                label: categoryErrorFocused ? qsTr("Retry") : qsTr("Open")
                             }
                         ];
                         if (categoryOptionsAvailable || favoritesOptionsAvailable)

--- a/src/ui/components/GameInfoModal.qml
+++ b/src/ui/components/GameInfoModal.qml
@@ -117,7 +117,7 @@ Item {
                 anchors.rightMargin: Sizing.pctW(4)
                 anchors.top: titleText.bottom
                 anchors.topMargin: Sizing.pctH(4)
-                text: Browse.GameInfo.error_message
+                text: qsTr("Could not load details. Check Zaparoo Core and try again.")
                 color: Theme.textPrimary
                 font.family: Theme.fontUi
                 font.pixelSize: Sizing.fontSize(2.6)

--- a/src/ui/components/LogUploadModal.qml
+++ b/src/ui/components/LogUploadModal.qml
@@ -194,7 +194,7 @@ Item {
             Text {
                 width: parent.width
                 visible: modal.phase === modal._stateError
-                text: Browse.LogUpload.error_message !== "" ? qsTr("Upload failed: %1").arg(Browse.LogUpload.error_message) : qsTr("Upload failed.")
+                text: qsTr("Upload failed. Check the network connection and try again.")
                 font.family: Theme.fontUi
                 font.pixelSize: Sizing.fontSize(2.4)
                 color: Theme.textPrimary

--- a/src/ui/components/Modal.qml
+++ b/src/ui/components/Modal.qml
@@ -193,6 +193,7 @@ Item {
                     width: parent.width
                     visible: modal.title !== ""
                     text: modal.title
+                    textFormat: Text.PlainText
                     font.family: Theme.fontUi
                     font.pixelSize: Sizing.fontSize(3.2)
                     color: Theme.textPrimary
@@ -205,6 +206,7 @@ Item {
                     width: parent.width
                     visible: modal.body !== "" && modal.kind !== "shell"
                     text: modal.body
+                    textFormat: Text.PlainText
                     font.family: Theme.fontUi
                     font.pixelSize: Sizing.fontSize(2.6)
                     color: Theme.textPrimary

--- a/src/ui/components/ScreenStateOverlay.qml
+++ b/src/ui/components/ScreenStateOverlay.qml
@@ -22,10 +22,13 @@ Item {
 
     property bool enabled: true
     property bool loading: false
+    // errorMessage is state only. It may contain backend diagnostics and must
+    // never be rendered; technical detail belongs in logs.
     property string errorMessage: ""
     property int count: 0
     property string emptyText: qsTr("Nothing here")
     property string loadingText: qsTr("Loading…")
+    property string errorText: qsTr("Check Zaparoo Core and try again.")
     property int loadingDelayMs: 300
     property int minimumLoadingVisibleMs: 200
     readonly property bool loadingVisible: overlay.enabled && delayedLoading.showing
@@ -78,8 +81,8 @@ Item {
 
         Text {
             anchors.horizontalCenter: parent.horizontalCenter
-            visible: overlay.viewState === "error" && overlay.errorMessage !== ""
-            text: overlay.errorMessage
+            visible: overlay.viewState === "error" && overlay.errorText !== ""
+            text: overlay.errorText
             font.family: Theme.fontUi
             font.pixelSize: Sizing.fontSize(2.4)
             color: Theme.textPrimary

--- a/src/ui/screens/FavoritesScreen.qml
+++ b/src/ui/screens/FavoritesScreen.qml
@@ -40,6 +40,7 @@ MediaListScreen {
     topStripTotalPagesProvider: () => favorites.mediaGrid.totalPageCount
     topStripTotalTextProvider: () => favorites.favoriteTotal >= 0 ? qsTr("%n favorite(s)", "", favorites.favoriteTotal) : ""
     pageMenuEnabledWhenEmpty: true
+    retryAction: () => Browse.FavoritesModel.retry()
 
     onSelectedSystemIdChanged: Browse.FavoritesModel.set_system(favorites.selectedSystemId)
     Component.onCompleted: Browse.FavoritesModel.set_system(favorites.selectedSystemId)

--- a/src/ui/screens/HubScreen.qml
+++ b/src/ui/screens/HubScreen.qml
@@ -161,6 +161,7 @@ Item {
     property int _crossSavedIndex: -1
 
     signal requestAccept(category: string)
+    signal requestRetry
     signal requestQuit
     signal requestFavoritesScreen
     signal requestRecentsScreen
@@ -500,6 +501,10 @@ Item {
     // after the push-in cue has had time to play.
     function _emitActivate(): void {
         if (hub.currentRow === 0) {
+            if ((Browse.CategoriesModel.error_message ?? "") !== "") {
+                hub.requestRetry();
+                return;
+            }
             // During optimistic boot the visible category row is backed
             // by localized placeholder labels. Accept the stable category
             // id, not the display name, so persisted HubState and router
@@ -620,9 +625,9 @@ Item {
         y: hub._blockY
 
         // Hide the tiles while the router holds us here on a forward
-        // transition so the centred "Loading…" cue (painted from
-        // Main.qml) reads alone.
-        visible: !hub.transitioning
+        // transition or while its load error is shown. Error text then paints
+        // against the screen background rather than over stale categories.
+        visible: !hub.transitioning && (Browse.CategoriesModel.error_message ?? "") === ""
 
         Component {
             id: tileDelegate
@@ -797,7 +802,7 @@ Item {
                 return entry.name;
             return "";
         }
-        visible: true
+        visible: hub.currentRow === 1 || (Browse.CategoriesModel.error_message ?? "") === ""
     }
 
     // CategoriesModel has no `loading` qproperty — the catalog is

--- a/src/ui/screens/MediaListScreen.qml
+++ b/src/ui/screens/MediaListScreen.qml
@@ -169,7 +169,7 @@ Item {
     // content hidden through the cue's minimum-visible tail so newly
     // loaded rows cannot paint underneath lingering loading text.
     readonly property bool _overlayLoadingVisible: stateOverlay.loadingVisible
-    readonly property bool _gateHide: root.transitioning || root._loading() || root._overlayLoadingVisible
+    readonly property bool _gateHide: root.transitioning || root._loading() || root._overlayLoadingVisible || root._errorMessage() !== ""
 
     signal requestHubScreen
     signal requestContextMenu(int index, var anchorRect)
@@ -622,7 +622,7 @@ Item {
 
     ActiveLabel {
         id: activeLabel
-        visible: !root._loading() && !root._overlayLoadingVisible && !root._listLayout && root.renderGridLayout
+        visible: !root._gateHide && !root._listLayout && root.renderGridLayout
         anchors.left: parent.left
         anchors.right: parent.right
         anchors.top: root.activeLabelAtBottom ? undefined : mediaGrid.bottom

--- a/src/ui/screens/RecentsScreen.qml
+++ b/src/ui/screens/RecentsScreen.qml
@@ -28,4 +28,5 @@ MediaListScreen {
     gridHasMorePages: Browse.RecentsModel.has_next_page
     paginationTotalKnown: false
     gridTileTopLabelProvider: index => Browse.RecentsModel.system_name_at(index)
+    retryAction: () => Browse.RecentsModel.retry()
 }

--- a/src/ui/screens/SystemsScreen.qml
+++ b/src/ui/screens/SystemsScreen.qml
@@ -29,6 +29,7 @@ Item {
 
     property alias systemsGrid: systemsGrid
     property alias listCard: listCard
+    property alias activeLabel: activeLabel
     property bool transitioning: false
     // True while Hub→Systems routing is preparing this destination, before
     // the delayed loading cue becomes visible. Used only to suspend hidden
@@ -76,7 +77,7 @@ Item {
     readonly property var _gridShape: Sizing.systemsGridShape(Sizing.screenWidth, Sizing.screenHeight)
     readonly property bool _loading: Browse.SystemsModel.loading || systems.optimisticLoading
     readonly property bool _overlayLoadingVisible: stateOverlay.loadingVisible
-    readonly property bool _gateHide: systems.transitioning || systems._loading || systems._overlayLoadingVisible
+    readonly property bool _gateHide: systems.transitioning || systems._loading || systems._overlayLoadingVisible || (Browse.SystemsModel.error_message ?? "") !== ""
 
     signal requestAccept(systemId: string)
     signal requestHubScreen
@@ -348,7 +349,7 @@ Item {
         anchors.bottomMargin: systems._footerProfile ? systems._footerProfile.activeLabelBottomMargin : Sizing.pctH(8)
         height: systems._footerProfile ? systems._footerProfile.activeLabelHeight : Sizing.pctH(7)
         text: systemsGrid.itemCount > 0 ? Browse.SystemsModel.system_name_at(systemsGrid.currentIndex) : ""
-        visible: !systems._loading && !systems._overlayLoadingVisible && !systems._listLayout
+        visible: !systems._gateHide && !systems._listLayout
     }
 
     Text {

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -490,6 +490,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/GameInfoModal.qml" line="120"/>
+        <source>Could not load details. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/GameInfoModal.qml" line="169"/>
         <source>Loading image…</source>
         <translation type="unfinished"></translation>
@@ -558,27 +563,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="202"/>
+        <location filename="../screens/HubScreen.qml" line="203"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="209"/>
+        <location filename="../screens/HubScreen.qml" line="210"/>
         <source>Favorites</source>
         <translation>المفضلة</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="215"/>
+        <location filename="../screens/HubScreen.qml" line="216"/>
         <source>Recently Played</source>
         <translation>تم لعبها مؤخرًا</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="222"/>
+        <location filename="../screens/HubScreen.qml" line="223"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="229"/>
+        <location filename="../screens/HubScreen.qml" line="230"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -587,7 +592,7 @@ Français - Wilfried</source>
         <translation type="vanished">الإعدادات</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="816"/>
+        <location filename="../screens/HubScreen.qml" line="821"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>لا توجد أنظمة متاحة. شغّل تحديث قاعدة بيانات الوسائط من الإعدادات.</translation>
     </message>
@@ -632,13 +637,16 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="197"/>
-        <source>Upload failed: %1</source>
-        <translation>فشل الرفع: %1</translation>
+        <source>Upload failed. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197"/>
+        <source>Upload failed: %1</source>
+        <translation type="vanished">فشل الرفع: %1</translation>
+    </message>
+    <message>
         <source>Upload failed.</source>
-        <translation>فشل الرفع.</translation>
+        <translation type="vanished">فشل الرفع.</translation>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="227"/>
@@ -654,58 +662,58 @@ Français - Wilfried</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1746"/>
+        <location filename="../app/Main.qml" line="1757"/>
         <source>Launch core</source>
         <translation>تشغيل النواة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1760"/>
-        <location filename="../app/Main.qml" line="2045"/>
+        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="2056"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1767"/>
-        <location filename="../app/Main.qml" line="1801"/>
+        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="1812"/>
         <source>Update media database</source>
         <translation type="unfinished">تحديث قاعدة بيانات الوسائط</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1770"/>
-        <location filename="../app/Main.qml" line="1804"/>
+        <location filename="../app/Main.qml" line="1781"/>
+        <location filename="../app/Main.qml" line="1815"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">استخراج البيانات الوصفية</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1829"/>
-        <location filename="../app/Main.qml" line="1864"/>
+        <location filename="../app/Main.qml" line="1840"/>
+        <location filename="../app/Main.qml" line="1875"/>
         <source>Launch game</source>
         <translation>تشغيل اللعبة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Remove from favorites</source>
         <translation>إزالة من المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Add to favorites</source>
         <translation>أضف إلى المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1850"/>
+        <location filename="../app/Main.qml" line="1861"/>
         <source>Write to NFC token</source>
         <translation>الكتابة إلى رمز NFC</translation>
     </message>
@@ -714,171 +722,316 @@ Français - Wilfried</source>
         <translation type="vanished">رمز QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2052"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2677"/>
         <source>Default</source>
         <translation type="unfinished">افتراضي</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
+        <location filename="../app/Main.qml" line="2052"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2579"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1755"/>
-        <location filename="../app/Main.qml" line="1796"/>
-        <location filename="../app/Main.qml" line="1813"/>
-        <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="1766"/>
+        <location filename="../app/Main.qml" line="1807"/>
+        <location filename="../app/Main.qml" line="1824"/>
+        <location filename="../app/Main.qml" line="1832"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2587"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2446"/>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Favorites</source>
         <translation type="unfinished">المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2431"/>
-        <location filename="../app/Main.qml" line="2470"/>
-        <location filename="../app/Main.qml" line="2480"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2634"/>
+        <location filename="../app/Main.qml" line="2644"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
+        <location filename="../app/Main.qml" line="2623"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2593"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2681"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2606"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2521"/>
+        <location filename="../app/Main.qml" line="2685"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2450"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1854"/>
+        <location filename="../app/Main.qml" line="1865"/>
         <source>Write with QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
-        <location filename="../app/Main.qml" line="2477"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Details unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2352"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2435"/>
+        <source>OK</source>
+        <translation type="unfinished">حسنًا</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2396"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2405"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2406"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2408"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2411"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2412"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2414"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2415"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2417"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2418"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2420"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2421"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2424"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2426"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2427"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2429"/>
+        <source>QR code failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2430"/>
+        <source>Could not create the QR code for this item.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2432"/>
+        <source>Setting not saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2433"/>
+        <source>Could not save this setting. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Log upload failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Could not upload the logs. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2627"/>
+        <location filename="../app/Main.qml" line="2641"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2467"/>
+        <location filename="../app/Main.qml" line="2631"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2495"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2659"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2655"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
+        <location filename="../app/Main.qml" line="2662"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2818"/>
+        <location filename="../app/Main.qml" line="2836"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2658"/>
+        <location filename="../app/Main.qml" line="2822"/>
+        <location filename="../app/Main.qml" line="2839"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Card write failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Could not write to this card. Check that it is writable and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="2852"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
-        <source>Error: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Retry</source>
         <translation type="unfinished">إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
-        <translation type="unfinished">إلغاء</translation>
+        <translation type="obsolete">إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3530"/>
+        <location filename="../app/Main.qml" line="3705"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3534"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3712"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3541"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3543"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>
@@ -886,136 +1039,128 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Writing failed</source>
         <translation>فشلت الكتابة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Put a writable card near the reader</source>
         <translation>ضع بطاقة قابلة للكتابة بالقرب من القارئ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="190"/>
+        <location filename="../app/MainLayout.qml" line="191"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="433"/>
-        <location filename="../app/MainLayout.qml" line="435"/>
+        <location filename="../app/MainLayout.qml" line="440"/>
+        <location filename="../app/MainLayout.qml" line="442"/>
         <source>Favorites</source>
         <translation type="unfinished">المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="437"/>
+        <location filename="../app/MainLayout.qml" line="444"/>
         <source>Recently Played</source>
         <translation type="unfinished">تم لعبها مؤخرًا</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="848"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="841"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="867"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="868"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="861"/>
-        <location filename="../app/MainLayout.qml" line="877"/>
-        <location filename="../app/MainLayout.qml" line="1186"/>
+        <location filename="../app/MainLayout.qml" line="320"/>
+        <location filename="../app/MainLayout.qml" line="869"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>OK</source>
         <translation type="unfinished">حسنًا</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875"/>
-        <source>Random game</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <source>No matching games found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Are you sure you want to exit?</source>
         <translation>هل أنت متأكد أنك تريد الخروج؟</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1193"/>
-        <location filename="../app/MainLayout.qml" line="1231"/>
-        <location filename="../app/MainLayout.qml" line="1268"/>
-        <location filename="../app/MainLayout.qml" line="1317"/>
-        <location filename="../app/MainLayout.qml" line="1373"/>
-        <location filename="../app/MainLayout.qml" line="1392"/>
-        <location filename="../app/MainLayout.qml" line="1465"/>
+        <location filename="../app/MainLayout.qml" line="1124"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1251"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1337"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1412"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
         <source>Move</source>
         <translation>تحريك</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1120"/>
-        <location filename="../app/MainLayout.qml" line="1197"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
         <source>Select</source>
         <translation>تحديد</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1124"/>
-        <location filename="../app/MainLayout.qml" line="1138"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1164"/>
+        <location filename="../app/MainLayout.qml" line="1132"/>
+        <location filename="../app/MainLayout.qml" line="1146"/>
+        <location filename="../app/MainLayout.qml" line="1161"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1198"/>
         <source>Close</source>
         <translation>إغلاق</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1131"/>
-        <location filename="../app/MainLayout.qml" line="1171"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1220"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1149"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
         <source>Done</source>
         <translation>تم</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1160"/>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1344"/>
-        <location filename="../app/MainLayout.qml" line="1493"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1364"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
         <source>Retry</source>
         <translation>إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1187"/>
         <source>I understand</source>
         <translation>أفهم</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1208"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1231"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1024,41 +1169,41 @@ Français - Wilfried</source>
         <translation type="vanished">ابدأ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1235"/>
-        <location filename="../app/MainLayout.qml" line="1273"/>
-        <location filename="../app/MainLayout.qml" line="1322"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
-        <location filename="../app/MainLayout.qml" line="1470"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1293"/>
+        <location filename="../app/MainLayout.qml" line="1342"/>
+        <location filename="../app/MainLayout.qml" line="1398"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
         <source>Open</source>
         <translation>فتح</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1265"/>
         <source>Quit</source>
         <translation>إنهاء</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1254"/>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1306"/>
-        <location filename="../app/MainLayout.qml" line="1336"/>
-        <location filename="../app/MainLayout.qml" line="1354"/>
-        <location filename="../app/MainLayout.qml" line="1366"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1416"/>
-        <location filename="../app/MainLayout.qml" line="1437"/>
-        <location filename="../app/MainLayout.qml" line="1446"/>
-        <location filename="../app/MainLayout.qml" line="1486"/>
-        <location filename="../app/MainLayout.qml" line="1505"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1310"/>
+        <location filename="../app/MainLayout.qml" line="1326"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1386"/>
+        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1436"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1506"/>
+        <location filename="../app/MainLayout.qml" line="1525"/>
         <source>Back</source>
         <translation>رجوع</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1332"/>
-        <location filename="../app/MainLayout.qml" line="1350"/>
-        <location filename="../app/MainLayout.qml" line="1482"/>
-        <location filename="../app/MainLayout.qml" line="1501"/>
+        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1370"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1521"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1067,25 +1212,25 @@ Français - Wilfried</source>
         <translation type="vanished">صفحة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1241"/>
-        <location filename="../app/MainLayout.qml" line="1276"/>
-        <location filename="../app/MainLayout.qml" line="1327"/>
-        <location filename="../app/MainLayout.qml" line="1475"/>
+        <location filename="../app/MainLayout.qml" line="1261"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
+        <location filename="../app/MainLayout.qml" line="1495"/>
         <source>Options</source>
         <translation>الخيارات</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1401"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Change</source>
         <translation>تغيير</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1407"/>
+        <location filename="../app/MainLayout.qml" line="1427"/>
         <source>Toggle</source>
         <translation>تبديل</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1433"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Scroll</source>
         <translation>تمرير</translation>
     </message>
@@ -1126,7 +1271,7 @@ Français - Wilfried</source>
         <translation>لا</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="258"/>
+        <location filename="../components/Modal.qml" line="260"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
@@ -1165,17 +1310,22 @@ Français - Wilfried</source>
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="29"/>
         <source>Nothing here</source>
         <translation>لا يوجد شيء هنا</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <source>Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScreenStateOverlay.qml" line="68"/>
         <source>Failed to load</source>
         <translation>فشل التحميل</translation>
     </message>
@@ -1728,24 +1878,24 @@ Français - Wilfried</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="252"/>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="253"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>%1 systems</source>
         <translation>%1 أنظمة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="253"/>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="254"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="399"/>
+        <location filename="../screens/SystemsScreen.qml" line="400"/>
         <source>No systems in this category</source>
         <translation>لا توجد أنظمة في هذه الفئة</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="400"/>
+        <location filename="../screens/SystemsScreen.qml" line="401"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -723,8 +723,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2052"/>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2677"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2679"/>
         <source>Default</source>
         <translation type="unfinished">افتراضي</translation>
     </message>
@@ -734,7 +734,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2579"/>
+        <location filename="../app/Main.qml" line="2581"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -743,53 +743,53 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1807"/>
         <location filename="../app/Main.qml" line="1824"/>
         <location filename="../app/Main.qml" line="1832"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2587"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2589"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Favorites</source>
         <translation type="unfinished">المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2595"/>
-        <location filename="../app/Main.qml" line="2634"/>
-        <location filename="../app/Main.qml" line="2644"/>
+        <location filename="../app/Main.qml" line="2597"/>
+        <location filename="../app/Main.qml" line="2636"/>
+        <location filename="../app/Main.qml" line="2646"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2623"/>
+        <location filename="../app/Main.qml" line="2625"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2595"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2681"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2683"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2608"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2685"/>
+        <location filename="../app/Main.qml" line="2687"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -810,189 +810,189 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2352"/>
-        <location filename="../app/Main.qml" line="2372"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2435"/>
+        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2437"/>
         <source>OK</source>
         <translation type="unfinished">حسنًا</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2398"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2405"/>
+        <location filename="../app/Main.qml" line="2407"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2406"/>
+        <location filename="../app/Main.qml" line="2408"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2408"/>
+        <location filename="../app/Main.qml" line="2410"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2413"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2412"/>
+        <location filename="../app/Main.qml" line="2414"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2414"/>
+        <location filename="../app/Main.qml" line="2416"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2417"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2417"/>
+        <location filename="../app/Main.qml" line="2419"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2418"/>
+        <location filename="../app/Main.qml" line="2420"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2420"/>
+        <location filename="../app/Main.qml" line="2422"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2421"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2424"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2428"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2431"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2430"/>
+        <location filename="../app/Main.qml" line="2432"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2432"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2433"/>
+        <location filename="../app/Main.qml" line="2435"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2627"/>
-        <location filename="../app/Main.qml" line="2641"/>
+        <location filename="../app/Main.qml" line="2629"/>
+        <location filename="../app/Main.qml" line="2643"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2631"/>
+        <location filename="../app/Main.qml" line="2633"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2659"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2661"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2657"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2662"/>
+        <location filename="../app/Main.qml" line="2664"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2818"/>
-        <location filename="../app/Main.qml" line="2836"/>
+        <location filename="../app/Main.qml" line="2820"/>
+        <location filename="../app/Main.qml" line="2838"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2822"/>
-        <location filename="../app/Main.qml" line="2839"/>
+        <location filename="../app/Main.qml" line="2824"/>
+        <location filename="../app/Main.qml" line="2841"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Card write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Could not write to this card. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2423"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2505"/>
-        <location filename="../app/Main.qml" line="2852"/>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="2507"/>
+        <location filename="../app/Main.qml" line="2854"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Retry</source>
         <translation type="unfinished">إعادة المحاولة</translation>
     </message>
@@ -1001,37 +1001,37 @@ Français - Wilfried</source>
         <translation type="obsolete">إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3707"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3709"/>
+        <location filename="../app/Main.qml" line="3711"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3712"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3714"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3716"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3720"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -686,44 +686,44 @@ Français - Wilfried</source>
         <translation>Spiel starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2579"/>
+        <location filename="../app/Main.qml" line="2581"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2595"/>
-        <location filename="../app/Main.qml" line="2634"/>
-        <location filename="../app/Main.qml" line="2644"/>
+        <location filename="../app/Main.qml" line="2597"/>
+        <location filename="../app/Main.qml" line="2636"/>
+        <location filename="../app/Main.qml" line="2646"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2631"/>
+        <location filename="../app/Main.qml" line="2633"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Card write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Could not write to this card. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3712"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3707"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
@@ -753,8 +753,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2052"/>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2677"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2679"/>
         <source>Default</source>
         <translation type="unfinished">Standard</translation>
     </message>
@@ -768,40 +768,40 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1807"/>
         <location filename="../app/Main.qml" line="1824"/>
         <location filename="../app/Main.qml" line="1832"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2587"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2589"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2623"/>
+        <location filename="../app/Main.qml" line="2625"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2595"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2681"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2683"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2608"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2685"/>
+        <location filename="../app/Main.qml" line="2687"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -822,180 +822,180 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2352"/>
-        <location filename="../app/Main.qml" line="2372"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2435"/>
+        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2437"/>
         <source>OK</source>
         <translation type="unfinished">In Ordnung</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2398"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2405"/>
+        <location filename="../app/Main.qml" line="2407"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2406"/>
+        <location filename="../app/Main.qml" line="2408"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2408"/>
+        <location filename="../app/Main.qml" line="2410"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2413"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2412"/>
+        <location filename="../app/Main.qml" line="2414"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2414"/>
+        <location filename="../app/Main.qml" line="2416"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2417"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2417"/>
+        <location filename="../app/Main.qml" line="2419"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2418"/>
+        <location filename="../app/Main.qml" line="2420"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2420"/>
+        <location filename="../app/Main.qml" line="2422"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2421"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2424"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2428"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2431"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2430"/>
+        <location filename="../app/Main.qml" line="2432"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2432"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2433"/>
+        <location filename="../app/Main.qml" line="2435"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoriten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2627"/>
-        <location filename="../app/Main.qml" line="2641"/>
+        <location filename="../app/Main.qml" line="2629"/>
+        <location filename="../app/Main.qml" line="2643"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2659"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2661"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2657"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2662"/>
+        <location filename="../app/Main.qml" line="2664"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2818"/>
-        <location filename="../app/Main.qml" line="2836"/>
+        <location filename="../app/Main.qml" line="2820"/>
+        <location filename="../app/Main.qml" line="2838"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2822"/>
-        <location filename="../app/Main.qml" line="2839"/>
+        <location filename="../app/Main.qml" line="2824"/>
+        <location filename="../app/Main.qml" line="2841"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2423"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2505"/>
-        <location filename="../app/Main.qml" line="2852"/>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="2507"/>
+        <location filename="../app/Main.qml" line="2854"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Retry</source>
         <translation type="unfinished">Wiederholen</translation>
     </message>
@@ -1004,22 +1004,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3709"/>
+        <location filename="../app/Main.qml" line="3711"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3714"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3716"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3720"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -478,6 +478,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/GameInfoModal.qml" line="120"/>
+        <source>Could not load details. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/GameInfoModal.qml" line="169"/>
         <source>Loading image…</source>
         <translation type="unfinished"></translation>
@@ -546,27 +551,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="202"/>
+        <location filename="../screens/HubScreen.qml" line="203"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="209"/>
+        <location filename="../screens/HubScreen.qml" line="210"/>
         <source>Favorites</source>
         <translation>Favoriten</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="215"/>
+        <location filename="../screens/HubScreen.qml" line="216"/>
         <source>Recently Played</source>
         <translation>Zuletzt gespielt</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="222"/>
+        <location filename="../screens/HubScreen.qml" line="223"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="229"/>
+        <location filename="../screens/HubScreen.qml" line="230"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,7 +580,7 @@ Français - Wilfried</source>
         <translation type="vanished">Einstellungen</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="816"/>
+        <location filename="../screens/HubScreen.qml" line="821"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Keine Systeme verfügbar. Bitte Mediendatenbank unter Einstellungen aktualisieren.</translation>
     </message>
@@ -620,13 +625,16 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="197"/>
-        <source>Upload failed: %1</source>
-        <translation>Upload fehlgeschlagen: %1</translation>
+        <source>Upload failed. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197"/>
+        <source>Upload failed: %1</source>
+        <translation type="vanished">Upload fehlgeschlagen: %1</translation>
+    </message>
+    <message>
         <source>Upload failed.</source>
-        <translation>Upload fehlgeschlagen.</translation>
+        <translation type="vanished">Upload fehlgeschlagen.</translation>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="227"/>
@@ -642,28 +650,28 @@ Français - Wilfried</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1746"/>
+        <location filename="../app/Main.qml" line="1757"/>
         <source>Launch core</source>
         <translation>Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1760"/>
-        <location filename="../app/Main.qml" line="2045"/>
+        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="2056"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Remove from favorites</source>
         <translation>Aus Favoriten entfernen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Add to favorites</source>
         <translation>Zu Favoriten hinzufügen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1850"/>
+        <location filename="../app/Main.qml" line="1861"/>
         <source>Write to NFC token</source>
         <translation>Auf NFC-Token schreiben</translation>
     </message>
@@ -672,201 +680,346 @@ Français - Wilfried</source>
         <translation type="vanished">QR-Code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1829"/>
-        <location filename="../app/Main.qml" line="1864"/>
+        <location filename="../app/Main.qml" line="1840"/>
+        <location filename="../app/Main.qml" line="1875"/>
         <source>Launch game</source>
         <translation>Spiel starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2579"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2431"/>
-        <location filename="../app/Main.qml" line="2470"/>
-        <location filename="../app/Main.qml" line="2480"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2634"/>
+        <location filename="../app/Main.qml" line="2644"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2467"/>
+        <location filename="../app/Main.qml" line="2631"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3530"/>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Card write failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Could not write to this card. Check that it is writable and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3705"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3712"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1767"/>
-        <location filename="../app/Main.qml" line="1801"/>
+        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="1812"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediendatenbank aktualisieren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1770"/>
-        <location filename="../app/Main.qml" line="1804"/>
+        <location filename="../app/Main.qml" line="1781"/>
+        <location filename="../app/Main.qml" line="1815"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadaten abrufen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2052"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2677"/>
         <source>Default</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
+        <location filename="../app/Main.qml" line="2052"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1755"/>
-        <location filename="../app/Main.qml" line="1796"/>
-        <location filename="../app/Main.qml" line="1813"/>
-        <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="1766"/>
+        <location filename="../app/Main.qml" line="1807"/>
+        <location filename="../app/Main.qml" line="1824"/>
+        <location filename="../app/Main.qml" line="1832"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2587"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
+        <location filename="../app/Main.qml" line="2623"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2593"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2681"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2606"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2521"/>
+        <location filename="../app/Main.qml" line="2685"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2450"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1854"/>
+        <location filename="../app/Main.qml" line="1865"/>
         <source>Write with QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Details unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2352"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2435"/>
+        <source>OK</source>
+        <translation type="unfinished">In Ordnung</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2396"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2405"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2406"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2408"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2411"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2412"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2414"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2415"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2417"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2418"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2420"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2421"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2424"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2426"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2427"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2446"/>
+        <source>QR code failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2430"/>
+        <source>Could not create the QR code for this item.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2432"/>
+        <source>Setting not saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2433"/>
+        <source>Could not save this setting. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Log upload failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Could not upload the logs. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoriten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
-        <location filename="../app/Main.qml" line="2477"/>
+        <location filename="../app/Main.qml" line="2627"/>
+        <location filename="../app/Main.qml" line="2641"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2495"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2659"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2655"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
+        <location filename="../app/Main.qml" line="2662"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2818"/>
+        <location filename="../app/Main.qml" line="2836"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2658"/>
+        <location filename="../app/Main.qml" line="2822"/>
+        <location filename="../app/Main.qml" line="2839"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="2852"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
-        <source>Error: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Retry</source>
         <translation type="unfinished">Wiederholen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
-        <translation type="unfinished">Abbrechen</translation>
+        <translation type="obsolete">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3534"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3541"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3543"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>
@@ -874,85 +1027,76 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Writing failed</source>
         <translation>Schreiben fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Put a writable card near the reader</source>
         <translation>Beschreibbare Karte an den Leser halten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="867"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="868"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="861"/>
-        <location filename="../app/MainLayout.qml" line="877"/>
-        <location filename="../app/MainLayout.qml" line="1186"/>
+        <location filename="../app/MainLayout.qml" line="320"/>
+        <location filename="../app/MainLayout.qml" line="869"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>OK</source>
         <translation type="unfinished">In Ordnung</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875"/>
-        <source>Random game</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <source>No matching games found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Are you sure you want to exit?</source>
         <translation>Wirklich beenden?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1120"/>
-        <location filename="../app/MainLayout.qml" line="1197"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
         <source>Select</source>
         <translation>Auswählen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1124"/>
-        <location filename="../app/MainLayout.qml" line="1138"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1164"/>
+        <location filename="../app/MainLayout.qml" line="1132"/>
+        <location filename="../app/MainLayout.qml" line="1146"/>
+        <location filename="../app/MainLayout.qml" line="1161"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1198"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1131"/>
-        <location filename="../app/MainLayout.qml" line="1171"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1220"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1149"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
         <source>Done</source>
         <translation>Fertig</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1187"/>
         <source>I understand</source>
         <translation>Ich verstehe</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1208"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1231"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -961,89 +1105,89 @@ Français - Wilfried</source>
         <translation type="vanished">Starten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1433"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Scroll</source>
         <translation>Scrollen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1332"/>
-        <location filename="../app/MainLayout.qml" line="1350"/>
-        <location filename="../app/MainLayout.qml" line="1482"/>
-        <location filename="../app/MainLayout.qml" line="1501"/>
+        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1370"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1521"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1193"/>
-        <location filename="../app/MainLayout.qml" line="1231"/>
-        <location filename="../app/MainLayout.qml" line="1268"/>
-        <location filename="../app/MainLayout.qml" line="1317"/>
-        <location filename="../app/MainLayout.qml" line="1373"/>
-        <location filename="../app/MainLayout.qml" line="1392"/>
-        <location filename="../app/MainLayout.qml" line="1465"/>
+        <location filename="../app/MainLayout.qml" line="1124"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1251"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1337"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1412"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="190"/>
+        <location filename="../app/MainLayout.qml" line="191"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="433"/>
-        <location filename="../app/MainLayout.qml" line="435"/>
+        <location filename="../app/MainLayout.qml" line="440"/>
+        <location filename="../app/MainLayout.qml" line="442"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoriten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="437"/>
+        <location filename="../app/MainLayout.qml" line="444"/>
         <source>Recently Played</source>
         <translation type="unfinished">Zuletzt gespielt</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="848"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="841"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1235"/>
-        <location filename="../app/MainLayout.qml" line="1273"/>
-        <location filename="../app/MainLayout.qml" line="1322"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
-        <location filename="../app/MainLayout.qml" line="1470"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1293"/>
+        <location filename="../app/MainLayout.qml" line="1342"/>
+        <location filename="../app/MainLayout.qml" line="1398"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1265"/>
         <source>Quit</source>
         <translation>Beenden</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1254"/>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1306"/>
-        <location filename="../app/MainLayout.qml" line="1336"/>
-        <location filename="../app/MainLayout.qml" line="1354"/>
-        <location filename="../app/MainLayout.qml" line="1366"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1416"/>
-        <location filename="../app/MainLayout.qml" line="1437"/>
-        <location filename="../app/MainLayout.qml" line="1446"/>
-        <location filename="../app/MainLayout.qml" line="1486"/>
-        <location filename="../app/MainLayout.qml" line="1505"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1310"/>
+        <location filename="../app/MainLayout.qml" line="1326"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1386"/>
+        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1436"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1506"/>
+        <location filename="../app/MainLayout.qml" line="1525"/>
         <source>Back</source>
         <translation>Zurück</translation>
     </message>
@@ -1052,28 +1196,29 @@ Français - Wilfried</source>
         <translation type="vanished">Seite</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1241"/>
-        <location filename="../app/MainLayout.qml" line="1276"/>
-        <location filename="../app/MainLayout.qml" line="1327"/>
-        <location filename="../app/MainLayout.qml" line="1475"/>
+        <location filename="../app/MainLayout.qml" line="1261"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
+        <location filename="../app/MainLayout.qml" line="1495"/>
         <source>Options</source>
         <translation>Optionen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1160"/>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1344"/>
-        <location filename="../app/MainLayout.qml" line="1493"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1364"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
         <source>Retry</source>
         <translation>Wiederholen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1401"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Change</source>
         <translation>Ändern</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1407"/>
+        <location filename="../app/MainLayout.qml" line="1427"/>
         <source>Toggle</source>
         <translation>Umschalten</translation>
     </message>
@@ -1114,7 +1259,7 @@ Français - Wilfried</source>
         <translation>Nein</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="258"/>
+        <location filename="../components/Modal.qml" line="260"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
@@ -1153,17 +1298,22 @@ Français - Wilfried</source>
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="29"/>
         <source>Nothing here</source>
         <translation>Nichts hier</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <source>Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScreenStateOverlay.qml" line="68"/>
         <source>Failed to load</source>
         <translation>Laden fehlgeschlagen</translation>
     </message>
@@ -1716,24 +1866,24 @@ Français - Wilfried</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="252"/>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="253"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>%1 systems</source>
         <translation>%1 Systeme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="253"/>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="254"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="399"/>
+        <location filename="../screens/SystemsScreen.qml" line="400"/>
         <source>No systems in this category</source>
         <translation>Keine Systeme in dieser Kategorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="400"/>
+        <location filename="../screens/SystemsScreen.qml" line="401"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -686,44 +686,44 @@ Français - Wilfried</source>
         <translation>Εκκίνηση παιχνιδιού</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2579"/>
+        <location filename="../app/Main.qml" line="2581"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2595"/>
-        <location filename="../app/Main.qml" line="2634"/>
-        <location filename="../app/Main.qml" line="2644"/>
+        <location filename="../app/Main.qml" line="2597"/>
+        <location filename="../app/Main.qml" line="2636"/>
+        <location filename="../app/Main.qml" line="2646"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2631"/>
+        <location filename="../app/Main.qml" line="2633"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Card write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Could not write to this card. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3712"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3707"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
@@ -753,8 +753,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2052"/>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2677"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2679"/>
         <source>Default</source>
         <translation type="unfinished">Προεπιλογή</translation>
     </message>
@@ -768,40 +768,40 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1807"/>
         <location filename="../app/Main.qml" line="1824"/>
         <location filename="../app/Main.qml" line="1832"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2587"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2589"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2623"/>
+        <location filename="../app/Main.qml" line="2625"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2595"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2681"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2683"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2608"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2685"/>
+        <location filename="../app/Main.qml" line="2687"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -822,180 +822,180 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2352"/>
-        <location filename="../app/Main.qml" line="2372"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2435"/>
+        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2437"/>
         <source>OK</source>
         <translation type="unfinished">Εντάξει</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2398"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2405"/>
+        <location filename="../app/Main.qml" line="2407"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2406"/>
+        <location filename="../app/Main.qml" line="2408"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2408"/>
+        <location filename="../app/Main.qml" line="2410"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2413"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2412"/>
+        <location filename="../app/Main.qml" line="2414"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2414"/>
+        <location filename="../app/Main.qml" line="2416"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2417"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2417"/>
+        <location filename="../app/Main.qml" line="2419"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2418"/>
+        <location filename="../app/Main.qml" line="2420"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2420"/>
+        <location filename="../app/Main.qml" line="2422"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2421"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2424"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2428"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2431"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2430"/>
+        <location filename="../app/Main.qml" line="2432"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2432"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2433"/>
+        <location filename="../app/Main.qml" line="2435"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Favorites</source>
         <translation type="unfinished">Αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2627"/>
-        <location filename="../app/Main.qml" line="2641"/>
+        <location filename="../app/Main.qml" line="2629"/>
+        <location filename="../app/Main.qml" line="2643"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2659"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2661"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2657"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2662"/>
+        <location filename="../app/Main.qml" line="2664"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2818"/>
-        <location filename="../app/Main.qml" line="2836"/>
+        <location filename="../app/Main.qml" line="2820"/>
+        <location filename="../app/Main.qml" line="2838"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2822"/>
-        <location filename="../app/Main.qml" line="2839"/>
+        <location filename="../app/Main.qml" line="2824"/>
+        <location filename="../app/Main.qml" line="2841"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2423"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2505"/>
-        <location filename="../app/Main.qml" line="2852"/>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="2507"/>
+        <location filename="../app/Main.qml" line="2854"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Retry</source>
         <translation type="unfinished">Επανάληψη</translation>
     </message>
@@ -1004,22 +1004,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3709"/>
+        <location filename="../app/Main.qml" line="3711"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3714"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3716"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3720"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -478,6 +478,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/GameInfoModal.qml" line="120"/>
+        <source>Could not load details. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/GameInfoModal.qml" line="169"/>
         <source>Loading image…</source>
         <translation type="unfinished"></translation>
@@ -546,27 +551,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="202"/>
+        <location filename="../screens/HubScreen.qml" line="203"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="209"/>
+        <location filename="../screens/HubScreen.qml" line="210"/>
         <source>Favorites</source>
         <translation>Αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="215"/>
+        <location filename="../screens/HubScreen.qml" line="216"/>
         <source>Recently Played</source>
         <translation>Πρόσφατα Παιγμένα</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="222"/>
+        <location filename="../screens/HubScreen.qml" line="223"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="229"/>
+        <location filename="../screens/HubScreen.qml" line="230"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,7 +580,7 @@ Français - Wilfried</source>
         <translation type="vanished">Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="816"/>
+        <location filename="../screens/HubScreen.qml" line="821"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Δεν υπάρχουν διαθέσιμα συστήματα. Εκτελέστε Ενημέρωση βάσης δεδομένων από τις Ρυθμίσεις.</translation>
     </message>
@@ -620,13 +625,16 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="197"/>
-        <source>Upload failed: %1</source>
-        <translation>Αποτυχία αποστολής: %1</translation>
+        <source>Upload failed. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197"/>
+        <source>Upload failed: %1</source>
+        <translation type="vanished">Αποτυχία αποστολής: %1</translation>
+    </message>
+    <message>
         <source>Upload failed.</source>
-        <translation>Αποτυχία αποστολής.</translation>
+        <translation type="vanished">Αποτυχία αποστολής.</translation>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="227"/>
@@ -642,28 +650,28 @@ Français - Wilfried</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1746"/>
+        <location filename="../app/Main.qml" line="1757"/>
         <source>Launch core</source>
         <translation>Εκκίνηση Core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1760"/>
-        <location filename="../app/Main.qml" line="2045"/>
+        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="2056"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Remove from favorites</source>
         <translation>Αφαίρεση από αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Add to favorites</source>
         <translation>Προσθήκη στα αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1850"/>
+        <location filename="../app/Main.qml" line="1861"/>
         <source>Write to NFC token</source>
         <translation>Εγγραφή σε NFC token</translation>
     </message>
@@ -672,201 +680,346 @@ Français - Wilfried</source>
         <translation type="vanished">Κωδικός QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1829"/>
-        <location filename="../app/Main.qml" line="1864"/>
+        <location filename="../app/Main.qml" line="1840"/>
+        <location filename="../app/Main.qml" line="1875"/>
         <source>Launch game</source>
         <translation>Εκκίνηση παιχνιδιού</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2579"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2431"/>
-        <location filename="../app/Main.qml" line="2470"/>
-        <location filename="../app/Main.qml" line="2480"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2634"/>
+        <location filename="../app/Main.qml" line="2644"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2467"/>
+        <location filename="../app/Main.qml" line="2631"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3530"/>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Card write failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Could not write to this card. Check that it is writable and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3705"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3712"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1767"/>
-        <location filename="../app/Main.qml" line="1801"/>
+        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="1812"/>
         <source>Update media database</source>
         <translation type="unfinished">Ενημέρωση βάσης δεδομένων</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1770"/>
-        <location filename="../app/Main.qml" line="1804"/>
+        <location filename="../app/Main.qml" line="1781"/>
+        <location filename="../app/Main.qml" line="1815"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Ανάκτηση μεταδεδομένων</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2052"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2677"/>
         <source>Default</source>
         <translation type="unfinished">Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
+        <location filename="../app/Main.qml" line="2052"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1755"/>
-        <location filename="../app/Main.qml" line="1796"/>
-        <location filename="../app/Main.qml" line="1813"/>
-        <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="1766"/>
+        <location filename="../app/Main.qml" line="1807"/>
+        <location filename="../app/Main.qml" line="1824"/>
+        <location filename="../app/Main.qml" line="1832"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2587"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
+        <location filename="../app/Main.qml" line="2623"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2593"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2681"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2606"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2521"/>
+        <location filename="../app/Main.qml" line="2685"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2450"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1854"/>
+        <location filename="../app/Main.qml" line="1865"/>
         <source>Write with QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Details unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2352"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2435"/>
+        <source>OK</source>
+        <translation type="unfinished">Εντάξει</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2396"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2405"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2406"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2408"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2411"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2412"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2414"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2415"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2417"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2418"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2420"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2421"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2424"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2426"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2427"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2446"/>
+        <source>QR code failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2430"/>
+        <source>Could not create the QR code for this item.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2432"/>
+        <source>Setting not saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2433"/>
+        <source>Could not save this setting. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Log upload failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Could not upload the logs. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Favorites</source>
         <translation type="unfinished">Αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
-        <location filename="../app/Main.qml" line="2477"/>
+        <location filename="../app/Main.qml" line="2627"/>
+        <location filename="../app/Main.qml" line="2641"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2495"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2659"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2655"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
+        <location filename="../app/Main.qml" line="2662"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2818"/>
+        <location filename="../app/Main.qml" line="2836"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2658"/>
+        <location filename="../app/Main.qml" line="2822"/>
+        <location filename="../app/Main.qml" line="2839"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="2852"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
-        <source>Error: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Retry</source>
         <translation type="unfinished">Επανάληψη</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
-        <translation type="unfinished">Ακύρωση</translation>
+        <translation type="obsolete">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3534"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3541"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3543"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>
@@ -874,85 +1027,76 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Writing failed</source>
         <translation>Αποτυχία εγγραφής</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Put a writable card near the reader</source>
         <translation>Τοποθετήστε μια εγγράψιμη κάρτα κοντά στον αναγνώστη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="867"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="868"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="861"/>
-        <location filename="../app/MainLayout.qml" line="877"/>
-        <location filename="../app/MainLayout.qml" line="1186"/>
+        <location filename="../app/MainLayout.qml" line="320"/>
+        <location filename="../app/MainLayout.qml" line="869"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>OK</source>
         <translation type="unfinished">Εντάξει</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875"/>
-        <source>Random game</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <source>No matching games found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Are you sure you want to exit?</source>
         <translation>Είστε σίγουροι ότι θέλετε να βγείτε;</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1120"/>
-        <location filename="../app/MainLayout.qml" line="1197"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
         <source>Select</source>
         <translation>Επιλογή</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1124"/>
-        <location filename="../app/MainLayout.qml" line="1138"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1164"/>
+        <location filename="../app/MainLayout.qml" line="1132"/>
+        <location filename="../app/MainLayout.qml" line="1146"/>
+        <location filename="../app/MainLayout.qml" line="1161"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1198"/>
         <source>Close</source>
         <translation>Κλείσιμο</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1131"/>
-        <location filename="../app/MainLayout.qml" line="1171"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1220"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1149"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
         <source>Done</source>
         <translation>Ολοκληρώθηκε</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1187"/>
         <source>I understand</source>
         <translation>Κατανοώ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1208"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1231"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -961,89 +1105,89 @@ Français - Wilfried</source>
         <translation type="vanished">Έναρξη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1433"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Scroll</source>
         <translation>Κύλιση</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1332"/>
-        <location filename="../app/MainLayout.qml" line="1350"/>
-        <location filename="../app/MainLayout.qml" line="1482"/>
-        <location filename="../app/MainLayout.qml" line="1501"/>
+        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1370"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1521"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1193"/>
-        <location filename="../app/MainLayout.qml" line="1231"/>
-        <location filename="../app/MainLayout.qml" line="1268"/>
-        <location filename="../app/MainLayout.qml" line="1317"/>
-        <location filename="../app/MainLayout.qml" line="1373"/>
-        <location filename="../app/MainLayout.qml" line="1392"/>
-        <location filename="../app/MainLayout.qml" line="1465"/>
+        <location filename="../app/MainLayout.qml" line="1124"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1251"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1337"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1412"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
         <source>Move</source>
         <translation>Μετακίνηση</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="190"/>
+        <location filename="../app/MainLayout.qml" line="191"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="433"/>
-        <location filename="../app/MainLayout.qml" line="435"/>
+        <location filename="../app/MainLayout.qml" line="440"/>
+        <location filename="../app/MainLayout.qml" line="442"/>
         <source>Favorites</source>
         <translation type="unfinished">Αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="437"/>
+        <location filename="../app/MainLayout.qml" line="444"/>
         <source>Recently Played</source>
         <translation type="unfinished">Πρόσφατα Παιγμένα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="848"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="841"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1235"/>
-        <location filename="../app/MainLayout.qml" line="1273"/>
-        <location filename="../app/MainLayout.qml" line="1322"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
-        <location filename="../app/MainLayout.qml" line="1470"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1293"/>
+        <location filename="../app/MainLayout.qml" line="1342"/>
+        <location filename="../app/MainLayout.qml" line="1398"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
         <source>Open</source>
         <translation>Άνοιγμα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1265"/>
         <source>Quit</source>
         <translation>Έξοδος</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1254"/>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1306"/>
-        <location filename="../app/MainLayout.qml" line="1336"/>
-        <location filename="../app/MainLayout.qml" line="1354"/>
-        <location filename="../app/MainLayout.qml" line="1366"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1416"/>
-        <location filename="../app/MainLayout.qml" line="1437"/>
-        <location filename="../app/MainLayout.qml" line="1446"/>
-        <location filename="../app/MainLayout.qml" line="1486"/>
-        <location filename="../app/MainLayout.qml" line="1505"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1310"/>
+        <location filename="../app/MainLayout.qml" line="1326"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1386"/>
+        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1436"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1506"/>
+        <location filename="../app/MainLayout.qml" line="1525"/>
         <source>Back</source>
         <translation>Πίσω</translation>
     </message>
@@ -1052,28 +1196,29 @@ Français - Wilfried</source>
         <translation type="vanished">Σελίδα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1241"/>
-        <location filename="../app/MainLayout.qml" line="1276"/>
-        <location filename="../app/MainLayout.qml" line="1327"/>
-        <location filename="../app/MainLayout.qml" line="1475"/>
+        <location filename="../app/MainLayout.qml" line="1261"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
+        <location filename="../app/MainLayout.qml" line="1495"/>
         <source>Options</source>
         <translation>Επιλογές</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1160"/>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1344"/>
-        <location filename="../app/MainLayout.qml" line="1493"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1364"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
         <source>Retry</source>
         <translation>Επανάληψη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1401"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Change</source>
         <translation>Αλλαγή</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1407"/>
+        <location filename="../app/MainLayout.qml" line="1427"/>
         <source>Toggle</source>
         <translation>Εναλλαγή</translation>
     </message>
@@ -1114,7 +1259,7 @@ Français - Wilfried</source>
         <translation>Όχι</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="258"/>
+        <location filename="../components/Modal.qml" line="260"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
@@ -1153,17 +1298,22 @@ Français - Wilfried</source>
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="29"/>
         <source>Nothing here</source>
         <translation>Τίποτα εδώ</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <source>Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScreenStateOverlay.qml" line="68"/>
         <source>Failed to load</source>
         <translation>Αποτυχία φόρτωσης</translation>
     </message>
@@ -1716,24 +1866,24 @@ Français - Wilfried</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="252"/>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="253"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>%1 systems</source>
         <translation>%1 συστήματα</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="253"/>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="254"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="399"/>
+        <location filename="../screens/SystemsScreen.qml" line="400"/>
         <source>No systems in this category</source>
         <translation>Δεν υπάρχουν συστήματα σε αυτή την κατηγορία</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="400"/>
+        <location filename="../screens/SystemsScreen.qml" line="401"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -426,6 +426,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/GameInfoModal.qml" line="120"/>
+        <source>Could not load details. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/GameInfoModal.qml" line="169"/>
         <source>Loading image…</source>
         <translation type="unfinished"></translation>
@@ -502,27 +507,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="202"/>
+        <location filename="../screens/HubScreen.qml" line="203"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="209"/>
+        <location filename="../screens/HubScreen.qml" line="210"/>
         <source>Favorites</source>
         <translation>Favorites</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="215"/>
+        <location filename="../screens/HubScreen.qml" line="216"/>
         <source>Recently Played</source>
         <translation>Recently Played</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="222"/>
+        <location filename="../screens/HubScreen.qml" line="223"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="229"/>
+        <location filename="../screens/HubScreen.qml" line="230"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -531,7 +536,7 @@ Français - Wilfried</source>
         <translation type="vanished">Settings</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="816"/>
+        <location filename="../screens/HubScreen.qml" line="821"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -576,12 +581,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="197"/>
-        <source>Upload failed: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/LogUploadModal.qml" line="197"/>
-        <source>Upload failed.</source>
+        <source>Upload failed. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -598,227 +598,372 @@ Français - Wilfried</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1746"/>
+        <location filename="../app/Main.qml" line="1757"/>
         <source>Launch core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1760"/>
-        <location filename="../app/Main.qml" line="2045"/>
+        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="2056"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Add to favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1850"/>
+        <location filename="../app/Main.qml" line="1861"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Write to NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1829"/>
-        <location filename="../app/Main.qml" line="1864"/>
+        <location filename="../app/Main.qml" line="1840"/>
+        <location filename="../app/Main.qml" line="1875"/>
         <source>Launch game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2579"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2431"/>
-        <location filename="../app/Main.qml" line="2470"/>
-        <location filename="../app/Main.qml" line="2480"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2634"/>
+        <location filename="../app/Main.qml" line="2644"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2467"/>
+        <location filename="../app/Main.qml" line="2631"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3530"/>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Card write failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Could not write to this card. Check that it is writable and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3705"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3712"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1767"/>
-        <location filename="../app/Main.qml" line="1801"/>
+        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="1812"/>
         <source>Update media database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1770"/>
-        <location filename="../app/Main.qml" line="1804"/>
+        <location filename="../app/Main.qml" line="1781"/>
+        <location filename="../app/Main.qml" line="1815"/>
         <source>Scrape metadata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2052"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2677"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
+        <location filename="../app/Main.qml" line="2052"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1755"/>
-        <location filename="../app/Main.qml" line="1796"/>
-        <location filename="../app/Main.qml" line="1813"/>
-        <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="1766"/>
+        <location filename="../app/Main.qml" line="1807"/>
+        <location filename="../app/Main.qml" line="1824"/>
+        <location filename="../app/Main.qml" line="1832"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2587"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
+        <location filename="../app/Main.qml" line="2623"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2593"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2681"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2606"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2521"/>
+        <location filename="../app/Main.qml" line="2685"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2450"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1854"/>
+        <location filename="../app/Main.qml" line="1865"/>
         <source>Write with QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Details unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2352"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2435"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2396"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2405"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2406"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2408"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2411"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2412"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2414"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2415"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2417"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2418"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2420"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2421"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2424"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2426"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2427"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2446"/>
+        <source>QR code failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2430"/>
+        <source>Could not create the QR code for this item.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2432"/>
+        <source>Setting not saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2433"/>
+        <source>Could not save this setting. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Log upload failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Could not upload the logs. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorites</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
-        <location filename="../app/Main.qml" line="2477"/>
+        <location filename="../app/Main.qml" line="2627"/>
+        <location filename="../app/Main.qml" line="2641"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2495"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2659"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2655"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
+        <location filename="../app/Main.qml" line="2662"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2818"/>
+        <location filename="../app/Main.qml" line="2836"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2658"/>
+        <location filename="../app/Main.qml" line="2822"/>
+        <location filename="../app/Main.qml" line="2839"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="2852"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
-        <source>Error: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Retry</source>
         <translation type="unfinished">Retry</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
-        <translation type="unfinished">Cancel</translation>
+        <translation type="obsolete">Cancel</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3534"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3541"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3543"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>
@@ -826,198 +971,190 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Writing failed</source>
         <translation>Writing failed</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Put a writable card near the reader</source>
         <translation>Put a writable card near the reader</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="867"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="868"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="861"/>
-        <location filename="../app/MainLayout.qml" line="877"/>
-        <location filename="../app/MainLayout.qml" line="1186"/>
+        <location filename="../app/MainLayout.qml" line="320"/>
+        <location filename="../app/MainLayout.qml" line="869"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875"/>
-        <source>Random game</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <source>No matching games found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Are you sure you want to exit?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1120"/>
-        <location filename="../app/MainLayout.qml" line="1197"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
         <source>Select</source>
         <translation>Select</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1124"/>
-        <location filename="../app/MainLayout.qml" line="1138"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1164"/>
+        <location filename="../app/MainLayout.qml" line="1132"/>
+        <location filename="../app/MainLayout.qml" line="1146"/>
+        <location filename="../app/MainLayout.qml" line="1161"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1198"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1131"/>
-        <location filename="../app/MainLayout.qml" line="1171"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1220"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1149"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
         <source>Done</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1187"/>
         <source>I understand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1208"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1231"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1433"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Scroll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1332"/>
-        <location filename="../app/MainLayout.qml" line="1350"/>
-        <location filename="../app/MainLayout.qml" line="1482"/>
-        <location filename="../app/MainLayout.qml" line="1501"/>
+        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1370"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1521"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1193"/>
-        <location filename="../app/MainLayout.qml" line="1231"/>
-        <location filename="../app/MainLayout.qml" line="1268"/>
-        <location filename="../app/MainLayout.qml" line="1317"/>
-        <location filename="../app/MainLayout.qml" line="1373"/>
-        <location filename="../app/MainLayout.qml" line="1392"/>
-        <location filename="../app/MainLayout.qml" line="1465"/>
+        <location filename="../app/MainLayout.qml" line="1124"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1251"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1337"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1412"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
         <source>Move</source>
         <translation>Move</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="190"/>
+        <location filename="../app/MainLayout.qml" line="191"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="433"/>
-        <location filename="../app/MainLayout.qml" line="435"/>
+        <location filename="../app/MainLayout.qml" line="440"/>
+        <location filename="../app/MainLayout.qml" line="442"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorites</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="437"/>
+        <location filename="../app/MainLayout.qml" line="444"/>
         <source>Recently Played</source>
         <translation type="unfinished">Recently Played</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="848"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="841"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1235"/>
-        <location filename="../app/MainLayout.qml" line="1273"/>
-        <location filename="../app/MainLayout.qml" line="1322"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
-        <location filename="../app/MainLayout.qml" line="1470"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1293"/>
+        <location filename="../app/MainLayout.qml" line="1342"/>
+        <location filename="../app/MainLayout.qml" line="1398"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
         <source>Open</source>
         <translation>Open</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1265"/>
         <source>Quit</source>
         <translation>Quit</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1254"/>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1306"/>
-        <location filename="../app/MainLayout.qml" line="1336"/>
-        <location filename="../app/MainLayout.qml" line="1354"/>
-        <location filename="../app/MainLayout.qml" line="1366"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1416"/>
-        <location filename="../app/MainLayout.qml" line="1437"/>
-        <location filename="../app/MainLayout.qml" line="1446"/>
-        <location filename="../app/MainLayout.qml" line="1486"/>
-        <location filename="../app/MainLayout.qml" line="1505"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1310"/>
+        <location filename="../app/MainLayout.qml" line="1326"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1386"/>
+        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1436"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1506"/>
+        <location filename="../app/MainLayout.qml" line="1525"/>
         <source>Back</source>
         <translation>Back</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1241"/>
-        <location filename="../app/MainLayout.qml" line="1276"/>
-        <location filename="../app/MainLayout.qml" line="1327"/>
-        <location filename="../app/MainLayout.qml" line="1475"/>
+        <location filename="../app/MainLayout.qml" line="1261"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
+        <location filename="../app/MainLayout.qml" line="1495"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1160"/>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1344"/>
-        <location filename="../app/MainLayout.qml" line="1493"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1364"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
         <source>Retry</source>
         <translation>Retry</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1401"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Change</source>
         <translation>Change</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1407"/>
+        <location filename="../app/MainLayout.qml" line="1427"/>
         <source>Toggle</source>
         <translation>Toggle</translation>
     </message>
@@ -1058,7 +1195,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="258"/>
+        <location filename="../components/Modal.qml" line="260"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
@@ -1097,17 +1234,22 @@ Français - Wilfried</source>
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="29"/>
         <source>Nothing here</source>
         <translation>Nothing here</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <source>Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScreenStateOverlay.qml" line="68"/>
         <source>Failed to load</source>
         <translation>Failed to load</translation>
     </message>
@@ -1648,24 +1790,24 @@ Français - Wilfried</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="252"/>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="253"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>%1 systems</source>
         <translation>%1 systems</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="253"/>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="254"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="399"/>
+        <location filename="../screens/SystemsScreen.qml" line="400"/>
         <source>No systems in this category</source>
         <translation>No systems in this category</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="400"/>
+        <location filename="../screens/SystemsScreen.qml" line="401"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -630,44 +630,44 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2579"/>
+        <location filename="../app/Main.qml" line="2581"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2595"/>
-        <location filename="../app/Main.qml" line="2634"/>
-        <location filename="../app/Main.qml" line="2644"/>
+        <location filename="../app/Main.qml" line="2597"/>
+        <location filename="../app/Main.qml" line="2636"/>
+        <location filename="../app/Main.qml" line="2646"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2631"/>
+        <location filename="../app/Main.qml" line="2633"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Card write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Could not write to this card. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3712"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3707"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -697,8 +697,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2052"/>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2677"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2679"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
@@ -712,40 +712,40 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1807"/>
         <location filename="../app/Main.qml" line="1824"/>
         <location filename="../app/Main.qml" line="1832"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2587"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2589"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2623"/>
+        <location filename="../app/Main.qml" line="2625"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2595"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2681"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2683"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2608"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2685"/>
+        <location filename="../app/Main.qml" line="2687"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -766,180 +766,180 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2352"/>
-        <location filename="../app/Main.qml" line="2372"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2435"/>
+        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2437"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2398"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2405"/>
+        <location filename="../app/Main.qml" line="2407"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2406"/>
+        <location filename="../app/Main.qml" line="2408"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2408"/>
+        <location filename="../app/Main.qml" line="2410"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2413"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2412"/>
+        <location filename="../app/Main.qml" line="2414"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2414"/>
+        <location filename="../app/Main.qml" line="2416"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2417"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2417"/>
+        <location filename="../app/Main.qml" line="2419"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2418"/>
+        <location filename="../app/Main.qml" line="2420"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2420"/>
+        <location filename="../app/Main.qml" line="2422"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2421"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2424"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2428"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2431"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2430"/>
+        <location filename="../app/Main.qml" line="2432"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2432"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2433"/>
+        <location filename="../app/Main.qml" line="2435"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorites</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2627"/>
-        <location filename="../app/Main.qml" line="2641"/>
+        <location filename="../app/Main.qml" line="2629"/>
+        <location filename="../app/Main.qml" line="2643"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2659"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2661"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2657"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2662"/>
+        <location filename="../app/Main.qml" line="2664"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2818"/>
-        <location filename="../app/Main.qml" line="2836"/>
+        <location filename="../app/Main.qml" line="2820"/>
+        <location filename="../app/Main.qml" line="2838"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2822"/>
-        <location filename="../app/Main.qml" line="2839"/>
+        <location filename="../app/Main.qml" line="2824"/>
+        <location filename="../app/Main.qml" line="2841"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2423"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2505"/>
-        <location filename="../app/Main.qml" line="2852"/>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="2507"/>
+        <location filename="../app/Main.qml" line="2854"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Retry</source>
         <translation type="unfinished">Retry</translation>
     </message>
@@ -948,22 +948,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Cancel</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3709"/>
+        <location filename="../app/Main.qml" line="3711"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3714"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3716"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3720"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -478,6 +478,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/GameInfoModal.qml" line="120"/>
+        <source>Could not load details. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/GameInfoModal.qml" line="169"/>
         <source>Loading image…</source>
         <translation type="unfinished"></translation>
@@ -546,27 +551,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="202"/>
+        <location filename="../screens/HubScreen.qml" line="203"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="209"/>
+        <location filename="../screens/HubScreen.qml" line="210"/>
         <source>Favorites</source>
         <translation>Favoritos</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="215"/>
+        <location filename="../screens/HubScreen.qml" line="216"/>
         <source>Recently Played</source>
         <translation>Recientemente Jugados</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="222"/>
+        <location filename="../screens/HubScreen.qml" line="223"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="229"/>
+        <location filename="../screens/HubScreen.qml" line="230"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,7 +580,7 @@ Français - Wilfried</source>
         <translation type="vanished">Ajustes</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="816"/>
+        <location filename="../screens/HubScreen.qml" line="821"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>No hay sistemas disponibles. Ejecuta Actualizar la base de datos de medios desde Ajustes.</translation>
     </message>
@@ -620,13 +625,16 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="197"/>
-        <source>Upload failed: %1</source>
-        <translation>Error de subida: %1</translation>
+        <source>Upload failed. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197"/>
+        <source>Upload failed: %1</source>
+        <translation type="vanished">Error de subida: %1</translation>
+    </message>
+    <message>
         <source>Upload failed.</source>
-        <translation>La subida falló.</translation>
+        <translation type="vanished">La subida falló.</translation>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="227"/>
@@ -642,28 +650,28 @@ Français - Wilfried</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1746"/>
+        <location filename="../app/Main.qml" line="1757"/>
         <source>Launch core</source>
         <translation>Lanzar core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1760"/>
-        <location filename="../app/Main.qml" line="2045"/>
+        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="2056"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Remove from favorites</source>
         <translation>Eliminar de favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Add to favorites</source>
         <translation>Agregar a favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1850"/>
+        <location filename="../app/Main.qml" line="1861"/>
         <source>Write to NFC token</source>
         <translation>Escribir en token NFC</translation>
     </message>
@@ -672,201 +680,346 @@ Français - Wilfried</source>
         <translation type="vanished">Código QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1829"/>
-        <location filename="../app/Main.qml" line="1864"/>
+        <location filename="../app/Main.qml" line="1840"/>
+        <location filename="../app/Main.qml" line="1875"/>
         <source>Launch game</source>
         <translation>Iniciar juego</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2579"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2431"/>
-        <location filename="../app/Main.qml" line="2470"/>
-        <location filename="../app/Main.qml" line="2480"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2634"/>
+        <location filename="../app/Main.qml" line="2644"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2467"/>
+        <location filename="../app/Main.qml" line="2631"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3530"/>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Card write failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Could not write to this card. Check that it is writable and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3705"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3712"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1767"/>
-        <location filename="../app/Main.qml" line="1801"/>
+        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="1812"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizar base de datos de medios</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1770"/>
-        <location filename="../app/Main.qml" line="1804"/>
+        <location filename="../app/Main.qml" line="1781"/>
+        <location filename="../app/Main.qml" line="1815"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extraer metadatos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2052"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2677"/>
         <source>Default</source>
         <translation type="unfinished">Por defecto</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
+        <location filename="../app/Main.qml" line="2052"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1755"/>
-        <location filename="../app/Main.qml" line="1796"/>
-        <location filename="../app/Main.qml" line="1813"/>
-        <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="1766"/>
+        <location filename="../app/Main.qml" line="1807"/>
+        <location filename="../app/Main.qml" line="1824"/>
+        <location filename="../app/Main.qml" line="1832"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2587"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
+        <location filename="../app/Main.qml" line="2623"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2593"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2681"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2606"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2521"/>
+        <location filename="../app/Main.qml" line="2685"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2450"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1854"/>
+        <location filename="../app/Main.qml" line="1865"/>
         <source>Write with QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Details unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2352"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2435"/>
+        <source>OK</source>
+        <translation type="unfinished">Aceptar</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2396"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2405"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2406"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2408"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2411"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2412"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2414"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2415"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2417"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2418"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2420"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2421"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2424"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2426"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2427"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2446"/>
+        <source>QR code failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2430"/>
+        <source>Could not create the QR code for this item.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2432"/>
+        <source>Setting not saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2433"/>
+        <source>Could not save this setting. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Log upload failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Could not upload the logs. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
-        <location filename="../app/Main.qml" line="2477"/>
+        <location filename="../app/Main.qml" line="2627"/>
+        <location filename="../app/Main.qml" line="2641"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2495"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2659"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2655"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
+        <location filename="../app/Main.qml" line="2662"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2818"/>
+        <location filename="../app/Main.qml" line="2836"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2658"/>
+        <location filename="../app/Main.qml" line="2822"/>
+        <location filename="../app/Main.qml" line="2839"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="2852"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
-        <source>Error: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Retry</source>
         <translation type="unfinished">Reintentar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
-        <translation type="unfinished">Cancelar</translation>
+        <translation type="obsolete">Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3534"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3541"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3543"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>
@@ -874,85 +1027,76 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Writing failed</source>
         <translation>Error de escritura</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Put a writable card near the reader</source>
         <translation>Pon una tarjeta escribible junto al lector</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="867"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="868"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="861"/>
-        <location filename="../app/MainLayout.qml" line="877"/>
-        <location filename="../app/MainLayout.qml" line="1186"/>
+        <location filename="../app/MainLayout.qml" line="320"/>
+        <location filename="../app/MainLayout.qml" line="869"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>OK</source>
         <translation type="unfinished">Aceptar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875"/>
-        <source>Random game</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <source>No matching games found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Are you sure you want to exit?</source>
         <translation>¿Seguro que quieres salir?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1120"/>
-        <location filename="../app/MainLayout.qml" line="1197"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
         <source>Select</source>
         <translation>Seleccionar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1124"/>
-        <location filename="../app/MainLayout.qml" line="1138"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1164"/>
+        <location filename="../app/MainLayout.qml" line="1132"/>
+        <location filename="../app/MainLayout.qml" line="1146"/>
+        <location filename="../app/MainLayout.qml" line="1161"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1198"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1131"/>
-        <location filename="../app/MainLayout.qml" line="1171"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1220"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1149"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
         <source>Done</source>
         <translation>Hecho</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1187"/>
         <source>I understand</source>
         <translation>Entendido</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1208"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1231"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -961,89 +1105,89 @@ Français - Wilfried</source>
         <translation type="vanished">Iniciar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1433"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Scroll</source>
         <translation>Desplazar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1332"/>
-        <location filename="../app/MainLayout.qml" line="1350"/>
-        <location filename="../app/MainLayout.qml" line="1482"/>
-        <location filename="../app/MainLayout.qml" line="1501"/>
+        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1370"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1521"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1193"/>
-        <location filename="../app/MainLayout.qml" line="1231"/>
-        <location filename="../app/MainLayout.qml" line="1268"/>
-        <location filename="../app/MainLayout.qml" line="1317"/>
-        <location filename="../app/MainLayout.qml" line="1373"/>
-        <location filename="../app/MainLayout.qml" line="1392"/>
-        <location filename="../app/MainLayout.qml" line="1465"/>
+        <location filename="../app/MainLayout.qml" line="1124"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1251"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1337"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1412"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
         <source>Move</source>
         <translation>Mover</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="190"/>
+        <location filename="../app/MainLayout.qml" line="191"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="433"/>
-        <location filename="../app/MainLayout.qml" line="435"/>
+        <location filename="../app/MainLayout.qml" line="440"/>
+        <location filename="../app/MainLayout.qml" line="442"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoritos</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="437"/>
+        <location filename="../app/MainLayout.qml" line="444"/>
         <source>Recently Played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="848"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="841"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1235"/>
-        <location filename="../app/MainLayout.qml" line="1273"/>
-        <location filename="../app/MainLayout.qml" line="1322"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
-        <location filename="../app/MainLayout.qml" line="1470"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1293"/>
+        <location filename="../app/MainLayout.qml" line="1342"/>
+        <location filename="../app/MainLayout.qml" line="1398"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1265"/>
         <source>Quit</source>
         <translation>Salir</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1254"/>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1306"/>
-        <location filename="../app/MainLayout.qml" line="1336"/>
-        <location filename="../app/MainLayout.qml" line="1354"/>
-        <location filename="../app/MainLayout.qml" line="1366"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1416"/>
-        <location filename="../app/MainLayout.qml" line="1437"/>
-        <location filename="../app/MainLayout.qml" line="1446"/>
-        <location filename="../app/MainLayout.qml" line="1486"/>
-        <location filename="../app/MainLayout.qml" line="1505"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1310"/>
+        <location filename="../app/MainLayout.qml" line="1326"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1386"/>
+        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1436"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1506"/>
+        <location filename="../app/MainLayout.qml" line="1525"/>
         <source>Back</source>
         <translation>Atrás</translation>
     </message>
@@ -1052,28 +1196,29 @@ Français - Wilfried</source>
         <translation type="vanished">Página</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1241"/>
-        <location filename="../app/MainLayout.qml" line="1276"/>
-        <location filename="../app/MainLayout.qml" line="1327"/>
-        <location filename="../app/MainLayout.qml" line="1475"/>
+        <location filename="../app/MainLayout.qml" line="1261"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
+        <location filename="../app/MainLayout.qml" line="1495"/>
         <source>Options</source>
         <translation>Opciones</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1160"/>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1344"/>
-        <location filename="../app/MainLayout.qml" line="1493"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1364"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
         <source>Retry</source>
         <translation>Reintentar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1401"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Change</source>
         <translation>Cambiar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1407"/>
+        <location filename="../app/MainLayout.qml" line="1427"/>
         <source>Toggle</source>
         <translation>Alternar</translation>
     </message>
@@ -1114,7 +1259,7 @@ Français - Wilfried</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="258"/>
+        <location filename="../components/Modal.qml" line="260"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -1153,17 +1298,22 @@ Français - Wilfried</source>
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="29"/>
         <source>Nothing here</source>
         <translation>Nada aquí</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <source>Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScreenStateOverlay.qml" line="68"/>
         <source>Failed to load</source>
         <translation>Fallo al cargar</translation>
     </message>
@@ -1716,24 +1866,24 @@ Français - Wilfried</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="252"/>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="253"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>%1 systems</source>
         <translation>%1 sistemas</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="253"/>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="254"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="399"/>
+        <location filename="../screens/SystemsScreen.qml" line="400"/>
         <source>No systems in this category</source>
         <translation>No hay sistemas en esta categoría</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="400"/>
+        <location filename="../screens/SystemsScreen.qml" line="401"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -686,44 +686,44 @@ Français - Wilfried</source>
         <translation>Iniciar juego</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2579"/>
+        <location filename="../app/Main.qml" line="2581"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2595"/>
-        <location filename="../app/Main.qml" line="2634"/>
-        <location filename="../app/Main.qml" line="2644"/>
+        <location filename="../app/Main.qml" line="2597"/>
+        <location filename="../app/Main.qml" line="2636"/>
+        <location filename="../app/Main.qml" line="2646"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2631"/>
+        <location filename="../app/Main.qml" line="2633"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Card write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Could not write to this card. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3712"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3707"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
@@ -753,8 +753,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2052"/>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2677"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2679"/>
         <source>Default</source>
         <translation type="unfinished">Por defecto</translation>
     </message>
@@ -768,40 +768,40 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1807"/>
         <location filename="../app/Main.qml" line="1824"/>
         <location filename="../app/Main.qml" line="1832"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2587"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2589"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2623"/>
+        <location filename="../app/Main.qml" line="2625"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2595"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2681"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2683"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2608"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2685"/>
+        <location filename="../app/Main.qml" line="2687"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -822,180 +822,180 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2352"/>
-        <location filename="../app/Main.qml" line="2372"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2435"/>
+        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2437"/>
         <source>OK</source>
         <translation type="unfinished">Aceptar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2398"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2405"/>
+        <location filename="../app/Main.qml" line="2407"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2406"/>
+        <location filename="../app/Main.qml" line="2408"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2408"/>
+        <location filename="../app/Main.qml" line="2410"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2413"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2412"/>
+        <location filename="../app/Main.qml" line="2414"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2414"/>
+        <location filename="../app/Main.qml" line="2416"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2417"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2417"/>
+        <location filename="../app/Main.qml" line="2419"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2418"/>
+        <location filename="../app/Main.qml" line="2420"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2420"/>
+        <location filename="../app/Main.qml" line="2422"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2421"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2424"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2428"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2431"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2430"/>
+        <location filename="../app/Main.qml" line="2432"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2432"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2433"/>
+        <location filename="../app/Main.qml" line="2435"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2627"/>
-        <location filename="../app/Main.qml" line="2641"/>
+        <location filename="../app/Main.qml" line="2629"/>
+        <location filename="../app/Main.qml" line="2643"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2659"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2661"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2657"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2662"/>
+        <location filename="../app/Main.qml" line="2664"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2818"/>
-        <location filename="../app/Main.qml" line="2836"/>
+        <location filename="../app/Main.qml" line="2820"/>
+        <location filename="../app/Main.qml" line="2838"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2822"/>
-        <location filename="../app/Main.qml" line="2839"/>
+        <location filename="../app/Main.qml" line="2824"/>
+        <location filename="../app/Main.qml" line="2841"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2423"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2505"/>
-        <location filename="../app/Main.qml" line="2852"/>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="2507"/>
+        <location filename="../app/Main.qml" line="2854"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Retry</source>
         <translation type="unfinished">Reintentar</translation>
     </message>
@@ -1004,22 +1004,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3709"/>
+        <location filename="../app/Main.qml" line="3711"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3714"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3716"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3720"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -482,6 +482,11 @@ Français - Wilfried</source>
         <translation type="unfinished">Xehetasunak kargatzen...</translation>
     </message>
     <message>
+        <location filename="../components/GameInfoModal.qml" line="120"/>
+        <source>Could not load details. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/GameInfoModal.qml" line="169"/>
         <source>Loading image…</source>
         <translation type="unfinished">Irudia kargatzen...</translation>
@@ -558,27 +563,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="202"/>
+        <location filename="../screens/HubScreen.qml" line="203"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="209"/>
+        <location filename="../screens/HubScreen.qml" line="210"/>
         <source>Favorites</source>
         <translation>Gogokoak</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="215"/>
+        <location filename="../screens/HubScreen.qml" line="216"/>
         <source>Recently Played</source>
         <translation>Duela gutxi jolastuta</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="222"/>
+        <location filename="../screens/HubScreen.qml" line="223"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="229"/>
+        <location filename="../screens/HubScreen.qml" line="230"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -587,7 +592,7 @@ Français - Wilfried</source>
         <translation type="vanished">Ezarpenak</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="816"/>
+        <location filename="../screens/HubScreen.qml" line="821"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation type="unfinished">Ez dago sistemarik eskuragarri. Exekutatu Eguneratu baliabide datubasea Aukeretatik</translation>
     </message>
@@ -632,13 +637,16 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="197"/>
-        <source>Upload failed: %1</source>
-        <translation type="unfinished">Igoerak huts egin du: %1</translation>
+        <source>Upload failed. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197"/>
+        <source>Upload failed: %1</source>
+        <translation type="obsolete">Igoerak huts egin du: %1</translation>
+    </message>
+    <message>
         <source>Upload failed.</source>
-        <translation type="unfinished">Igoerak huts egin du</translation>
+        <translation type="obsolete">Igoerak huts egin du</translation>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="227"/>
@@ -654,28 +662,28 @@ Français - Wilfried</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1746"/>
+        <location filename="../app/Main.qml" line="1757"/>
         <source>Launch core</source>
         <translation type="unfinished">Exekutatu nukleoa</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1760"/>
-        <location filename="../app/Main.qml" line="2045"/>
+        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="2056"/>
         <source>Change launcher</source>
         <translation type="unfinished">Aldatu abiarazlea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Remove from favorites</source>
         <translation type="unfinished">Kendu gogokoetatik</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Add to favorites</source>
         <translation type="unfinished">Gehitu gogokoetan</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1850"/>
+        <location filename="../app/Main.qml" line="1861"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Idatzi NFC token-a</translation>
     </message>
@@ -684,201 +692,350 @@ Français - Wilfried</source>
         <translation type="obsolete">QR kodea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1829"/>
-        <location filename="../app/Main.qml" line="1864"/>
+        <location filename="../app/Main.qml" line="1840"/>
+        <location filename="../app/Main.qml" line="1875"/>
         <source>Launch game</source>
         <translation type="unfinished">Abiarazi jokua</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2579"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2431"/>
-        <location filename="../app/Main.qml" line="2470"/>
-        <location filename="../app/Main.qml" line="2480"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2634"/>
+        <location filename="../app/Main.qml" line="2644"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2467"/>
+        <location filename="../app/Main.qml" line="2631"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3530"/>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Card write failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Could not write to this card. Check that it is writable and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3705"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3712"/>
         <source>Loading favorites…</source>
         <translation type="unfinished">Gogokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading games…</source>
         <translation type="unfinished">Jokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1767"/>
-        <location filename="../app/Main.qml" line="1801"/>
+        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="1812"/>
         <source>Update media database</source>
         <translation type="unfinished">Eguneratu multimedia datu-basea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1770"/>
-        <location filename="../app/Main.qml" line="1804"/>
+        <location filename="../app/Main.qml" line="1781"/>
+        <location filename="../app/Main.qml" line="1815"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadatuak scrapeatu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2052"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2677"/>
         <source>Default</source>
         <translation type="unfinished">Lehenetsia</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
+        <location filename="../app/Main.qml" line="2052"/>
         <source>Current: %1</source>
         <translation type="unfinished">Unekoa: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1755"/>
-        <location filename="../app/Main.qml" line="1796"/>
-        <location filename="../app/Main.qml" line="1813"/>
-        <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="1766"/>
+        <location filename="../app/Main.qml" line="1807"/>
+        <location filename="../app/Main.qml" line="1824"/>
+        <location filename="../app/Main.qml" line="1832"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2587"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
+        <location filename="../app/Main.qml" line="2623"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2593"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2681"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2606"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2521"/>
+        <location filename="../app/Main.qml" line="2685"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2450"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1854"/>
+        <location filename="../app/Main.qml" line="1865"/>
         <source>Write with QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Details unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2352"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2435"/>
+        <source>OK</source>
+        <translation type="unfinished">Ados</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2396"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2405"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2406"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2408"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2411"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2412"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2414"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2415"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2417"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2418"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2420"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2421"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2424"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2426"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2427"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2446"/>
+        <source>QR code failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2430"/>
+        <source>Could not create the QR code for this item.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2432"/>
+        <source>Setting not saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2433"/>
+        <source>Could not save this setting. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Log upload failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Could not upload the logs. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Favorites</source>
         <translation type="unfinished">Gogokoak</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
-        <location filename="../app/Main.qml" line="2477"/>
+        <location filename="../app/Main.qml" line="2627"/>
+        <location filename="../app/Main.qml" line="2641"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2495"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2659"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2655"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
+        <location filename="../app/Main.qml" line="2662"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2818"/>
+        <location filename="../app/Main.qml" line="2836"/>
         <source>Saving launcher</source>
         <translation type="unfinished">Abiarazlea gordetzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2658"/>
+        <location filename="../app/Main.qml" line="2822"/>
+        <location filename="../app/Main.qml" line="2839"/>
         <source>Saving…</source>
         <translation type="unfinished">Gordetzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="2852"/>
         <source>Launcher update failed</source>
         <translation type="unfinished">Abiarazle egukeraketak huts egin du</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
         <source>Error: %1</source>
-        <translation type="unfinished">Errorea: %1</translation>
+        <translation type="obsolete">Errorea: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Retry</source>
         <translation type="unfinished">Berriro saiatu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
-        <translation type="unfinished">Utzi</translation>
+        <translation type="obsolete">Utzi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3534"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading game…</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading recently played…</source>
         <translation type="unfinished">Duela gutxi jokatutakoak kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3541"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3543"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
@@ -886,85 +1043,76 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Writing failed</source>
         <translation>Idazketak huts egin du</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Put a writable card near the reader</source>
         <translation>Jarri idatzi daitekeen txartel bat irakurlearen ondoan</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="867"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="868"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="861"/>
-        <location filename="../app/MainLayout.qml" line="877"/>
-        <location filename="../app/MainLayout.qml" line="1186"/>
+        <location filename="../app/MainLayout.qml" line="320"/>
+        <location filename="../app/MainLayout.qml" line="869"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>OK</source>
         <translation type="unfinished">Ados</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875"/>
-        <source>Random game</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <source>No matching games found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Are you sure you want to exit?</source>
         <translation type="unfinished">Ziur zaude irten nahi duzula?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1120"/>
-        <location filename="../app/MainLayout.qml" line="1197"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
         <source>Select</source>
         <translation>Aukeratu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1124"/>
-        <location filename="../app/MainLayout.qml" line="1138"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1164"/>
+        <location filename="../app/MainLayout.qml" line="1132"/>
+        <location filename="../app/MainLayout.qml" line="1146"/>
+        <location filename="../app/MainLayout.qml" line="1161"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1198"/>
         <source>Close</source>
         <translation>Itxi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1131"/>
-        <location filename="../app/MainLayout.qml" line="1171"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1220"/>
         <source>Cancel</source>
         <translation>Utzi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1149"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
         <source>Done</source>
         <translation type="unfinished">Eginda</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1187"/>
         <source>I understand</source>
         <translation type="unfinished">Ulertzen dut</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1208"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1231"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -973,89 +1121,89 @@ Français - Wilfried</source>
         <translation type="obsolete">Hasi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1433"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Scroll</source>
         <translation type="unfinished">Scroll-a egin</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1332"/>
-        <location filename="../app/MainLayout.qml" line="1350"/>
-        <location filename="../app/MainLayout.qml" line="1482"/>
-        <location filename="../app/MainLayout.qml" line="1501"/>
+        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1370"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1521"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1193"/>
-        <location filename="../app/MainLayout.qml" line="1231"/>
-        <location filename="../app/MainLayout.qml" line="1268"/>
-        <location filename="../app/MainLayout.qml" line="1317"/>
-        <location filename="../app/MainLayout.qml" line="1373"/>
-        <location filename="../app/MainLayout.qml" line="1392"/>
-        <location filename="../app/MainLayout.qml" line="1465"/>
+        <location filename="../app/MainLayout.qml" line="1124"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1251"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1337"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1412"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
         <source>Move</source>
         <translation>Mugitu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="190"/>
+        <location filename="../app/MainLayout.qml" line="191"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished">Zaparoo Frontend</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="433"/>
-        <location filename="../app/MainLayout.qml" line="435"/>
+        <location filename="../app/MainLayout.qml" line="440"/>
+        <location filename="../app/MainLayout.qml" line="442"/>
         <source>Favorites</source>
         <translation type="unfinished">Gogokoak</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="437"/>
+        <location filename="../app/MainLayout.qml" line="444"/>
         <source>Recently Played</source>
         <translation type="unfinished">Duela gutxi jokatuak</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="848"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished">Itxi eta Zaparoo Frontend berabiarazi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="841"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished">Ezarpenak indarrean jartzeko frontend-a berrabiarazi behar dugu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished">Itxi Zaparoo Frontend?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1235"/>
-        <location filename="../app/MainLayout.qml" line="1273"/>
-        <location filename="../app/MainLayout.qml" line="1322"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
-        <location filename="../app/MainLayout.qml" line="1470"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1293"/>
+        <location filename="../app/MainLayout.qml" line="1342"/>
+        <location filename="../app/MainLayout.qml" line="1398"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
         <source>Open</source>
         <translation>Ireki</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1265"/>
         <source>Quit</source>
         <translation>Irten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1254"/>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1306"/>
-        <location filename="../app/MainLayout.qml" line="1336"/>
-        <location filename="../app/MainLayout.qml" line="1354"/>
-        <location filename="../app/MainLayout.qml" line="1366"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1416"/>
-        <location filename="../app/MainLayout.qml" line="1437"/>
-        <location filename="../app/MainLayout.qml" line="1446"/>
-        <location filename="../app/MainLayout.qml" line="1486"/>
-        <location filename="../app/MainLayout.qml" line="1505"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1310"/>
+        <location filename="../app/MainLayout.qml" line="1326"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1386"/>
+        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1436"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1506"/>
+        <location filename="../app/MainLayout.qml" line="1525"/>
         <source>Back</source>
         <translation>Atzera</translation>
     </message>
@@ -1064,28 +1212,29 @@ Français - Wilfried</source>
         <translation type="obsolete">Orria</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1241"/>
-        <location filename="../app/MainLayout.qml" line="1276"/>
-        <location filename="../app/MainLayout.qml" line="1327"/>
-        <location filename="../app/MainLayout.qml" line="1475"/>
+        <location filename="../app/MainLayout.qml" line="1261"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
+        <location filename="../app/MainLayout.qml" line="1495"/>
         <source>Options</source>
         <translation type="unfinished">Aukerak</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1160"/>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1344"/>
-        <location filename="../app/MainLayout.qml" line="1493"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1364"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
         <source>Retry</source>
         <translation>Berriro saiatu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1401"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Change</source>
         <translation>Aldatu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1407"/>
+        <location filename="../app/MainLayout.qml" line="1427"/>
         <source>Toggle</source>
         <translation>Txandakatu</translation>
     </message>
@@ -1126,7 +1275,7 @@ Français - Wilfried</source>
         <translation type="unfinished">Ez</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="258"/>
+        <location filename="../components/Modal.qml" line="260"/>
         <source>Cancel</source>
         <translation>Utzi</translation>
     </message>
@@ -1165,17 +1314,22 @@ Français - Wilfried</source>
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="29"/>
         <source>Nothing here</source>
         <translation>Ez dago ezer hemen</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <source>Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScreenStateOverlay.qml" line="68"/>
         <source>Failed to load</source>
         <translation>Ezin izan da kargatu</translation>
     </message>
@@ -1728,24 +1882,24 @@ Français - Wilfried</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="252"/>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="253"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>%1 systems</source>
         <translation>%1 sistema</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="253"/>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="254"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>%1 / %2</source>
         <translation type="unfinished">%1 / %2</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="399"/>
+        <location filename="../screens/SystemsScreen.qml" line="400"/>
         <source>No systems in this category</source>
         <translation>Ez dago sistemarik kategoria honetan</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="400"/>
+        <location filename="../screens/SystemsScreen.qml" line="401"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -698,44 +698,44 @@ Français - Wilfried</source>
         <translation type="unfinished">Abiarazi jokua</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2579"/>
+        <location filename="../app/Main.qml" line="2581"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2595"/>
-        <location filename="../app/Main.qml" line="2634"/>
-        <location filename="../app/Main.qml" line="2644"/>
+        <location filename="../app/Main.qml" line="2597"/>
+        <location filename="../app/Main.qml" line="2636"/>
+        <location filename="../app/Main.qml" line="2646"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2631"/>
+        <location filename="../app/Main.qml" line="2633"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Card write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Could not write to this card. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3712"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading favorites…</source>
         <translation type="unfinished">Gogokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3707"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading games…</source>
         <translation type="unfinished">Jokoak kargatzen</translation>
     </message>
@@ -765,8 +765,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2052"/>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2677"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2679"/>
         <source>Default</source>
         <translation type="unfinished">Lehenetsia</translation>
     </message>
@@ -780,40 +780,40 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1807"/>
         <location filename="../app/Main.qml" line="1824"/>
         <location filename="../app/Main.qml" line="1832"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2587"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2589"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2623"/>
+        <location filename="../app/Main.qml" line="2625"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2595"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2681"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2683"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2608"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2685"/>
+        <location filename="../app/Main.qml" line="2687"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -834,172 +834,172 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2352"/>
-        <location filename="../app/Main.qml" line="2372"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2435"/>
+        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2437"/>
         <source>OK</source>
         <translation type="unfinished">Ados</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2398"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2405"/>
+        <location filename="../app/Main.qml" line="2407"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2406"/>
+        <location filename="../app/Main.qml" line="2408"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2408"/>
+        <location filename="../app/Main.qml" line="2410"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2413"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2412"/>
+        <location filename="../app/Main.qml" line="2414"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2414"/>
+        <location filename="../app/Main.qml" line="2416"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2417"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2417"/>
+        <location filename="../app/Main.qml" line="2419"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2418"/>
+        <location filename="../app/Main.qml" line="2420"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2420"/>
+        <location filename="../app/Main.qml" line="2422"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2421"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2424"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2428"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2431"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2430"/>
+        <location filename="../app/Main.qml" line="2432"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2432"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2433"/>
+        <location filename="../app/Main.qml" line="2435"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Favorites</source>
         <translation type="unfinished">Gogokoak</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2627"/>
-        <location filename="../app/Main.qml" line="2641"/>
+        <location filename="../app/Main.qml" line="2629"/>
+        <location filename="../app/Main.qml" line="2643"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2659"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2661"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2657"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2662"/>
+        <location filename="../app/Main.qml" line="2664"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2818"/>
-        <location filename="../app/Main.qml" line="2836"/>
+        <location filename="../app/Main.qml" line="2820"/>
+        <location filename="../app/Main.qml" line="2838"/>
         <source>Saving launcher</source>
         <translation type="unfinished">Abiarazlea gordetzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2822"/>
-        <location filename="../app/Main.qml" line="2839"/>
+        <location filename="../app/Main.qml" line="2824"/>
+        <location filename="../app/Main.qml" line="2841"/>
         <source>Saving…</source>
         <translation type="unfinished">Gordetzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2423"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Launcher update failed</source>
         <translation type="unfinished">Abiarazle egukeraketak huts egin du</translation>
     </message>
@@ -1009,9 +1009,9 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2505"/>
-        <location filename="../app/Main.qml" line="2852"/>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="2507"/>
+        <location filename="../app/Main.qml" line="2854"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Retry</source>
         <translation type="unfinished">Berriro saiatu</translation>
     </message>
@@ -1020,22 +1020,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Utzi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3709"/>
+        <location filename="../app/Main.qml" line="3711"/>
         <source>Loading game…</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3714"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading recently played…</source>
         <translation type="unfinished">Duela gutxi jokatutakoak kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3716"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3720"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>

--- a/src/ui/translations/frontend_fr.ts
+++ b/src/ui/translations/frontend_fr.ts
@@ -677,39 +677,39 @@ Français - Wilfried</translation>
         <translation>Lancer le jeu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2579"/>
+        <location filename="../app/Main.qml" line="2581"/>
         <source>Go to...</source>
         <translation>Aller à...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2595"/>
-        <location filename="../app/Main.qml" line="2634"/>
-        <location filename="../app/Main.qml" line="2644"/>
+        <location filename="../app/Main.qml" line="2597"/>
+        <location filename="../app/Main.qml" line="2636"/>
+        <location filename="../app/Main.qml" line="2646"/>
         <source>View</source>
         <translation>Afficher</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Card write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Could not write to this card. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading systems…</source>
         <translation>Chargement des systèmes…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3712"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading favorites…</source>
         <translation>Chargement des favoris…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3707"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading games…</source>
         <translation>Chargement des jeux…</translation>
     </message>
@@ -739,8 +739,8 @@ Français - Wilfried</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2052"/>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2677"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2679"/>
         <source>Default</source>
         <translation>Par défaut</translation>
     </message>
@@ -754,8 +754,8 @@ Français - Wilfried</translation>
         <location filename="../app/Main.qml" line="1807"/>
         <location filename="../app/Main.qml" line="1824"/>
         <location filename="../app/Main.qml" line="1832"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2587"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2589"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
@@ -776,209 +776,209 @@ Français - Wilfried</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2352"/>
-        <location filename="../app/Main.qml" line="2372"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2435"/>
+        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2437"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2398"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2405"/>
+        <location filename="../app/Main.qml" line="2407"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2406"/>
+        <location filename="../app/Main.qml" line="2408"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2408"/>
+        <location filename="../app/Main.qml" line="2410"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2413"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2412"/>
+        <location filename="../app/Main.qml" line="2414"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2414"/>
+        <location filename="../app/Main.qml" line="2416"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2417"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2417"/>
+        <location filename="../app/Main.qml" line="2419"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2418"/>
+        <location filename="../app/Main.qml" line="2420"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2420"/>
+        <location filename="../app/Main.qml" line="2422"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2421"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2424"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2428"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2431"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2430"/>
+        <location filename="../app/Main.qml" line="2432"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2432"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2433"/>
+        <location filename="../app/Main.qml" line="2435"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2595"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoris</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2608"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2623"/>
+        <location filename="../app/Main.qml" line="2625"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2627"/>
-        <location filename="../app/Main.qml" line="2641"/>
+        <location filename="../app/Main.qml" line="2629"/>
+        <location filename="../app/Main.qml" line="2643"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2631"/>
+        <location filename="../app/Main.qml" line="2633"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2659"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2661"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2657"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2662"/>
+        <location filename="../app/Main.qml" line="2664"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2681"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2683"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2685"/>
+        <location filename="../app/Main.qml" line="2687"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2818"/>
-        <location filename="../app/Main.qml" line="2836"/>
+        <location filename="../app/Main.qml" line="2820"/>
+        <location filename="../app/Main.qml" line="2838"/>
         <source>Saving launcher</source>
         <translation>Enregistrement du lanceur</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2822"/>
-        <location filename="../app/Main.qml" line="2839"/>
+        <location filename="../app/Main.qml" line="2824"/>
+        <location filename="../app/Main.qml" line="2841"/>
         <source>Saving…</source>
         <translation>Enregistrement…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2423"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Launcher update failed</source>
         <translation>Échec de la mise à jour du lanceur</translation>
     </message>
@@ -988,9 +988,9 @@ Français - Wilfried</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2505"/>
-        <location filename="../app/Main.qml" line="2852"/>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="2507"/>
+        <location filename="../app/Main.qml" line="2854"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Retry</source>
         <translation>Réessayer</translation>
     </message>
@@ -999,22 +999,22 @@ Français - Wilfried</translation>
         <translation type="vanished">Annuler</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3709"/>
+        <location filename="../app/Main.qml" line="3711"/>
         <source>Loading game…</source>
         <translation>Chargement du jeu…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3714"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading recently played…</source>
         <translation>Chargement des jeux récents…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3716"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading settings…</source>
         <translation>Chargement des réglages…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3720"/>
         <source>Loading…</source>
         <translation>Chargement…</translation>
     </message>

--- a/src/ui/translations/frontend_fr.ts
+++ b/src/ui/translations/frontend_fr.ts
@@ -461,6 +461,11 @@ Français - Wilfried</translation>
         <translation>Chargement des détails…</translation>
     </message>
     <message>
+        <location filename="../components/GameInfoModal.qml" line="120"/>
+        <source>Could not load details. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/GameInfoModal.qml" line="169"/>
         <source>Loading image…</source>
         <translation>Chargement de l&apos;image…</translation>
@@ -537,27 +542,27 @@ Français - Wilfried</translation>
         <translation>Autres</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="202"/>
+        <location filename="../screens/HubScreen.qml" line="203"/>
         <source>Resume</source>
         <translation>Reprendre</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="209"/>
+        <location filename="../screens/HubScreen.qml" line="210"/>
         <source>Favorites</source>
         <translation>Favoris</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="215"/>
+        <location filename="../screens/HubScreen.qml" line="216"/>
         <source>Recently Played</source>
         <translation>Joués récemment</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="222"/>
+        <location filename="../screens/HubScreen.qml" line="223"/>
         <source>Update</source>
         <translation>Mise à jour</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="229"/>
+        <location filename="../screens/HubScreen.qml" line="230"/>
         <source>Settings &amp; Utilities</source>
         <translation>Réglages et utilitaires</translation>
     </message>
@@ -566,7 +571,7 @@ Français - Wilfried</translation>
         <translation type="vanished">Réglages</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="816"/>
+        <location filename="../screens/HubScreen.qml" line="821"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Aucun système disponible. Lancez Mettre à jour la base de données média depuis les Réglages.</translation>
     </message>
@@ -611,13 +616,16 @@ Français - Wilfried</translation>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="197"/>
-        <source>Upload failed: %1</source>
-        <translation>Échec de l&apos;envoi&#xa0;: %1</translation>
+        <source>Upload failed. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197"/>
+        <source>Upload failed: %1</source>
+        <translation type="vanished">Échec de l&apos;envoi&#xa0;: %1</translation>
+    </message>
+    <message>
         <source>Upload failed.</source>
-        <translation>Échec de l&apos;envoi.</translation>
+        <translation type="vanished">Échec de l&apos;envoi.</translation>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="227"/>
@@ -633,28 +641,28 @@ Français - Wilfried</translation>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1746"/>
+        <location filename="../app/Main.qml" line="1757"/>
         <source>Launch core</source>
         <translation>Lancer le core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1760"/>
-        <location filename="../app/Main.qml" line="2045"/>
+        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="2056"/>
         <source>Change launcher</source>
         <translation>Modifier le lanceur</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Remove from favorites</source>
         <translation>Retirer des favoris</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Add to favorites</source>
         <translation>Ajouter aux favoris</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1850"/>
+        <location filename="../app/Main.qml" line="1861"/>
         <source>Write to NFC token</source>
         <translation>Écrire sur un badge NFC</translation>
     </message>
@@ -663,201 +671,350 @@ Français - Wilfried</translation>
         <translation type="vanished">QR code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1829"/>
-        <location filename="../app/Main.qml" line="1864"/>
+        <location filename="../app/Main.qml" line="1840"/>
+        <location filename="../app/Main.qml" line="1875"/>
         <source>Launch game</source>
         <translation>Lancer le jeu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2579"/>
         <source>Go to...</source>
         <translation>Aller à...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2431"/>
-        <location filename="../app/Main.qml" line="2470"/>
-        <location filename="../app/Main.qml" line="2480"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2634"/>
+        <location filename="../app/Main.qml" line="2644"/>
         <source>View</source>
         <translation>Afficher</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3530"/>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Card write failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Could not write to this card. Check that it is writable and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3705"/>
         <source>Loading systems…</source>
         <translation>Chargement des systèmes…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3712"/>
         <source>Loading favorites…</source>
         <translation>Chargement des favoris…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading games…</source>
         <translation>Chargement des jeux…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1767"/>
-        <location filename="../app/Main.qml" line="1801"/>
+        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="1812"/>
         <source>Update media database</source>
         <translation>Mettre à jour la base de données média</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1770"/>
-        <location filename="../app/Main.qml" line="1804"/>
+        <location filename="../app/Main.qml" line="1781"/>
+        <location filename="../app/Main.qml" line="1815"/>
         <source>Scrape metadata</source>
         <translation>Scraper les métadonnées</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Unhide</source>
         <translation>Afficher</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Hide</source>
         <translation>Masquer</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2052"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2677"/>
         <source>Default</source>
         <translation>Par défaut</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
+        <location filename="../app/Main.qml" line="2052"/>
         <source>Current: %1</source>
         <translation>Actuel&#xa0;: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1755"/>
-        <location filename="../app/Main.qml" line="1796"/>
-        <location filename="../app/Main.qml" line="1813"/>
-        <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="1766"/>
+        <location filename="../app/Main.qml" line="1807"/>
+        <location filename="../app/Main.qml" line="1824"/>
+        <location filename="../app/Main.qml" line="1832"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2587"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1854"/>
+        <location filename="../app/Main.qml" line="1865"/>
         <source>Write with QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Details unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2352"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2435"/>
+        <source>OK</source>
+        <translation type="unfinished">OK</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2396"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2405"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2406"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2408"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2411"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2412"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2414"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2415"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2417"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2418"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2420"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2421"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2424"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2426"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2427"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../app/Main.qml" line="2429"/>
+        <source>QR code failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2430"/>
+        <source>Could not create the QR code for this item.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2432"/>
+        <source>Setting not saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2433"/>
+        <source>Could not save this setting. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Log upload failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Could not upload the logs. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2593"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2446"/>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoris</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2606"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2450"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
+        <location filename="../app/Main.qml" line="2623"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
-        <location filename="../app/Main.qml" line="2477"/>
+        <location filename="../app/Main.qml" line="2627"/>
+        <location filename="../app/Main.qml" line="2641"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2467"/>
+        <location filename="../app/Main.qml" line="2631"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2495"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2659"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2655"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
+        <location filename="../app/Main.qml" line="2662"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2681"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2521"/>
+        <location filename="../app/Main.qml" line="2685"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2818"/>
+        <location filename="../app/Main.qml" line="2836"/>
         <source>Saving launcher</source>
         <translation>Enregistrement du lanceur</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2658"/>
+        <location filename="../app/Main.qml" line="2822"/>
+        <location filename="../app/Main.qml" line="2839"/>
         <source>Saving…</source>
         <translation>Enregistrement…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="2852"/>
         <source>Launcher update failed</source>
         <translation>Échec de la mise à jour du lanceur</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
         <source>Error: %1</source>
-        <translation>Erreur&#xa0;: %1</translation>
+        <translation type="vanished">Erreur&#xa0;: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Retry</source>
         <translation>Réessayer</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
-        <translation>Annuler</translation>
+        <translation type="vanished">Annuler</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3534"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading game…</source>
         <translation>Chargement du jeu…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading recently played…</source>
         <translation>Chargement des jeux récents…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3541"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading settings…</source>
         <translation>Chargement des réglages…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3543"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading…</source>
         <translation>Chargement…</translation>
     </message>
@@ -865,85 +1022,76 @@ Français - Wilfried</translation>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Writing failed</source>
         <translation>Échec de l&apos;écriture</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Put a writable card near the reader</source>
         <translation>Placez une carte inscriptible près du lecteur</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="867"/>
         <source>Update Zaparoo Core</source>
         <translation>Mettre à jour Zaparoo Core</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="868"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation>Ce frontend nécessite Zaparoo Core %1 ou plus récent. Vous utilisez la version %2. Certaines fonctionnalités peuvent ne pas fonctionner tant que la mise à jour n&apos;est pas effectuée.</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="861"/>
-        <location filename="../app/MainLayout.qml" line="877"/>
-        <location filename="../app/MainLayout.qml" line="1186"/>
+        <location filename="../app/MainLayout.qml" line="320"/>
+        <location filename="../app/MainLayout.qml" line="869"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875"/>
-        <source>Random game</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <source>No matching games found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Are you sure you want to exit?</source>
         <translation>Êtes-vous sûr de vouloir quitter&#xa0;?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1120"/>
-        <location filename="../app/MainLayout.qml" line="1197"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
         <source>Select</source>
         <translation>Sélectionner</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1124"/>
-        <location filename="../app/MainLayout.qml" line="1138"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1164"/>
+        <location filename="../app/MainLayout.qml" line="1132"/>
+        <location filename="../app/MainLayout.qml" line="1146"/>
+        <location filename="../app/MainLayout.qml" line="1161"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1198"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1131"/>
-        <location filename="../app/MainLayout.qml" line="1171"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1220"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1149"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
         <source>Done</source>
         <translation>Terminé</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1187"/>
         <source>I understand</source>
         <translation>J&apos;ai compris</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1208"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Adjust</source>
         <translation>Ajuster</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1231"/>
         <source>Save</source>
         <translation>Enregistrer</translation>
     </message>
@@ -952,115 +1100,116 @@ Français - Wilfried</translation>
         <translation type="vanished">Démarrer</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1433"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Scroll</source>
         <translation>Défiler</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1332"/>
-        <location filename="../app/MainLayout.qml" line="1350"/>
-        <location filename="../app/MainLayout.qml" line="1482"/>
-        <location filename="../app/MainLayout.qml" line="1501"/>
+        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1370"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1521"/>
         <source>View</source>
         <translation>Afficher</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1193"/>
-        <location filename="../app/MainLayout.qml" line="1231"/>
-        <location filename="../app/MainLayout.qml" line="1268"/>
-        <location filename="../app/MainLayout.qml" line="1317"/>
-        <location filename="../app/MainLayout.qml" line="1373"/>
-        <location filename="../app/MainLayout.qml" line="1392"/>
-        <location filename="../app/MainLayout.qml" line="1465"/>
+        <location filename="../app/MainLayout.qml" line="1124"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1251"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1337"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1412"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
         <source>Move</source>
         <translation>Déplacer</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="190"/>
+        <location filename="../app/MainLayout.qml" line="191"/>
         <source>Zaparoo Frontend</source>
         <translation>Zaparoo Frontend</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="433"/>
-        <location filename="../app/MainLayout.qml" line="435"/>
+        <location filename="../app/MainLayout.qml" line="440"/>
+        <location filename="../app/MainLayout.qml" line="442"/>
         <source>Favorites</source>
         <translation>Favoris</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="437"/>
+        <location filename="../app/MainLayout.qml" line="444"/>
         <source>Recently Played</source>
         <translation>Joués récemment</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="848"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation>Quitter et redémarrer Zaparoo Frontend&#xa0;?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="841"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation>Pour appliquer ce réglage, le frontend doit être redémarré.</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation>Quitter Zaparoo Frontend&#xa0;?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1235"/>
-        <location filename="../app/MainLayout.qml" line="1273"/>
-        <location filename="../app/MainLayout.qml" line="1322"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
-        <location filename="../app/MainLayout.qml" line="1470"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1293"/>
+        <location filename="../app/MainLayout.qml" line="1342"/>
+        <location filename="../app/MainLayout.qml" line="1398"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
         <source>Open</source>
         <translation>Ouvrir</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1265"/>
         <source>Quit</source>
         <translation>Quitter</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1254"/>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1306"/>
-        <location filename="../app/MainLayout.qml" line="1336"/>
-        <location filename="../app/MainLayout.qml" line="1354"/>
-        <location filename="../app/MainLayout.qml" line="1366"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1416"/>
-        <location filename="../app/MainLayout.qml" line="1437"/>
-        <location filename="../app/MainLayout.qml" line="1446"/>
-        <location filename="../app/MainLayout.qml" line="1486"/>
-        <location filename="../app/MainLayout.qml" line="1505"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1310"/>
+        <location filename="../app/MainLayout.qml" line="1326"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1386"/>
+        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1436"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1506"/>
+        <location filename="../app/MainLayout.qml" line="1525"/>
         <source>Back</source>
         <translation>Retour</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1241"/>
-        <location filename="../app/MainLayout.qml" line="1276"/>
-        <location filename="../app/MainLayout.qml" line="1327"/>
-        <location filename="../app/MainLayout.qml" line="1475"/>
+        <location filename="../app/MainLayout.qml" line="1261"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
+        <location filename="../app/MainLayout.qml" line="1495"/>
         <source>Options</source>
         <translation>Options</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1160"/>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1344"/>
-        <location filename="../app/MainLayout.qml" line="1493"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1364"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
         <source>Retry</source>
         <translation>Réessayer</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1401"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Change</source>
         <translation>Modifier</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1407"/>
+        <location filename="../app/MainLayout.qml" line="1427"/>
         <source>Toggle</source>
         <translation>Basculer</translation>
     </message>
@@ -1101,7 +1250,7 @@ Français - Wilfried</translation>
         <translation>Non</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="258"/>
+        <location filename="../components/Modal.qml" line="260"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
@@ -1140,17 +1289,22 @@ Français - Wilfried</translation>
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="29"/>
         <source>Nothing here</source>
         <translation>Rien ici</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
         <source>Loading…</source>
         <translation>Chargement…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <source>Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScreenStateOverlay.qml" line="68"/>
         <source>Failed to load</source>
         <translation>Échec du chargement</translation>
     </message>
@@ -1695,24 +1849,24 @@ Français - Wilfried</translation>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="252"/>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="253"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>%1 systems</source>
         <translation>%1 systèmes</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="253"/>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="254"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>%1 / %2</source>
         <translation>%1 / %2</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="399"/>
+        <location filename="../screens/SystemsScreen.qml" line="400"/>
         <source>No systems in this category</source>
         <translation>Aucun système dans cette catégorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="400"/>
+        <location filename="../screens/SystemsScreen.qml" line="401"/>
         <source>Loading systems…</source>
         <translation>Chargement des systèmes…</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -711,8 +711,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2052"/>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2677"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2679"/>
         <source>Default</source>
         <translation type="unfinished">ברירת מחדל</translation>
     </message>
@@ -722,7 +722,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2579"/>
+        <location filename="../app/Main.qml" line="2581"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -731,53 +731,53 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1807"/>
         <location filename="../app/Main.qml" line="1824"/>
         <location filename="../app/Main.qml" line="1832"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2587"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2589"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Favorites</source>
         <translation type="unfinished">מועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2595"/>
-        <location filename="../app/Main.qml" line="2634"/>
-        <location filename="../app/Main.qml" line="2644"/>
+        <location filename="../app/Main.qml" line="2597"/>
+        <location filename="../app/Main.qml" line="2636"/>
+        <location filename="../app/Main.qml" line="2646"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2623"/>
+        <location filename="../app/Main.qml" line="2625"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2595"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2681"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2683"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2608"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2685"/>
+        <location filename="../app/Main.qml" line="2687"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -798,189 +798,189 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2352"/>
-        <location filename="../app/Main.qml" line="2372"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2435"/>
+        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2437"/>
         <source>OK</source>
         <translation type="unfinished">אישור</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2398"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2405"/>
+        <location filename="../app/Main.qml" line="2407"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2406"/>
+        <location filename="../app/Main.qml" line="2408"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2408"/>
+        <location filename="../app/Main.qml" line="2410"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2413"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2412"/>
+        <location filename="../app/Main.qml" line="2414"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2414"/>
+        <location filename="../app/Main.qml" line="2416"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2417"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2417"/>
+        <location filename="../app/Main.qml" line="2419"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2418"/>
+        <location filename="../app/Main.qml" line="2420"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2420"/>
+        <location filename="../app/Main.qml" line="2422"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2421"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2424"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2428"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2431"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2430"/>
+        <location filename="../app/Main.qml" line="2432"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2432"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2433"/>
+        <location filename="../app/Main.qml" line="2435"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2627"/>
-        <location filename="../app/Main.qml" line="2641"/>
+        <location filename="../app/Main.qml" line="2629"/>
+        <location filename="../app/Main.qml" line="2643"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2631"/>
+        <location filename="../app/Main.qml" line="2633"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2659"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2661"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2657"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2662"/>
+        <location filename="../app/Main.qml" line="2664"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2818"/>
-        <location filename="../app/Main.qml" line="2836"/>
+        <location filename="../app/Main.qml" line="2820"/>
+        <location filename="../app/Main.qml" line="2838"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2822"/>
-        <location filename="../app/Main.qml" line="2839"/>
+        <location filename="../app/Main.qml" line="2824"/>
+        <location filename="../app/Main.qml" line="2841"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Card write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Could not write to this card. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2423"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2505"/>
-        <location filename="../app/Main.qml" line="2852"/>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="2507"/>
+        <location filename="../app/Main.qml" line="2854"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Retry</source>
         <translation type="unfinished">נסה שוב</translation>
     </message>
@@ -989,37 +989,37 @@ Français - Wilfried</source>
         <translation type="obsolete">ביטול</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3707"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3709"/>
+        <location filename="../app/Main.qml" line="3711"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3712"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3714"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3716"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3720"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -478,6 +478,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/GameInfoModal.qml" line="120"/>
+        <source>Could not load details. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/GameInfoModal.qml" line="169"/>
         <source>Loading image…</source>
         <translation type="unfinished"></translation>
@@ -546,27 +551,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="202"/>
+        <location filename="../screens/HubScreen.qml" line="203"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="209"/>
+        <location filename="../screens/HubScreen.qml" line="210"/>
         <source>Favorites</source>
         <translation>מועדפים</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="215"/>
+        <location filename="../screens/HubScreen.qml" line="216"/>
         <source>Recently Played</source>
         <translation>שוחקו לאחרונה</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="222"/>
+        <location filename="../screens/HubScreen.qml" line="223"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="229"/>
+        <location filename="../screens/HubScreen.qml" line="230"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,7 +580,7 @@ Français - Wilfried</source>
         <translation type="vanished">הגדרות</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="816"/>
+        <location filename="../screens/HubScreen.qml" line="821"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>אין מערכות זמינות. הפעילו &quot;עדכון מסד נתוני מדיה&quot; מההגדרות.</translation>
     </message>
@@ -620,13 +625,16 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="197"/>
-        <source>Upload failed: %1</source>
-        <translation>ההעלאה נכשלה: %1</translation>
+        <source>Upload failed. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197"/>
+        <source>Upload failed: %1</source>
+        <translation type="vanished">ההעלאה נכשלה: %1</translation>
+    </message>
+    <message>
         <source>Upload failed.</source>
-        <translation>ההעלאה נכשלה.</translation>
+        <translation type="vanished">ההעלאה נכשלה.</translation>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="227"/>
@@ -642,58 +650,58 @@ Français - Wilfried</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1746"/>
+        <location filename="../app/Main.qml" line="1757"/>
         <source>Launch core</source>
         <translation>הפעל את הליבה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1760"/>
-        <location filename="../app/Main.qml" line="2045"/>
+        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="2056"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1767"/>
-        <location filename="../app/Main.qml" line="1801"/>
+        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="1812"/>
         <source>Update media database</source>
         <translation type="unfinished">עדכון מסד נתוני המדיה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1770"/>
-        <location filename="../app/Main.qml" line="1804"/>
+        <location filename="../app/Main.qml" line="1781"/>
+        <location filename="../app/Main.qml" line="1815"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">איסוף מטא-נתונים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1829"/>
-        <location filename="../app/Main.qml" line="1864"/>
+        <location filename="../app/Main.qml" line="1840"/>
+        <location filename="../app/Main.qml" line="1875"/>
         <source>Launch game</source>
         <translation>הפעל משחק</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Remove from favorites</source>
         <translation>הסר מהמועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Add to favorites</source>
         <translation>הוסף למועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1850"/>
+        <location filename="../app/Main.qml" line="1861"/>
         <source>Write to NFC token</source>
         <translation>כתוב לטוקן NFC</translation>
     </message>
@@ -702,171 +710,316 @@ Français - Wilfried</source>
         <translation type="vanished">קוד QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2052"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2677"/>
         <source>Default</source>
         <translation type="unfinished">ברירת מחדל</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
+        <location filename="../app/Main.qml" line="2052"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2579"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1755"/>
-        <location filename="../app/Main.qml" line="1796"/>
-        <location filename="../app/Main.qml" line="1813"/>
-        <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="1766"/>
+        <location filename="../app/Main.qml" line="1807"/>
+        <location filename="../app/Main.qml" line="1824"/>
+        <location filename="../app/Main.qml" line="1832"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2587"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2446"/>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Favorites</source>
         <translation type="unfinished">מועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2431"/>
-        <location filename="../app/Main.qml" line="2470"/>
-        <location filename="../app/Main.qml" line="2480"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2634"/>
+        <location filename="../app/Main.qml" line="2644"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
+        <location filename="../app/Main.qml" line="2623"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2593"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2681"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2606"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2521"/>
+        <location filename="../app/Main.qml" line="2685"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2450"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1854"/>
+        <location filename="../app/Main.qml" line="1865"/>
         <source>Write with QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
-        <location filename="../app/Main.qml" line="2477"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Details unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2352"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2435"/>
+        <source>OK</source>
+        <translation type="unfinished">אישור</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2396"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2405"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2406"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2408"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2411"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2412"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2414"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2415"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2417"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2418"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2420"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2421"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2424"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2426"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2427"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2429"/>
+        <source>QR code failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2430"/>
+        <source>Could not create the QR code for this item.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2432"/>
+        <source>Setting not saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2433"/>
+        <source>Could not save this setting. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Log upload failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Could not upload the logs. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2627"/>
+        <location filename="../app/Main.qml" line="2641"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2467"/>
+        <location filename="../app/Main.qml" line="2631"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2495"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2659"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2655"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
+        <location filename="../app/Main.qml" line="2662"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2818"/>
+        <location filename="../app/Main.qml" line="2836"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2658"/>
+        <location filename="../app/Main.qml" line="2822"/>
+        <location filename="../app/Main.qml" line="2839"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Card write failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Could not write to this card. Check that it is writable and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="2852"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
-        <source>Error: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Retry</source>
         <translation type="unfinished">נסה שוב</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
-        <translation type="unfinished">ביטול</translation>
+        <translation type="obsolete">ביטול</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3530"/>
+        <location filename="../app/Main.qml" line="3705"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3534"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3712"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3541"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3543"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>
@@ -874,136 +1027,128 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Writing failed</source>
         <translation>הכתיבה נכשלה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Put a writable card near the reader</source>
         <translation>הניחו כרטיס הניתן לכתיבה ליד הקורא</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="190"/>
+        <location filename="../app/MainLayout.qml" line="191"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="433"/>
-        <location filename="../app/MainLayout.qml" line="435"/>
+        <location filename="../app/MainLayout.qml" line="440"/>
+        <location filename="../app/MainLayout.qml" line="442"/>
         <source>Favorites</source>
         <translation type="unfinished">מועדפים</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="437"/>
+        <location filename="../app/MainLayout.qml" line="444"/>
         <source>Recently Played</source>
         <translation type="unfinished">שוחקו לאחרונה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="848"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="841"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="867"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="868"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="861"/>
-        <location filename="../app/MainLayout.qml" line="877"/>
-        <location filename="../app/MainLayout.qml" line="1186"/>
+        <location filename="../app/MainLayout.qml" line="320"/>
+        <location filename="../app/MainLayout.qml" line="869"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>OK</source>
         <translation type="unfinished">אישור</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875"/>
-        <source>Random game</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <source>No matching games found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Are you sure you want to exit?</source>
         <translation>האם אתה בטוח שברצונך לצאת?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1193"/>
-        <location filename="../app/MainLayout.qml" line="1231"/>
-        <location filename="../app/MainLayout.qml" line="1268"/>
-        <location filename="../app/MainLayout.qml" line="1317"/>
-        <location filename="../app/MainLayout.qml" line="1373"/>
-        <location filename="../app/MainLayout.qml" line="1392"/>
-        <location filename="../app/MainLayout.qml" line="1465"/>
+        <location filename="../app/MainLayout.qml" line="1124"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1251"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1337"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1412"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
         <source>Move</source>
         <translation>הזזה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1120"/>
-        <location filename="../app/MainLayout.qml" line="1197"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
         <source>Select</source>
         <translation>בחירה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1124"/>
-        <location filename="../app/MainLayout.qml" line="1138"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1164"/>
+        <location filename="../app/MainLayout.qml" line="1132"/>
+        <location filename="../app/MainLayout.qml" line="1146"/>
+        <location filename="../app/MainLayout.qml" line="1161"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1198"/>
         <source>Close</source>
         <translation>סגור</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1131"/>
-        <location filename="../app/MainLayout.qml" line="1171"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1220"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1149"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
         <source>Done</source>
         <translation>הושלם</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1160"/>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1344"/>
-        <location filename="../app/MainLayout.qml" line="1493"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1364"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
         <source>Retry</source>
         <translation>נסה שוב</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1187"/>
         <source>I understand</source>
         <translation>הבנתי</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1208"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1231"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1012,41 +1157,41 @@ Français - Wilfried</source>
         <translation type="vanished">התחל</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1235"/>
-        <location filename="../app/MainLayout.qml" line="1273"/>
-        <location filename="../app/MainLayout.qml" line="1322"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
-        <location filename="../app/MainLayout.qml" line="1470"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1293"/>
+        <location filename="../app/MainLayout.qml" line="1342"/>
+        <location filename="../app/MainLayout.qml" line="1398"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
         <source>Open</source>
         <translation>פתח</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1265"/>
         <source>Quit</source>
         <translation>יציאה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1254"/>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1306"/>
-        <location filename="../app/MainLayout.qml" line="1336"/>
-        <location filename="../app/MainLayout.qml" line="1354"/>
-        <location filename="../app/MainLayout.qml" line="1366"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1416"/>
-        <location filename="../app/MainLayout.qml" line="1437"/>
-        <location filename="../app/MainLayout.qml" line="1446"/>
-        <location filename="../app/MainLayout.qml" line="1486"/>
-        <location filename="../app/MainLayout.qml" line="1505"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1310"/>
+        <location filename="../app/MainLayout.qml" line="1326"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1386"/>
+        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1436"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1506"/>
+        <location filename="../app/MainLayout.qml" line="1525"/>
         <source>Back</source>
         <translation>חזרה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1332"/>
-        <location filename="../app/MainLayout.qml" line="1350"/>
-        <location filename="../app/MainLayout.qml" line="1482"/>
-        <location filename="../app/MainLayout.qml" line="1501"/>
+        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1370"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1521"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1055,25 +1200,25 @@ Français - Wilfried</source>
         <translation type="vanished">עמוד</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1241"/>
-        <location filename="../app/MainLayout.qml" line="1276"/>
-        <location filename="../app/MainLayout.qml" line="1327"/>
-        <location filename="../app/MainLayout.qml" line="1475"/>
+        <location filename="../app/MainLayout.qml" line="1261"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
+        <location filename="../app/MainLayout.qml" line="1495"/>
         <source>Options</source>
         <translation>אפשרויות</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1401"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Change</source>
         <translation>שינוי</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1407"/>
+        <location filename="../app/MainLayout.qml" line="1427"/>
         <source>Toggle</source>
         <translation>החלף</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1433"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Scroll</source>
         <translation>גלילה</translation>
     </message>
@@ -1114,7 +1259,7 @@ Français - Wilfried</source>
         <translation>לא</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="258"/>
+        <location filename="../components/Modal.qml" line="260"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
@@ -1153,17 +1298,22 @@ Français - Wilfried</source>
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="29"/>
         <source>Nothing here</source>
         <translation>אין כאן כלום</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <source>Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScreenStateOverlay.qml" line="68"/>
         <source>Failed to load</source>
         <translation>הטעינה נכשלה</translation>
     </message>
@@ -1716,24 +1866,24 @@ Français - Wilfried</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="252"/>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="253"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>%1 systems</source>
         <translation>%1 מערכות</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="253"/>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="254"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="399"/>
+        <location filename="../screens/SystemsScreen.qml" line="400"/>
         <source>No systems in this category</source>
         <translation>אין מערכות בקטגוריה זו</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="400"/>
+        <location filename="../screens/SystemsScreen.qml" line="401"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -711,8 +711,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2052"/>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2677"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2679"/>
         <source>Default</source>
         <translation type="unfinished">डिफ़ॉल्ट</translation>
     </message>
@@ -722,7 +722,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2579"/>
+        <location filename="../app/Main.qml" line="2581"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -731,53 +731,53 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1807"/>
         <location filename="../app/Main.qml" line="1824"/>
         <location filename="../app/Main.qml" line="1832"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2587"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2589"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Favorites</source>
         <translation type="unfinished">पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2595"/>
-        <location filename="../app/Main.qml" line="2634"/>
-        <location filename="../app/Main.qml" line="2644"/>
+        <location filename="../app/Main.qml" line="2597"/>
+        <location filename="../app/Main.qml" line="2636"/>
+        <location filename="../app/Main.qml" line="2646"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2623"/>
+        <location filename="../app/Main.qml" line="2625"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2595"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2681"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2683"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2608"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2685"/>
+        <location filename="../app/Main.qml" line="2687"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -798,189 +798,189 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2352"/>
-        <location filename="../app/Main.qml" line="2372"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2435"/>
+        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2437"/>
         <source>OK</source>
         <translation type="unfinished">ठीक है</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2398"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2405"/>
+        <location filename="../app/Main.qml" line="2407"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2406"/>
+        <location filename="../app/Main.qml" line="2408"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2408"/>
+        <location filename="../app/Main.qml" line="2410"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2413"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2412"/>
+        <location filename="../app/Main.qml" line="2414"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2414"/>
+        <location filename="../app/Main.qml" line="2416"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2417"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2417"/>
+        <location filename="../app/Main.qml" line="2419"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2418"/>
+        <location filename="../app/Main.qml" line="2420"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2420"/>
+        <location filename="../app/Main.qml" line="2422"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2421"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2424"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2428"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2431"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2430"/>
+        <location filename="../app/Main.qml" line="2432"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2432"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2433"/>
+        <location filename="../app/Main.qml" line="2435"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2627"/>
-        <location filename="../app/Main.qml" line="2641"/>
+        <location filename="../app/Main.qml" line="2629"/>
+        <location filename="../app/Main.qml" line="2643"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2631"/>
+        <location filename="../app/Main.qml" line="2633"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2659"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2661"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2657"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2662"/>
+        <location filename="../app/Main.qml" line="2664"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2818"/>
-        <location filename="../app/Main.qml" line="2836"/>
+        <location filename="../app/Main.qml" line="2820"/>
+        <location filename="../app/Main.qml" line="2838"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2822"/>
-        <location filename="../app/Main.qml" line="2839"/>
+        <location filename="../app/Main.qml" line="2824"/>
+        <location filename="../app/Main.qml" line="2841"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Card write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Could not write to this card. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2423"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2505"/>
-        <location filename="../app/Main.qml" line="2852"/>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="2507"/>
+        <location filename="../app/Main.qml" line="2854"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Retry</source>
         <translation type="unfinished">फिर से प्रयास करें</translation>
     </message>
@@ -989,37 +989,37 @@ Français - Wilfried</source>
         <translation type="obsolete">रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3707"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3709"/>
+        <location filename="../app/Main.qml" line="3711"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3712"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3714"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3716"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3720"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -478,6 +478,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/GameInfoModal.qml" line="120"/>
+        <source>Could not load details. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/GameInfoModal.qml" line="169"/>
         <source>Loading image…</source>
         <translation type="unfinished"></translation>
@@ -546,27 +551,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="202"/>
+        <location filename="../screens/HubScreen.qml" line="203"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="209"/>
+        <location filename="../screens/HubScreen.qml" line="210"/>
         <source>Favorites</source>
         <translation>पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="215"/>
+        <location filename="../screens/HubScreen.qml" line="216"/>
         <source>Recently Played</source>
         <translation>हाल ही में खेले गए</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="222"/>
+        <location filename="../screens/HubScreen.qml" line="223"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="229"/>
+        <location filename="../screens/HubScreen.qml" line="230"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,7 +580,7 @@ Français - Wilfried</source>
         <translation type="vanished">सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="816"/>
+        <location filename="../screens/HubScreen.qml" line="821"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>कोई सिस्टम उपलब्ध नहीं है। सेटिंग्स से मीडिया डेटाबेस अपडेट चलाएँ।</translation>
     </message>
@@ -620,13 +625,16 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="197"/>
-        <source>Upload failed: %1</source>
-        <translation>अपलोड विफल हुआ: %1</translation>
+        <source>Upload failed. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197"/>
+        <source>Upload failed: %1</source>
+        <translation type="vanished">अपलोड विफल हुआ: %1</translation>
+    </message>
+    <message>
         <source>Upload failed.</source>
-        <translation>अपलोड विफल हुआ।</translation>
+        <translation type="vanished">अपलोड विफल हुआ।</translation>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="227"/>
@@ -642,58 +650,58 @@ Français - Wilfried</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1746"/>
+        <location filename="../app/Main.qml" line="1757"/>
         <source>Launch core</source>
         <translation>कोर चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1760"/>
-        <location filename="../app/Main.qml" line="2045"/>
+        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="2056"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1767"/>
-        <location filename="../app/Main.qml" line="1801"/>
+        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="1812"/>
         <source>Update media database</source>
         <translation type="unfinished">मीडिया डेटाबेस अपडेट करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1770"/>
-        <location filename="../app/Main.qml" line="1804"/>
+        <location filename="../app/Main.qml" line="1781"/>
+        <location filename="../app/Main.qml" line="1815"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">मेटाडेटा स्क्रैप करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1829"/>
-        <location filename="../app/Main.qml" line="1864"/>
+        <location filename="../app/Main.qml" line="1840"/>
+        <location filename="../app/Main.qml" line="1875"/>
         <source>Launch game</source>
         <translation>गेम चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Remove from favorites</source>
         <translation>पसंदीदा से हटाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Add to favorites</source>
         <translation>पसंदीदा में जोड़ें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1850"/>
+        <location filename="../app/Main.qml" line="1861"/>
         <source>Write to NFC token</source>
         <translation>NFC टोकन पर लिखें</translation>
     </message>
@@ -702,171 +710,316 @@ Français - Wilfried</source>
         <translation type="vanished">QR कोड</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2052"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2677"/>
         <source>Default</source>
         <translation type="unfinished">डिफ़ॉल्ट</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
+        <location filename="../app/Main.qml" line="2052"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2579"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1755"/>
-        <location filename="../app/Main.qml" line="1796"/>
-        <location filename="../app/Main.qml" line="1813"/>
-        <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="1766"/>
+        <location filename="../app/Main.qml" line="1807"/>
+        <location filename="../app/Main.qml" line="1824"/>
+        <location filename="../app/Main.qml" line="1832"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2587"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2446"/>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Favorites</source>
         <translation type="unfinished">पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2431"/>
-        <location filename="../app/Main.qml" line="2470"/>
-        <location filename="../app/Main.qml" line="2480"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2634"/>
+        <location filename="../app/Main.qml" line="2644"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
+        <location filename="../app/Main.qml" line="2623"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2593"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2681"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2606"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2521"/>
+        <location filename="../app/Main.qml" line="2685"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2450"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1854"/>
+        <location filename="../app/Main.qml" line="1865"/>
         <source>Write with QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
-        <location filename="../app/Main.qml" line="2477"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Details unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2352"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2435"/>
+        <source>OK</source>
+        <translation type="unfinished">ठीक है</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2396"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2405"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2406"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2408"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2411"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2412"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2414"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2415"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2417"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2418"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2420"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2421"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2424"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2426"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2427"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2429"/>
+        <source>QR code failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2430"/>
+        <source>Could not create the QR code for this item.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2432"/>
+        <source>Setting not saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2433"/>
+        <source>Could not save this setting. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Log upload failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Could not upload the logs. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2627"/>
+        <location filename="../app/Main.qml" line="2641"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2467"/>
+        <location filename="../app/Main.qml" line="2631"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2495"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2659"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2655"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
+        <location filename="../app/Main.qml" line="2662"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2818"/>
+        <location filename="../app/Main.qml" line="2836"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2658"/>
+        <location filename="../app/Main.qml" line="2822"/>
+        <location filename="../app/Main.qml" line="2839"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Card write failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Could not write to this card. Check that it is writable and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="2852"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
-        <source>Error: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Retry</source>
         <translation type="unfinished">फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
-        <translation type="unfinished">रद्द करें</translation>
+        <translation type="obsolete">रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3530"/>
+        <location filename="../app/Main.qml" line="3705"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3534"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3712"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3541"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3543"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>
@@ -874,136 +1027,128 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Writing failed</source>
         <translation>लिखना विफल हुआ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Put a writable card near the reader</source>
         <translation>रीडर के पास लिखने योग्य कार्ड रखें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="190"/>
+        <location filename="../app/MainLayout.qml" line="191"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="433"/>
-        <location filename="../app/MainLayout.qml" line="435"/>
+        <location filename="../app/MainLayout.qml" line="440"/>
+        <location filename="../app/MainLayout.qml" line="442"/>
         <source>Favorites</source>
         <translation type="unfinished">पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="437"/>
+        <location filename="../app/MainLayout.qml" line="444"/>
         <source>Recently Played</source>
         <translation type="unfinished">हाल ही में खेले गए</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="848"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="841"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="867"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="868"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="861"/>
-        <location filename="../app/MainLayout.qml" line="877"/>
-        <location filename="../app/MainLayout.qml" line="1186"/>
+        <location filename="../app/MainLayout.qml" line="320"/>
+        <location filename="../app/MainLayout.qml" line="869"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>OK</source>
         <translation type="unfinished">ठीक है</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875"/>
-        <source>Random game</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <source>No matching games found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Are you sure you want to exit?</source>
         <translation>क्या आप वाकई बाहर निकलना चाहते हैं?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1193"/>
-        <location filename="../app/MainLayout.qml" line="1231"/>
-        <location filename="../app/MainLayout.qml" line="1268"/>
-        <location filename="../app/MainLayout.qml" line="1317"/>
-        <location filename="../app/MainLayout.qml" line="1373"/>
-        <location filename="../app/MainLayout.qml" line="1392"/>
-        <location filename="../app/MainLayout.qml" line="1465"/>
+        <location filename="../app/MainLayout.qml" line="1124"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1251"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1337"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1412"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
         <source>Move</source>
         <translation>स्थानांतरित करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1120"/>
-        <location filename="../app/MainLayout.qml" line="1197"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
         <source>Select</source>
         <translation>चुनें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1124"/>
-        <location filename="../app/MainLayout.qml" line="1138"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1164"/>
+        <location filename="../app/MainLayout.qml" line="1132"/>
+        <location filename="../app/MainLayout.qml" line="1146"/>
+        <location filename="../app/MainLayout.qml" line="1161"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1198"/>
         <source>Close</source>
         <translation>बंद करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1131"/>
-        <location filename="../app/MainLayout.qml" line="1171"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1220"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1149"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
         <source>Done</source>
         <translation>पूरा</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1160"/>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1344"/>
-        <location filename="../app/MainLayout.qml" line="1493"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1364"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
         <source>Retry</source>
         <translation>फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1187"/>
         <source>I understand</source>
         <translation>मैं समझ गया</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1208"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1231"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1012,41 +1157,41 @@ Français - Wilfried</source>
         <translation type="vanished">शुरू करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1235"/>
-        <location filename="../app/MainLayout.qml" line="1273"/>
-        <location filename="../app/MainLayout.qml" line="1322"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
-        <location filename="../app/MainLayout.qml" line="1470"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1293"/>
+        <location filename="../app/MainLayout.qml" line="1342"/>
+        <location filename="../app/MainLayout.qml" line="1398"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
         <source>Open</source>
         <translation>खोलें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1265"/>
         <source>Quit</source>
         <translation>बंद करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1254"/>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1306"/>
-        <location filename="../app/MainLayout.qml" line="1336"/>
-        <location filename="../app/MainLayout.qml" line="1354"/>
-        <location filename="../app/MainLayout.qml" line="1366"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1416"/>
-        <location filename="../app/MainLayout.qml" line="1437"/>
-        <location filename="../app/MainLayout.qml" line="1446"/>
-        <location filename="../app/MainLayout.qml" line="1486"/>
-        <location filename="../app/MainLayout.qml" line="1505"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1310"/>
+        <location filename="../app/MainLayout.qml" line="1326"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1386"/>
+        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1436"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1506"/>
+        <location filename="../app/MainLayout.qml" line="1525"/>
         <source>Back</source>
         <translation>वापस</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1332"/>
-        <location filename="../app/MainLayout.qml" line="1350"/>
-        <location filename="../app/MainLayout.qml" line="1482"/>
-        <location filename="../app/MainLayout.qml" line="1501"/>
+        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1370"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1521"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1055,25 +1200,25 @@ Français - Wilfried</source>
         <translation type="vanished">पृष्ठ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1241"/>
-        <location filename="../app/MainLayout.qml" line="1276"/>
-        <location filename="../app/MainLayout.qml" line="1327"/>
-        <location filename="../app/MainLayout.qml" line="1475"/>
+        <location filename="../app/MainLayout.qml" line="1261"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
+        <location filename="../app/MainLayout.qml" line="1495"/>
         <source>Options</source>
         <translation>विकल्प</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1401"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Change</source>
         <translation>बदलें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1407"/>
+        <location filename="../app/MainLayout.qml" line="1427"/>
         <source>Toggle</source>
         <translation>टॉगल</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1433"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Scroll</source>
         <translation>स्क्रॉल</translation>
     </message>
@@ -1114,7 +1259,7 @@ Français - Wilfried</source>
         <translation>नहीं</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="258"/>
+        <location filename="../components/Modal.qml" line="260"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
@@ -1153,17 +1298,22 @@ Français - Wilfried</source>
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="29"/>
         <source>Nothing here</source>
         <translation>यहाँ कुछ नहीं है</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <source>Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScreenStateOverlay.qml" line="68"/>
         <source>Failed to load</source>
         <translation>लोड करने में विफल</translation>
     </message>
@@ -1716,24 +1866,24 @@ Français - Wilfried</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="252"/>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="253"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>%1 systems</source>
         <translation>%1 सिस्टम</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="253"/>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="254"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="399"/>
+        <location filename="../screens/SystemsScreen.qml" line="400"/>
         <source>No systems in this category</source>
         <translation>इस श्रेणी में कोई सिस्टम नहीं है</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="400"/>
+        <location filename="../screens/SystemsScreen.qml" line="401"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -478,6 +478,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/GameInfoModal.qml" line="120"/>
+        <source>Could not load details. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/GameInfoModal.qml" line="169"/>
         <source>Loading image…</source>
         <translation type="unfinished"></translation>
@@ -546,27 +551,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="202"/>
+        <location filename="../screens/HubScreen.qml" line="203"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="209"/>
+        <location filename="../screens/HubScreen.qml" line="210"/>
         <source>Favorites</source>
         <translation>Preferiti</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="215"/>
+        <location filename="../screens/HubScreen.qml" line="216"/>
         <source>Recently Played</source>
         <translation>Giocati di recente</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="222"/>
+        <location filename="../screens/HubScreen.qml" line="223"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="229"/>
+        <location filename="../screens/HubScreen.qml" line="230"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,7 +580,7 @@ Français - Wilfried</source>
         <translation type="vanished">Impostazioni</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="816"/>
+        <location filename="../screens/HubScreen.qml" line="821"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Nessun sistema disponibile. Esegui Aggiorna database multimediale dalle Impostazioni.</translation>
     </message>
@@ -620,13 +625,16 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="197"/>
-        <source>Upload failed: %1</source>
-        <translation>Caricamento fallito: %1</translation>
+        <source>Upload failed. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197"/>
+        <source>Upload failed: %1</source>
+        <translation type="vanished">Caricamento fallito: %1</translation>
+    </message>
+    <message>
         <source>Upload failed.</source>
-        <translation>Caricamento fallito.</translation>
+        <translation type="vanished">Caricamento fallito.</translation>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="227"/>
@@ -642,28 +650,28 @@ Français - Wilfried</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1746"/>
+        <location filename="../app/Main.qml" line="1757"/>
         <source>Launch core</source>
         <translation>Avvia core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1760"/>
-        <location filename="../app/Main.qml" line="2045"/>
+        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="2056"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Remove from favorites</source>
         <translation>Rimuovi dai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Add to favorites</source>
         <translation>Aggiungi ai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1850"/>
+        <location filename="../app/Main.qml" line="1861"/>
         <source>Write to NFC token</source>
         <translation>Scrivi sul token NFC</translation>
     </message>
@@ -672,201 +680,346 @@ Français - Wilfried</source>
         <translation type="vanished">Codice QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1829"/>
-        <location filename="../app/Main.qml" line="1864"/>
+        <location filename="../app/Main.qml" line="1840"/>
+        <location filename="../app/Main.qml" line="1875"/>
         <source>Launch game</source>
         <translation>Avvia gioco</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2579"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2431"/>
-        <location filename="../app/Main.qml" line="2470"/>
-        <location filename="../app/Main.qml" line="2480"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2634"/>
+        <location filename="../app/Main.qml" line="2644"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2467"/>
+        <location filename="../app/Main.qml" line="2631"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3530"/>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Card write failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Could not write to this card. Check that it is writable and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3705"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3712"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1767"/>
-        <location filename="../app/Main.qml" line="1801"/>
+        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="1812"/>
         <source>Update media database</source>
         <translation type="unfinished">Aggiorna database multimediale</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1770"/>
-        <location filename="../app/Main.qml" line="1804"/>
+        <location filename="../app/Main.qml" line="1781"/>
+        <location filename="../app/Main.qml" line="1815"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Recupera metadati</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2052"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2677"/>
         <source>Default</source>
         <translation type="unfinished">Predefinito</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
+        <location filename="../app/Main.qml" line="2052"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1755"/>
-        <location filename="../app/Main.qml" line="1796"/>
-        <location filename="../app/Main.qml" line="1813"/>
-        <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="1766"/>
+        <location filename="../app/Main.qml" line="1807"/>
+        <location filename="../app/Main.qml" line="1824"/>
+        <location filename="../app/Main.qml" line="1832"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2587"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
+        <location filename="../app/Main.qml" line="2623"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2593"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2681"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2606"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2521"/>
+        <location filename="../app/Main.qml" line="2685"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2450"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1854"/>
+        <location filename="../app/Main.qml" line="1865"/>
         <source>Write with QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Details unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2352"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2435"/>
+        <source>OK</source>
+        <translation type="unfinished">Va bene</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2396"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2405"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2406"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2408"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2411"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2412"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2414"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2415"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2417"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2418"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2420"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2421"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2424"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2426"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2427"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2446"/>
+        <source>QR code failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2430"/>
+        <source>Could not create the QR code for this item.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2432"/>
+        <source>Setting not saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2433"/>
+        <source>Could not save this setting. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Log upload failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Could not upload the logs. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Favorites</source>
         <translation type="unfinished">Preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
-        <location filename="../app/Main.qml" line="2477"/>
+        <location filename="../app/Main.qml" line="2627"/>
+        <location filename="../app/Main.qml" line="2641"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2495"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2659"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2655"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
+        <location filename="../app/Main.qml" line="2662"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2818"/>
+        <location filename="../app/Main.qml" line="2836"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2658"/>
+        <location filename="../app/Main.qml" line="2822"/>
+        <location filename="../app/Main.qml" line="2839"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="2852"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
-        <source>Error: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Retry</source>
         <translation type="unfinished">Riprova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
-        <translation type="unfinished">Annulla</translation>
+        <translation type="obsolete">Annulla</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3534"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3541"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3543"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>
@@ -874,85 +1027,76 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Writing failed</source>
         <translation>Scrittura non riuscita</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Put a writable card near the reader</source>
         <translation>Avvicina una scheda scrivibile al lettore</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="867"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="868"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="861"/>
-        <location filename="../app/MainLayout.qml" line="877"/>
-        <location filename="../app/MainLayout.qml" line="1186"/>
+        <location filename="../app/MainLayout.qml" line="320"/>
+        <location filename="../app/MainLayout.qml" line="869"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>OK</source>
         <translation type="unfinished">Va bene</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875"/>
-        <source>Random game</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <source>No matching games found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Are you sure you want to exit?</source>
         <translation>Sei sicuro di voler uscire?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1120"/>
-        <location filename="../app/MainLayout.qml" line="1197"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
         <source>Select</source>
         <translation>Seleziona</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1124"/>
-        <location filename="../app/MainLayout.qml" line="1138"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1164"/>
+        <location filename="../app/MainLayout.qml" line="1132"/>
+        <location filename="../app/MainLayout.qml" line="1146"/>
+        <location filename="../app/MainLayout.qml" line="1161"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1198"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1131"/>
-        <location filename="../app/MainLayout.qml" line="1171"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1220"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1149"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
         <source>Done</source>
         <translation>Fatto</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1187"/>
         <source>I understand</source>
         <translation>Ho capito</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1208"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1231"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -961,89 +1105,89 @@ Français - Wilfried</source>
         <translation type="vanished">Avvia</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1433"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Scroll</source>
         <translation>Scorri</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1332"/>
-        <location filename="../app/MainLayout.qml" line="1350"/>
-        <location filename="../app/MainLayout.qml" line="1482"/>
-        <location filename="../app/MainLayout.qml" line="1501"/>
+        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1370"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1521"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1193"/>
-        <location filename="../app/MainLayout.qml" line="1231"/>
-        <location filename="../app/MainLayout.qml" line="1268"/>
-        <location filename="../app/MainLayout.qml" line="1317"/>
-        <location filename="../app/MainLayout.qml" line="1373"/>
-        <location filename="../app/MainLayout.qml" line="1392"/>
-        <location filename="../app/MainLayout.qml" line="1465"/>
+        <location filename="../app/MainLayout.qml" line="1124"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1251"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1337"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1412"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
         <source>Move</source>
         <translation>Muovi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="190"/>
+        <location filename="../app/MainLayout.qml" line="191"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="433"/>
-        <location filename="../app/MainLayout.qml" line="435"/>
+        <location filename="../app/MainLayout.qml" line="440"/>
+        <location filename="../app/MainLayout.qml" line="442"/>
         <source>Favorites</source>
         <translation type="unfinished">Preferiti</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="437"/>
+        <location filename="../app/MainLayout.qml" line="444"/>
         <source>Recently Played</source>
         <translation type="unfinished">Giocati di recente</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="848"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="841"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1235"/>
-        <location filename="../app/MainLayout.qml" line="1273"/>
-        <location filename="../app/MainLayout.qml" line="1322"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
-        <location filename="../app/MainLayout.qml" line="1470"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1293"/>
+        <location filename="../app/MainLayout.qml" line="1342"/>
+        <location filename="../app/MainLayout.qml" line="1398"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1265"/>
         <source>Quit</source>
         <translation>Esci</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1254"/>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1306"/>
-        <location filename="../app/MainLayout.qml" line="1336"/>
-        <location filename="../app/MainLayout.qml" line="1354"/>
-        <location filename="../app/MainLayout.qml" line="1366"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1416"/>
-        <location filename="../app/MainLayout.qml" line="1437"/>
-        <location filename="../app/MainLayout.qml" line="1446"/>
-        <location filename="../app/MainLayout.qml" line="1486"/>
-        <location filename="../app/MainLayout.qml" line="1505"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1310"/>
+        <location filename="../app/MainLayout.qml" line="1326"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1386"/>
+        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1436"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1506"/>
+        <location filename="../app/MainLayout.qml" line="1525"/>
         <source>Back</source>
         <translation>Indietro</translation>
     </message>
@@ -1052,28 +1196,29 @@ Français - Wilfried</source>
         <translation type="vanished">Pagina</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1241"/>
-        <location filename="../app/MainLayout.qml" line="1276"/>
-        <location filename="../app/MainLayout.qml" line="1327"/>
-        <location filename="../app/MainLayout.qml" line="1475"/>
+        <location filename="../app/MainLayout.qml" line="1261"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
+        <location filename="../app/MainLayout.qml" line="1495"/>
         <source>Options</source>
         <translation>Opzioni</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1160"/>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1344"/>
-        <location filename="../app/MainLayout.qml" line="1493"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1364"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
         <source>Retry</source>
         <translation>Riprova</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1401"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Change</source>
         <translation>Cambia</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1407"/>
+        <location filename="../app/MainLayout.qml" line="1427"/>
         <source>Toggle</source>
         <translation>Alterna</translation>
     </message>
@@ -1114,7 +1259,7 @@ Français - Wilfried</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="258"/>
+        <location filename="../components/Modal.qml" line="260"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
@@ -1153,17 +1298,22 @@ Français - Wilfried</source>
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="29"/>
         <source>Nothing here</source>
         <translation>Niente qui</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <source>Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScreenStateOverlay.qml" line="68"/>
         <source>Failed to load</source>
         <translation>Caricamento non riuscito</translation>
     </message>
@@ -1716,24 +1866,24 @@ Français - Wilfried</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="252"/>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="253"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>%1 systems</source>
         <translation>%1 sistemi</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="253"/>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="254"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="399"/>
+        <location filename="../screens/SystemsScreen.qml" line="400"/>
         <source>No systems in this category</source>
         <translation>Nessun sistema in questa categoria</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="400"/>
+        <location filename="../screens/SystemsScreen.qml" line="401"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -686,44 +686,44 @@ Français - Wilfried</source>
         <translation>Avvia gioco</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2579"/>
+        <location filename="../app/Main.qml" line="2581"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2595"/>
-        <location filename="../app/Main.qml" line="2634"/>
-        <location filename="../app/Main.qml" line="2644"/>
+        <location filename="../app/Main.qml" line="2597"/>
+        <location filename="../app/Main.qml" line="2636"/>
+        <location filename="../app/Main.qml" line="2646"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2631"/>
+        <location filename="../app/Main.qml" line="2633"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Card write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Could not write to this card. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3712"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3707"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
@@ -753,8 +753,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2052"/>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2677"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2679"/>
         <source>Default</source>
         <translation type="unfinished">Predefinito</translation>
     </message>
@@ -768,40 +768,40 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1807"/>
         <location filename="../app/Main.qml" line="1824"/>
         <location filename="../app/Main.qml" line="1832"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2587"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2589"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2623"/>
+        <location filename="../app/Main.qml" line="2625"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2595"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2681"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2683"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2608"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2685"/>
+        <location filename="../app/Main.qml" line="2687"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -822,180 +822,180 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2352"/>
-        <location filename="../app/Main.qml" line="2372"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2435"/>
+        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2437"/>
         <source>OK</source>
         <translation type="unfinished">Va bene</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2398"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2405"/>
+        <location filename="../app/Main.qml" line="2407"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2406"/>
+        <location filename="../app/Main.qml" line="2408"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2408"/>
+        <location filename="../app/Main.qml" line="2410"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2413"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2412"/>
+        <location filename="../app/Main.qml" line="2414"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2414"/>
+        <location filename="../app/Main.qml" line="2416"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2417"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2417"/>
+        <location filename="../app/Main.qml" line="2419"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2418"/>
+        <location filename="../app/Main.qml" line="2420"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2420"/>
+        <location filename="../app/Main.qml" line="2422"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2421"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2424"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2428"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2431"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2430"/>
+        <location filename="../app/Main.qml" line="2432"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2432"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2433"/>
+        <location filename="../app/Main.qml" line="2435"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Favorites</source>
         <translation type="unfinished">Preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2627"/>
-        <location filename="../app/Main.qml" line="2641"/>
+        <location filename="../app/Main.qml" line="2629"/>
+        <location filename="../app/Main.qml" line="2643"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2659"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2661"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2657"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2662"/>
+        <location filename="../app/Main.qml" line="2664"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2818"/>
-        <location filename="../app/Main.qml" line="2836"/>
+        <location filename="../app/Main.qml" line="2820"/>
+        <location filename="../app/Main.qml" line="2838"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2822"/>
-        <location filename="../app/Main.qml" line="2839"/>
+        <location filename="../app/Main.qml" line="2824"/>
+        <location filename="../app/Main.qml" line="2841"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2423"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2505"/>
-        <location filename="../app/Main.qml" line="2852"/>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="2507"/>
+        <location filename="../app/Main.qml" line="2854"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Retry</source>
         <translation type="unfinished">Riprova</translation>
     </message>
@@ -1004,22 +1004,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Annulla</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3709"/>
+        <location filename="../app/Main.qml" line="3711"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3714"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3716"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3720"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -683,44 +683,44 @@ Français - Wilfried</source>
         <translation>ゲームを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2579"/>
+        <location filename="../app/Main.qml" line="2581"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2595"/>
-        <location filename="../app/Main.qml" line="2634"/>
-        <location filename="../app/Main.qml" line="2644"/>
+        <location filename="../app/Main.qml" line="2597"/>
+        <location filename="../app/Main.qml" line="2636"/>
+        <location filename="../app/Main.qml" line="2646"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2631"/>
+        <location filename="../app/Main.qml" line="2633"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Card write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Could not write to this card. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3712"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3707"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
@@ -750,8 +750,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2052"/>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2677"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2679"/>
         <source>Default</source>
         <translation type="unfinished">デフォルト</translation>
     </message>
@@ -765,40 +765,40 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1807"/>
         <location filename="../app/Main.qml" line="1824"/>
         <location filename="../app/Main.qml" line="1832"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2587"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2589"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2623"/>
+        <location filename="../app/Main.qml" line="2625"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2595"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2681"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2683"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2608"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2685"/>
+        <location filename="../app/Main.qml" line="2687"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -819,180 +819,180 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2352"/>
-        <location filename="../app/Main.qml" line="2372"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2435"/>
+        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2437"/>
         <source>OK</source>
         <translation type="unfinished">決定</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2398"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2405"/>
+        <location filename="../app/Main.qml" line="2407"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2406"/>
+        <location filename="../app/Main.qml" line="2408"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2408"/>
+        <location filename="../app/Main.qml" line="2410"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2413"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2412"/>
+        <location filename="../app/Main.qml" line="2414"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2414"/>
+        <location filename="../app/Main.qml" line="2416"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2417"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2417"/>
+        <location filename="../app/Main.qml" line="2419"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2418"/>
+        <location filename="../app/Main.qml" line="2420"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2420"/>
+        <location filename="../app/Main.qml" line="2422"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2421"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2424"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2428"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2431"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2430"/>
+        <location filename="../app/Main.qml" line="2432"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2432"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2433"/>
+        <location filename="../app/Main.qml" line="2435"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Favorites</source>
         <translation type="unfinished">お気に入り</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2627"/>
-        <location filename="../app/Main.qml" line="2641"/>
+        <location filename="../app/Main.qml" line="2629"/>
+        <location filename="../app/Main.qml" line="2643"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2659"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2661"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2657"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2662"/>
+        <location filename="../app/Main.qml" line="2664"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2818"/>
-        <location filename="../app/Main.qml" line="2836"/>
+        <location filename="../app/Main.qml" line="2820"/>
+        <location filename="../app/Main.qml" line="2838"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2822"/>
-        <location filename="../app/Main.qml" line="2839"/>
+        <location filename="../app/Main.qml" line="2824"/>
+        <location filename="../app/Main.qml" line="2841"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2423"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2505"/>
-        <location filename="../app/Main.qml" line="2852"/>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="2507"/>
+        <location filename="../app/Main.qml" line="2854"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Retry</source>
         <translation type="unfinished">再試行</translation>
     </message>
@@ -1001,22 +1001,22 @@ Français - Wilfried</source>
         <translation type="obsolete">キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3709"/>
+        <location filename="../app/Main.qml" line="3711"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3714"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3716"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3720"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -475,6 +475,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/GameInfoModal.qml" line="120"/>
+        <source>Could not load details. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/GameInfoModal.qml" line="169"/>
         <source>Loading image…</source>
         <translation type="unfinished"></translation>
@@ -543,27 +548,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="202"/>
+        <location filename="../screens/HubScreen.qml" line="203"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="209"/>
+        <location filename="../screens/HubScreen.qml" line="210"/>
         <source>Favorites</source>
         <translation>お気に入り</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="215"/>
+        <location filename="../screens/HubScreen.qml" line="216"/>
         <source>Recently Played</source>
         <translation>最近プレイしたゲーム</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="222"/>
+        <location filename="../screens/HubScreen.qml" line="223"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="229"/>
+        <location filename="../screens/HubScreen.qml" line="230"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -572,7 +577,7 @@ Français - Wilfried</source>
         <translation type="vanished">設定</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="816"/>
+        <location filename="../screens/HubScreen.qml" line="821"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>利用可能なシステムがありません。設定からメディアデータベースの更新を実行してください。</translation>
     </message>
@@ -617,13 +622,16 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="197"/>
-        <source>Upload failed: %1</source>
-        <translation>アップロード失敗: %1</translation>
+        <source>Upload failed. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197"/>
+        <source>Upload failed: %1</source>
+        <translation type="vanished">アップロード失敗: %1</translation>
+    </message>
+    <message>
         <source>Upload failed.</source>
-        <translation>アップロードに失敗しました。</translation>
+        <translation type="vanished">アップロードに失敗しました。</translation>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="227"/>
@@ -639,28 +647,28 @@ Français - Wilfried</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1746"/>
+        <location filename="../app/Main.qml" line="1757"/>
         <source>Launch core</source>
         <translation>コアを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1760"/>
-        <location filename="../app/Main.qml" line="2045"/>
+        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="2056"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Remove from favorites</source>
         <translation>お気に入りから削除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Add to favorites</source>
         <translation>お気に入りに追加</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1850"/>
+        <location filename="../app/Main.qml" line="1861"/>
         <source>Write to NFC token</source>
         <translation>NFC トークンに書き込む</translation>
     </message>
@@ -669,201 +677,346 @@ Français - Wilfried</source>
         <translation type="vanished">QR コード</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1829"/>
-        <location filename="../app/Main.qml" line="1864"/>
+        <location filename="../app/Main.qml" line="1840"/>
+        <location filename="../app/Main.qml" line="1875"/>
         <source>Launch game</source>
         <translation>ゲームを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2579"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2431"/>
-        <location filename="../app/Main.qml" line="2470"/>
-        <location filename="../app/Main.qml" line="2480"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2634"/>
+        <location filename="../app/Main.qml" line="2644"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2467"/>
+        <location filename="../app/Main.qml" line="2631"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3530"/>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Card write failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Could not write to this card. Check that it is writable and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3705"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3712"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1767"/>
-        <location filename="../app/Main.qml" line="1801"/>
+        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="1812"/>
         <source>Update media database</source>
         <translation type="unfinished">メディアデータベースを更新</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1770"/>
-        <location filename="../app/Main.qml" line="1804"/>
+        <location filename="../app/Main.qml" line="1781"/>
+        <location filename="../app/Main.qml" line="1815"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">メタデータをスクレイピング</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2052"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2677"/>
         <source>Default</source>
         <translation type="unfinished">デフォルト</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
+        <location filename="../app/Main.qml" line="2052"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1755"/>
-        <location filename="../app/Main.qml" line="1796"/>
-        <location filename="../app/Main.qml" line="1813"/>
-        <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="1766"/>
+        <location filename="../app/Main.qml" line="1807"/>
+        <location filename="../app/Main.qml" line="1824"/>
+        <location filename="../app/Main.qml" line="1832"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2587"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
+        <location filename="../app/Main.qml" line="2623"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2593"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2681"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2606"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2521"/>
+        <location filename="../app/Main.qml" line="2685"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2450"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1854"/>
+        <location filename="../app/Main.qml" line="1865"/>
         <source>Write with QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Details unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2352"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2435"/>
+        <source>OK</source>
+        <translation type="unfinished">決定</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2396"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2405"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2406"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2408"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2411"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2412"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2414"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2415"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2417"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2418"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2420"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2421"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2424"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2426"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2427"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2446"/>
+        <source>QR code failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2430"/>
+        <source>Could not create the QR code for this item.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2432"/>
+        <source>Setting not saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2433"/>
+        <source>Could not save this setting. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Log upload failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Could not upload the logs. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Favorites</source>
         <translation type="unfinished">お気に入り</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
-        <location filename="../app/Main.qml" line="2477"/>
+        <location filename="../app/Main.qml" line="2627"/>
+        <location filename="../app/Main.qml" line="2641"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2495"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2659"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2655"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
+        <location filename="../app/Main.qml" line="2662"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2818"/>
+        <location filename="../app/Main.qml" line="2836"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2658"/>
+        <location filename="../app/Main.qml" line="2822"/>
+        <location filename="../app/Main.qml" line="2839"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="2852"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
-        <source>Error: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Retry</source>
         <translation type="unfinished">再試行</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
-        <translation type="unfinished">キャンセル</translation>
+        <translation type="obsolete">キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3534"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3541"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3543"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>
@@ -871,85 +1024,76 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Writing failed</source>
         <translation>書き込み失敗</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Put a writable card near the reader</source>
         <translation>書き込み可能なカードをリーダーに近づけてください</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="867"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="868"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="861"/>
-        <location filename="../app/MainLayout.qml" line="877"/>
-        <location filename="../app/MainLayout.qml" line="1186"/>
+        <location filename="../app/MainLayout.qml" line="320"/>
+        <location filename="../app/MainLayout.qml" line="869"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>OK</source>
         <translation type="unfinished">決定</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875"/>
-        <source>Random game</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <source>No matching games found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Are you sure you want to exit?</source>
         <translation>本当に終了しますか？</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1120"/>
-        <location filename="../app/MainLayout.qml" line="1197"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
         <source>Select</source>
         <translation>選択</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1124"/>
-        <location filename="../app/MainLayout.qml" line="1138"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1164"/>
+        <location filename="../app/MainLayout.qml" line="1132"/>
+        <location filename="../app/MainLayout.qml" line="1146"/>
+        <location filename="../app/MainLayout.qml" line="1161"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1198"/>
         <source>Close</source>
         <translation>閉じる</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1131"/>
-        <location filename="../app/MainLayout.qml" line="1171"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1220"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1149"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
         <source>Done</source>
         <translation>完了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1187"/>
         <source>I understand</source>
         <translation>了解しました</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1208"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1231"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -958,89 +1102,89 @@ Français - Wilfried</source>
         <translation type="vanished">開始</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1433"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Scroll</source>
         <translation>スクロール</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1332"/>
-        <location filename="../app/MainLayout.qml" line="1350"/>
-        <location filename="../app/MainLayout.qml" line="1482"/>
-        <location filename="../app/MainLayout.qml" line="1501"/>
+        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1370"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1521"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1193"/>
-        <location filename="../app/MainLayout.qml" line="1231"/>
-        <location filename="../app/MainLayout.qml" line="1268"/>
-        <location filename="../app/MainLayout.qml" line="1317"/>
-        <location filename="../app/MainLayout.qml" line="1373"/>
-        <location filename="../app/MainLayout.qml" line="1392"/>
-        <location filename="../app/MainLayout.qml" line="1465"/>
+        <location filename="../app/MainLayout.qml" line="1124"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1251"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1337"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1412"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
         <source>Move</source>
         <translation>移動</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="190"/>
+        <location filename="../app/MainLayout.qml" line="191"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="433"/>
-        <location filename="../app/MainLayout.qml" line="435"/>
+        <location filename="../app/MainLayout.qml" line="440"/>
+        <location filename="../app/MainLayout.qml" line="442"/>
         <source>Favorites</source>
         <translation type="unfinished">お気に入り</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="437"/>
+        <location filename="../app/MainLayout.qml" line="444"/>
         <source>Recently Played</source>
         <translation type="unfinished">最近プレイしたゲーム</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="848"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="841"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1235"/>
-        <location filename="../app/MainLayout.qml" line="1273"/>
-        <location filename="../app/MainLayout.qml" line="1322"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
-        <location filename="../app/MainLayout.qml" line="1470"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1293"/>
+        <location filename="../app/MainLayout.qml" line="1342"/>
+        <location filename="../app/MainLayout.qml" line="1398"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
         <source>Open</source>
         <translation>開く</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1265"/>
         <source>Quit</source>
         <translation>終了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1254"/>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1306"/>
-        <location filename="../app/MainLayout.qml" line="1336"/>
-        <location filename="../app/MainLayout.qml" line="1354"/>
-        <location filename="../app/MainLayout.qml" line="1366"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1416"/>
-        <location filename="../app/MainLayout.qml" line="1437"/>
-        <location filename="../app/MainLayout.qml" line="1446"/>
-        <location filename="../app/MainLayout.qml" line="1486"/>
-        <location filename="../app/MainLayout.qml" line="1505"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1310"/>
+        <location filename="../app/MainLayout.qml" line="1326"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1386"/>
+        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1436"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1506"/>
+        <location filename="../app/MainLayout.qml" line="1525"/>
         <source>Back</source>
         <translation>戻る</translation>
     </message>
@@ -1049,28 +1193,29 @@ Français - Wilfried</source>
         <translation type="vanished">ページ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1241"/>
-        <location filename="../app/MainLayout.qml" line="1276"/>
-        <location filename="../app/MainLayout.qml" line="1327"/>
-        <location filename="../app/MainLayout.qml" line="1475"/>
+        <location filename="../app/MainLayout.qml" line="1261"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
+        <location filename="../app/MainLayout.qml" line="1495"/>
         <source>Options</source>
         <translation>オプション</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1160"/>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1344"/>
-        <location filename="../app/MainLayout.qml" line="1493"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1364"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
         <source>Retry</source>
         <translation>再試行</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1401"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Change</source>
         <translation>変更</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1407"/>
+        <location filename="../app/MainLayout.qml" line="1427"/>
         <source>Toggle</source>
         <translation>切り替え</translation>
     </message>
@@ -1111,7 +1256,7 @@ Français - Wilfried</source>
         <translation>いいえ</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="258"/>
+        <location filename="../components/Modal.qml" line="260"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
@@ -1150,17 +1295,22 @@ Français - Wilfried</source>
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="29"/>
         <source>Nothing here</source>
         <translation>ここには何もありません</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <source>Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScreenStateOverlay.qml" line="68"/>
         <source>Failed to load</source>
         <translation>読み込みに失敗しました</translation>
     </message>
@@ -1713,24 +1863,24 @@ Français - Wilfried</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="252"/>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="253"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>%1 systems</source>
         <translation>%1 システム</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="253"/>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="254"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="399"/>
+        <location filename="../screens/SystemsScreen.qml" line="400"/>
         <source>No systems in this category</source>
         <translation>このカテゴリにシステムはありません</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="400"/>
+        <location filename="../screens/SystemsScreen.qml" line="401"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -708,8 +708,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2052"/>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2677"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2679"/>
         <source>Default</source>
         <translation type="unfinished">기본값</translation>
     </message>
@@ -719,7 +719,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2579"/>
+        <location filename="../app/Main.qml" line="2581"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -728,53 +728,53 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1807"/>
         <location filename="../app/Main.qml" line="1824"/>
         <location filename="../app/Main.qml" line="1832"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2587"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2589"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Favorites</source>
         <translation type="unfinished">즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2595"/>
-        <location filename="../app/Main.qml" line="2634"/>
-        <location filename="../app/Main.qml" line="2644"/>
+        <location filename="../app/Main.qml" line="2597"/>
+        <location filename="../app/Main.qml" line="2636"/>
+        <location filename="../app/Main.qml" line="2646"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2623"/>
+        <location filename="../app/Main.qml" line="2625"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2595"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2681"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2683"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2608"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2685"/>
+        <location filename="../app/Main.qml" line="2687"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -795,189 +795,189 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2352"/>
-        <location filename="../app/Main.qml" line="2372"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2435"/>
+        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2437"/>
         <source>OK</source>
         <translation type="unfinished">확인</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2398"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2405"/>
+        <location filename="../app/Main.qml" line="2407"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2406"/>
+        <location filename="../app/Main.qml" line="2408"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2408"/>
+        <location filename="../app/Main.qml" line="2410"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2413"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2412"/>
+        <location filename="../app/Main.qml" line="2414"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2414"/>
+        <location filename="../app/Main.qml" line="2416"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2417"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2417"/>
+        <location filename="../app/Main.qml" line="2419"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2418"/>
+        <location filename="../app/Main.qml" line="2420"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2420"/>
+        <location filename="../app/Main.qml" line="2422"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2421"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2424"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2428"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2431"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2430"/>
+        <location filename="../app/Main.qml" line="2432"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2432"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2433"/>
+        <location filename="../app/Main.qml" line="2435"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2627"/>
-        <location filename="../app/Main.qml" line="2641"/>
+        <location filename="../app/Main.qml" line="2629"/>
+        <location filename="../app/Main.qml" line="2643"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2631"/>
+        <location filename="../app/Main.qml" line="2633"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2659"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2661"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2657"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2662"/>
+        <location filename="../app/Main.qml" line="2664"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2818"/>
-        <location filename="../app/Main.qml" line="2836"/>
+        <location filename="../app/Main.qml" line="2820"/>
+        <location filename="../app/Main.qml" line="2838"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2822"/>
-        <location filename="../app/Main.qml" line="2839"/>
+        <location filename="../app/Main.qml" line="2824"/>
+        <location filename="../app/Main.qml" line="2841"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Card write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Could not write to this card. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2423"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2505"/>
-        <location filename="../app/Main.qml" line="2852"/>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="2507"/>
+        <location filename="../app/Main.qml" line="2854"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Retry</source>
         <translation type="unfinished">다시 시도</translation>
     </message>
@@ -986,37 +986,37 @@ Français - Wilfried</source>
         <translation type="obsolete">취소</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3707"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3709"/>
+        <location filename="../app/Main.qml" line="3711"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3712"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3714"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3716"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3720"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -475,6 +475,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/GameInfoModal.qml" line="120"/>
+        <source>Could not load details. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/GameInfoModal.qml" line="169"/>
         <source>Loading image…</source>
         <translation type="unfinished"></translation>
@@ -543,27 +548,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="202"/>
+        <location filename="../screens/HubScreen.qml" line="203"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="209"/>
+        <location filename="../screens/HubScreen.qml" line="210"/>
         <source>Favorites</source>
         <translation>즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="215"/>
+        <location filename="../screens/HubScreen.qml" line="216"/>
         <source>Recently Played</source>
         <translation>최근 플레이</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="222"/>
+        <location filename="../screens/HubScreen.qml" line="223"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="229"/>
+        <location filename="../screens/HubScreen.qml" line="230"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -572,7 +577,7 @@ Français - Wilfried</source>
         <translation type="vanished">설정</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="816"/>
+        <location filename="../screens/HubScreen.qml" line="821"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>사용 가능한 시스템이 없습니다. 설정에서 미디어 데이터베이스 업데이트를 실행하세요.</translation>
     </message>
@@ -617,13 +622,16 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="197"/>
-        <source>Upload failed: %1</source>
-        <translation>업로드 실패: %1</translation>
+        <source>Upload failed. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197"/>
+        <source>Upload failed: %1</source>
+        <translation type="vanished">업로드 실패: %1</translation>
+    </message>
+    <message>
         <source>Upload failed.</source>
-        <translation>업로드 실패.</translation>
+        <translation type="vanished">업로드 실패.</translation>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="227"/>
@@ -639,58 +647,58 @@ Français - Wilfried</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1746"/>
+        <location filename="../app/Main.qml" line="1757"/>
         <source>Launch core</source>
         <translation>코어 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1760"/>
-        <location filename="../app/Main.qml" line="2045"/>
+        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="2056"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1767"/>
-        <location filename="../app/Main.qml" line="1801"/>
+        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="1812"/>
         <source>Update media database</source>
         <translation type="unfinished">미디어 데이터베이스 업데이트</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1770"/>
-        <location filename="../app/Main.qml" line="1804"/>
+        <location filename="../app/Main.qml" line="1781"/>
+        <location filename="../app/Main.qml" line="1815"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">메타데이터 수집</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1829"/>
-        <location filename="../app/Main.qml" line="1864"/>
+        <location filename="../app/Main.qml" line="1840"/>
+        <location filename="../app/Main.qml" line="1875"/>
         <source>Launch game</source>
         <translation>게임 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Remove from favorites</source>
         <translation>즐겨찾기에서 제거</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Add to favorites</source>
         <translation>즐겨찾기에 추가</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1850"/>
+        <location filename="../app/Main.qml" line="1861"/>
         <source>Write to NFC token</source>
         <translation>NFC 토큰에 쓰기</translation>
     </message>
@@ -699,171 +707,316 @@ Français - Wilfried</source>
         <translation type="vanished">QR 코드</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2052"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2677"/>
         <source>Default</source>
         <translation type="unfinished">기본값</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
+        <location filename="../app/Main.qml" line="2052"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2579"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1755"/>
-        <location filename="../app/Main.qml" line="1796"/>
-        <location filename="../app/Main.qml" line="1813"/>
-        <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="1766"/>
+        <location filename="../app/Main.qml" line="1807"/>
+        <location filename="../app/Main.qml" line="1824"/>
+        <location filename="../app/Main.qml" line="1832"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2587"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2446"/>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Favorites</source>
         <translation type="unfinished">즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2431"/>
-        <location filename="../app/Main.qml" line="2470"/>
-        <location filename="../app/Main.qml" line="2480"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2634"/>
+        <location filename="../app/Main.qml" line="2644"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
+        <location filename="../app/Main.qml" line="2623"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2593"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2681"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2606"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2521"/>
+        <location filename="../app/Main.qml" line="2685"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2450"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1854"/>
+        <location filename="../app/Main.qml" line="1865"/>
         <source>Write with QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
-        <location filename="../app/Main.qml" line="2477"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Details unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2352"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2435"/>
+        <source>OK</source>
+        <translation type="unfinished">확인</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2396"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2405"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2406"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2408"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2411"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2412"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2414"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2415"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2417"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2418"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2420"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2421"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2424"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2426"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2427"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2429"/>
+        <source>QR code failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2430"/>
+        <source>Could not create the QR code for this item.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2432"/>
+        <source>Setting not saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2433"/>
+        <source>Could not save this setting. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Log upload failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Could not upload the logs. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2627"/>
+        <location filename="../app/Main.qml" line="2641"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2467"/>
+        <location filename="../app/Main.qml" line="2631"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2495"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2659"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2655"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
+        <location filename="../app/Main.qml" line="2662"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2818"/>
+        <location filename="../app/Main.qml" line="2836"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2658"/>
+        <location filename="../app/Main.qml" line="2822"/>
+        <location filename="../app/Main.qml" line="2839"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Card write failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Could not write to this card. Check that it is writable and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="2852"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
-        <source>Error: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Retry</source>
         <translation type="unfinished">다시 시도</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
-        <translation type="unfinished">취소</translation>
+        <translation type="obsolete">취소</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3530"/>
+        <location filename="../app/Main.qml" line="3705"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3534"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3712"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3541"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3543"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>
@@ -871,136 +1024,128 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Writing failed</source>
         <translation>쓰기 실패</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Put a writable card near the reader</source>
         <translation>기록 가능한 카드를 리더 근처에 놓으세요</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="190"/>
+        <location filename="../app/MainLayout.qml" line="191"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="433"/>
-        <location filename="../app/MainLayout.qml" line="435"/>
+        <location filename="../app/MainLayout.qml" line="440"/>
+        <location filename="../app/MainLayout.qml" line="442"/>
         <source>Favorites</source>
         <translation type="unfinished">즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="437"/>
+        <location filename="../app/MainLayout.qml" line="444"/>
         <source>Recently Played</source>
         <translation type="unfinished">최근 플레이</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="848"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="841"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="867"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="868"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="861"/>
-        <location filename="../app/MainLayout.qml" line="877"/>
-        <location filename="../app/MainLayout.qml" line="1186"/>
+        <location filename="../app/MainLayout.qml" line="320"/>
+        <location filename="../app/MainLayout.qml" line="869"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>OK</source>
         <translation type="unfinished">확인</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875"/>
-        <source>Random game</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <source>No matching games found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Are you sure you want to exit?</source>
         <translation>정말 종료하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1193"/>
-        <location filename="../app/MainLayout.qml" line="1231"/>
-        <location filename="../app/MainLayout.qml" line="1268"/>
-        <location filename="../app/MainLayout.qml" line="1317"/>
-        <location filename="../app/MainLayout.qml" line="1373"/>
-        <location filename="../app/MainLayout.qml" line="1392"/>
-        <location filename="../app/MainLayout.qml" line="1465"/>
+        <location filename="../app/MainLayout.qml" line="1124"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1251"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1337"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1412"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
         <source>Move</source>
         <translation>이동</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1120"/>
-        <location filename="../app/MainLayout.qml" line="1197"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
         <source>Select</source>
         <translation>선택</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1124"/>
-        <location filename="../app/MainLayout.qml" line="1138"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1164"/>
+        <location filename="../app/MainLayout.qml" line="1132"/>
+        <location filename="../app/MainLayout.qml" line="1146"/>
+        <location filename="../app/MainLayout.qml" line="1161"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1198"/>
         <source>Close</source>
         <translation>닫기</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1131"/>
-        <location filename="../app/MainLayout.qml" line="1171"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1220"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1149"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
         <source>Done</source>
         <translation>완료</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1160"/>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1344"/>
-        <location filename="../app/MainLayout.qml" line="1493"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1364"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
         <source>Retry</source>
         <translation>다시 시도</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1187"/>
         <source>I understand</source>
         <translation>이해했습니다</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1208"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1231"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1009,41 +1154,41 @@ Français - Wilfried</source>
         <translation type="vanished">시작</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1235"/>
-        <location filename="../app/MainLayout.qml" line="1273"/>
-        <location filename="../app/MainLayout.qml" line="1322"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
-        <location filename="../app/MainLayout.qml" line="1470"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1293"/>
+        <location filename="../app/MainLayout.qml" line="1342"/>
+        <location filename="../app/MainLayout.qml" line="1398"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
         <source>Open</source>
         <translation>열기</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1265"/>
         <source>Quit</source>
         <translation>종료</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1254"/>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1306"/>
-        <location filename="../app/MainLayout.qml" line="1336"/>
-        <location filename="../app/MainLayout.qml" line="1354"/>
-        <location filename="../app/MainLayout.qml" line="1366"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1416"/>
-        <location filename="../app/MainLayout.qml" line="1437"/>
-        <location filename="../app/MainLayout.qml" line="1446"/>
-        <location filename="../app/MainLayout.qml" line="1486"/>
-        <location filename="../app/MainLayout.qml" line="1505"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1310"/>
+        <location filename="../app/MainLayout.qml" line="1326"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1386"/>
+        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1436"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1506"/>
+        <location filename="../app/MainLayout.qml" line="1525"/>
         <source>Back</source>
         <translation>뒤로</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1332"/>
-        <location filename="../app/MainLayout.qml" line="1350"/>
-        <location filename="../app/MainLayout.qml" line="1482"/>
-        <location filename="../app/MainLayout.qml" line="1501"/>
+        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1370"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1521"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1052,25 +1197,25 @@ Français - Wilfried</source>
         <translation type="vanished">페이지</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1241"/>
-        <location filename="../app/MainLayout.qml" line="1276"/>
-        <location filename="../app/MainLayout.qml" line="1327"/>
-        <location filename="../app/MainLayout.qml" line="1475"/>
+        <location filename="../app/MainLayout.qml" line="1261"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
+        <location filename="../app/MainLayout.qml" line="1495"/>
         <source>Options</source>
         <translation>옵션</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1401"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Change</source>
         <translation>변경</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1407"/>
+        <location filename="../app/MainLayout.qml" line="1427"/>
         <source>Toggle</source>
         <translation>전환</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1433"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Scroll</source>
         <translation>스크롤</translation>
     </message>
@@ -1111,7 +1256,7 @@ Français - Wilfried</source>
         <translation>아니요</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="258"/>
+        <location filename="../components/Modal.qml" line="260"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
@@ -1150,17 +1295,22 @@ Français - Wilfried</source>
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="29"/>
         <source>Nothing here</source>
         <translation>여기에 아무것도 없습니다</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <source>Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScreenStateOverlay.qml" line="68"/>
         <source>Failed to load</source>
         <translation>불러오지 못했습니다</translation>
     </message>
@@ -1713,24 +1863,24 @@ Français - Wilfried</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="252"/>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="253"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>%1 systems</source>
         <translation>시스템 %1개</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="253"/>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="254"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="399"/>
+        <location filename="../screens/SystemsScreen.qml" line="400"/>
         <source>No systems in this category</source>
         <translation>이 카테고리에는 시스템이 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="400"/>
+        <location filename="../screens/SystemsScreen.qml" line="401"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -478,6 +478,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/GameInfoModal.qml" line="120"/>
+        <source>Could not load details. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/GameInfoModal.qml" line="169"/>
         <source>Loading image…</source>
         <translation type="unfinished"></translation>
@@ -546,27 +551,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="202"/>
+        <location filename="../screens/HubScreen.qml" line="203"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="209"/>
+        <location filename="../screens/HubScreen.qml" line="210"/>
         <source>Favorites</source>
         <translation>Favorieten</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="215"/>
+        <location filename="../screens/HubScreen.qml" line="216"/>
         <source>Recently Played</source>
         <translation>Recent gespeeld</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="222"/>
+        <location filename="../screens/HubScreen.qml" line="223"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="229"/>
+        <location filename="../screens/HubScreen.qml" line="230"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,7 +580,7 @@ Français - Wilfried</source>
         <translation type="vanished">Instellingen</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="816"/>
+        <location filename="../screens/HubScreen.qml" line="821"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Geen systemen beschikbaar. Voer Database bijwerken uit via Instellingen.</translation>
     </message>
@@ -620,13 +625,16 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="197"/>
-        <source>Upload failed: %1</source>
-        <translation>Upload mislukt: %1</translation>
+        <source>Upload failed. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197"/>
+        <source>Upload failed: %1</source>
+        <translation type="vanished">Upload mislukt: %1</translation>
+    </message>
+    <message>
         <source>Upload failed.</source>
-        <translation>Upload mislukt.</translation>
+        <translation type="vanished">Upload mislukt.</translation>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="227"/>
@@ -642,28 +650,28 @@ Français - Wilfried</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1746"/>
+        <location filename="../app/Main.qml" line="1757"/>
         <source>Launch core</source>
         <translation>Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1760"/>
-        <location filename="../app/Main.qml" line="2045"/>
+        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="2056"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Remove from favorites</source>
         <translation>Uit favorieten verwijderen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Add to favorites</source>
         <translation>Aan favorieten toevoegen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1850"/>
+        <location filename="../app/Main.qml" line="1861"/>
         <source>Write to NFC token</source>
         <translation>Naar NFC-token schrijven</translation>
     </message>
@@ -672,201 +680,346 @@ Français - Wilfried</source>
         <translation type="vanished">QR-code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1829"/>
-        <location filename="../app/Main.qml" line="1864"/>
+        <location filename="../app/Main.qml" line="1840"/>
+        <location filename="../app/Main.qml" line="1875"/>
         <source>Launch game</source>
         <translation>Game starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2579"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2431"/>
-        <location filename="../app/Main.qml" line="2470"/>
-        <location filename="../app/Main.qml" line="2480"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2634"/>
+        <location filename="../app/Main.qml" line="2644"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2467"/>
+        <location filename="../app/Main.qml" line="2631"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3530"/>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Card write failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Could not write to this card. Check that it is writable and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3705"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3712"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1767"/>
-        <location filename="../app/Main.qml" line="1801"/>
+        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="1812"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediadatabase bijwerken</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1770"/>
-        <location filename="../app/Main.qml" line="1804"/>
+        <location filename="../app/Main.qml" line="1781"/>
+        <location filename="../app/Main.qml" line="1815"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadata ophalen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2052"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2677"/>
         <source>Default</source>
         <translation type="unfinished">Standaard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
+        <location filename="../app/Main.qml" line="2052"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1755"/>
-        <location filename="../app/Main.qml" line="1796"/>
-        <location filename="../app/Main.qml" line="1813"/>
-        <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="1766"/>
+        <location filename="../app/Main.qml" line="1807"/>
+        <location filename="../app/Main.qml" line="1824"/>
+        <location filename="../app/Main.qml" line="1832"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2587"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
+        <location filename="../app/Main.qml" line="2623"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2593"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2681"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2606"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2521"/>
+        <location filename="../app/Main.qml" line="2685"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2450"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1854"/>
+        <location filename="../app/Main.qml" line="1865"/>
         <source>Write with QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Details unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2352"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2435"/>
+        <source>OK</source>
+        <translation type="unfinished">Akkoord</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2396"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2405"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2406"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2408"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2411"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2412"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2414"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2415"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2417"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2418"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2420"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2421"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2424"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2426"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2427"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2446"/>
+        <source>QR code failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2430"/>
+        <source>Could not create the QR code for this item.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2432"/>
+        <source>Setting not saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2433"/>
+        <source>Could not save this setting. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Log upload failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Could not upload the logs. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorieten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
-        <location filename="../app/Main.qml" line="2477"/>
+        <location filename="../app/Main.qml" line="2627"/>
+        <location filename="../app/Main.qml" line="2641"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2495"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2659"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2655"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
+        <location filename="../app/Main.qml" line="2662"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2818"/>
+        <location filename="../app/Main.qml" line="2836"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2658"/>
+        <location filename="../app/Main.qml" line="2822"/>
+        <location filename="../app/Main.qml" line="2839"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="2852"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
-        <source>Error: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Retry</source>
         <translation type="unfinished">Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
-        <translation type="unfinished">Annuleren</translation>
+        <translation type="obsolete">Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3534"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3541"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3543"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>
@@ -874,85 +1027,76 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Writing failed</source>
         <translation>Schrijven mislukt</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Put a writable card near the reader</source>
         <translation>Houd een beschrijfbare kaart bij de lezer</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="867"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="868"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="861"/>
-        <location filename="../app/MainLayout.qml" line="877"/>
-        <location filename="../app/MainLayout.qml" line="1186"/>
+        <location filename="../app/MainLayout.qml" line="320"/>
+        <location filename="../app/MainLayout.qml" line="869"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>OK</source>
         <translation type="unfinished">Akkoord</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875"/>
-        <source>Random game</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <source>No matching games found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Are you sure you want to exit?</source>
         <translation>Weet u zeker dat u wilt afsluiten?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1120"/>
-        <location filename="../app/MainLayout.qml" line="1197"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
         <source>Select</source>
         <translation>Selecteren</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1124"/>
-        <location filename="../app/MainLayout.qml" line="1138"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1164"/>
+        <location filename="../app/MainLayout.qml" line="1132"/>
+        <location filename="../app/MainLayout.qml" line="1146"/>
+        <location filename="../app/MainLayout.qml" line="1161"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1198"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1131"/>
-        <location filename="../app/MainLayout.qml" line="1171"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1220"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1149"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
         <source>Done</source>
         <translation>Klaar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1187"/>
         <source>I understand</source>
         <translation>Ik begrijp het</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1208"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1231"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -961,89 +1105,89 @@ Français - Wilfried</source>
         <translation type="vanished">Starten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1433"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Scroll</source>
         <translation>Scrollen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1332"/>
-        <location filename="../app/MainLayout.qml" line="1350"/>
-        <location filename="../app/MainLayout.qml" line="1482"/>
-        <location filename="../app/MainLayout.qml" line="1501"/>
+        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1370"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1521"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1193"/>
-        <location filename="../app/MainLayout.qml" line="1231"/>
-        <location filename="../app/MainLayout.qml" line="1268"/>
-        <location filename="../app/MainLayout.qml" line="1317"/>
-        <location filename="../app/MainLayout.qml" line="1373"/>
-        <location filename="../app/MainLayout.qml" line="1392"/>
-        <location filename="../app/MainLayout.qml" line="1465"/>
+        <location filename="../app/MainLayout.qml" line="1124"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1251"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1337"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1412"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="190"/>
+        <location filename="../app/MainLayout.qml" line="191"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="433"/>
-        <location filename="../app/MainLayout.qml" line="435"/>
+        <location filename="../app/MainLayout.qml" line="440"/>
+        <location filename="../app/MainLayout.qml" line="442"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorieten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="437"/>
+        <location filename="../app/MainLayout.qml" line="444"/>
         <source>Recently Played</source>
         <translation type="unfinished">Recent gespeeld</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="848"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="841"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1235"/>
-        <location filename="../app/MainLayout.qml" line="1273"/>
-        <location filename="../app/MainLayout.qml" line="1322"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
-        <location filename="../app/MainLayout.qml" line="1470"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1293"/>
+        <location filename="../app/MainLayout.qml" line="1342"/>
+        <location filename="../app/MainLayout.qml" line="1398"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
         <source>Open</source>
         <translation>Openen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1265"/>
         <source>Quit</source>
         <translation>Afsluiten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1254"/>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1306"/>
-        <location filename="../app/MainLayout.qml" line="1336"/>
-        <location filename="../app/MainLayout.qml" line="1354"/>
-        <location filename="../app/MainLayout.qml" line="1366"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1416"/>
-        <location filename="../app/MainLayout.qml" line="1437"/>
-        <location filename="../app/MainLayout.qml" line="1446"/>
-        <location filename="../app/MainLayout.qml" line="1486"/>
-        <location filename="../app/MainLayout.qml" line="1505"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1310"/>
+        <location filename="../app/MainLayout.qml" line="1326"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1386"/>
+        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1436"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1506"/>
+        <location filename="../app/MainLayout.qml" line="1525"/>
         <source>Back</source>
         <translation>Terug</translation>
     </message>
@@ -1052,28 +1196,29 @@ Français - Wilfried</source>
         <translation type="vanished">Pagina</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1241"/>
-        <location filename="../app/MainLayout.qml" line="1276"/>
-        <location filename="../app/MainLayout.qml" line="1327"/>
-        <location filename="../app/MainLayout.qml" line="1475"/>
+        <location filename="../app/MainLayout.qml" line="1261"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
+        <location filename="../app/MainLayout.qml" line="1495"/>
         <source>Options</source>
         <translation>Opties</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1160"/>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1344"/>
-        <location filename="../app/MainLayout.qml" line="1493"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1364"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
         <source>Retry</source>
         <translation>Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1401"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Change</source>
         <translation>Wijzigen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1407"/>
+        <location filename="../app/MainLayout.qml" line="1427"/>
         <source>Toggle</source>
         <translation>Schakelen</translation>
     </message>
@@ -1114,7 +1259,7 @@ Français - Wilfried</source>
         <translation>Nee</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="258"/>
+        <location filename="../components/Modal.qml" line="260"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
@@ -1153,17 +1298,22 @@ Français - Wilfried</source>
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="29"/>
         <source>Nothing here</source>
         <translation>Niets hier</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <source>Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScreenStateOverlay.qml" line="68"/>
         <source>Failed to load</source>
         <translation>Laden mislukt</translation>
     </message>
@@ -1716,24 +1866,24 @@ Français - Wilfried</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="252"/>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="253"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>%1 systems</source>
         <translation>%1 systemen</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="253"/>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="254"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="399"/>
+        <location filename="../screens/SystemsScreen.qml" line="400"/>
         <source>No systems in this category</source>
         <translation>Geen systemen in deze categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="400"/>
+        <location filename="../screens/SystemsScreen.qml" line="401"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -686,44 +686,44 @@ Français - Wilfried</source>
         <translation>Game starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2579"/>
+        <location filename="../app/Main.qml" line="2581"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2595"/>
-        <location filename="../app/Main.qml" line="2634"/>
-        <location filename="../app/Main.qml" line="2644"/>
+        <location filename="../app/Main.qml" line="2597"/>
+        <location filename="../app/Main.qml" line="2636"/>
+        <location filename="../app/Main.qml" line="2646"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2631"/>
+        <location filename="../app/Main.qml" line="2633"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Card write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Could not write to this card. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3712"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3707"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
@@ -753,8 +753,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2052"/>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2677"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2679"/>
         <source>Default</source>
         <translation type="unfinished">Standaard</translation>
     </message>
@@ -768,40 +768,40 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1807"/>
         <location filename="../app/Main.qml" line="1824"/>
         <location filename="../app/Main.qml" line="1832"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2587"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2589"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2623"/>
+        <location filename="../app/Main.qml" line="2625"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2595"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2681"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2683"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2608"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2685"/>
+        <location filename="../app/Main.qml" line="2687"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -822,180 +822,180 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2352"/>
-        <location filename="../app/Main.qml" line="2372"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2435"/>
+        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2437"/>
         <source>OK</source>
         <translation type="unfinished">Akkoord</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2398"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2405"/>
+        <location filename="../app/Main.qml" line="2407"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2406"/>
+        <location filename="../app/Main.qml" line="2408"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2408"/>
+        <location filename="../app/Main.qml" line="2410"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2413"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2412"/>
+        <location filename="../app/Main.qml" line="2414"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2414"/>
+        <location filename="../app/Main.qml" line="2416"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2417"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2417"/>
+        <location filename="../app/Main.qml" line="2419"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2418"/>
+        <location filename="../app/Main.qml" line="2420"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2420"/>
+        <location filename="../app/Main.qml" line="2422"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2421"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2424"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2428"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2431"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2430"/>
+        <location filename="../app/Main.qml" line="2432"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2432"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2433"/>
+        <location filename="../app/Main.qml" line="2435"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorieten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2627"/>
-        <location filename="../app/Main.qml" line="2641"/>
+        <location filename="../app/Main.qml" line="2629"/>
+        <location filename="../app/Main.qml" line="2643"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2659"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2661"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2657"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2662"/>
+        <location filename="../app/Main.qml" line="2664"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2818"/>
-        <location filename="../app/Main.qml" line="2836"/>
+        <location filename="../app/Main.qml" line="2820"/>
+        <location filename="../app/Main.qml" line="2838"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2822"/>
-        <location filename="../app/Main.qml" line="2839"/>
+        <location filename="../app/Main.qml" line="2824"/>
+        <location filename="../app/Main.qml" line="2841"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2423"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2505"/>
-        <location filename="../app/Main.qml" line="2852"/>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="2507"/>
+        <location filename="../app/Main.qml" line="2854"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Retry</source>
         <translation type="unfinished">Opnieuw proberen</translation>
     </message>
@@ -1004,22 +1004,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3709"/>
+        <location filename="../app/Main.qml" line="3711"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3714"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3716"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3720"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -689,44 +689,44 @@ Français - Wilfried</source>
         <translation>Lansare joc</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2579"/>
+        <location filename="../app/Main.qml" line="2581"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2595"/>
-        <location filename="../app/Main.qml" line="2634"/>
-        <location filename="../app/Main.qml" line="2644"/>
+        <location filename="../app/Main.qml" line="2597"/>
+        <location filename="../app/Main.qml" line="2636"/>
+        <location filename="../app/Main.qml" line="2646"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2631"/>
+        <location filename="../app/Main.qml" line="2633"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Card write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Could not write to this card. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3712"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3707"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
@@ -756,8 +756,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2052"/>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2677"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2679"/>
         <source>Default</source>
         <translation type="unfinished">Implicit</translation>
     </message>
@@ -771,40 +771,40 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1807"/>
         <location filename="../app/Main.qml" line="1824"/>
         <location filename="../app/Main.qml" line="1832"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2587"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2589"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2623"/>
+        <location filename="../app/Main.qml" line="2625"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2595"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2681"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2683"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2608"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2685"/>
+        <location filename="../app/Main.qml" line="2687"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -825,180 +825,180 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2352"/>
-        <location filename="../app/Main.qml" line="2372"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2435"/>
+        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2437"/>
         <source>OK</source>
         <translation type="unfinished">În regulă</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2398"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2405"/>
+        <location filename="../app/Main.qml" line="2407"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2406"/>
+        <location filename="../app/Main.qml" line="2408"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2408"/>
+        <location filename="../app/Main.qml" line="2410"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2413"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2412"/>
+        <location filename="../app/Main.qml" line="2414"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2414"/>
+        <location filename="../app/Main.qml" line="2416"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2417"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2417"/>
+        <location filename="../app/Main.qml" line="2419"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2418"/>
+        <location filename="../app/Main.qml" line="2420"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2420"/>
+        <location filename="../app/Main.qml" line="2422"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2421"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2424"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2428"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2431"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2430"/>
+        <location filename="../app/Main.qml" line="2432"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2432"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2433"/>
+        <location filename="../app/Main.qml" line="2435"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2627"/>
-        <location filename="../app/Main.qml" line="2641"/>
+        <location filename="../app/Main.qml" line="2629"/>
+        <location filename="../app/Main.qml" line="2643"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2659"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2661"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2657"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2662"/>
+        <location filename="../app/Main.qml" line="2664"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2818"/>
-        <location filename="../app/Main.qml" line="2836"/>
+        <location filename="../app/Main.qml" line="2820"/>
+        <location filename="../app/Main.qml" line="2838"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2822"/>
-        <location filename="../app/Main.qml" line="2839"/>
+        <location filename="../app/Main.qml" line="2824"/>
+        <location filename="../app/Main.qml" line="2841"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2423"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2505"/>
-        <location filename="../app/Main.qml" line="2852"/>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="2507"/>
+        <location filename="../app/Main.qml" line="2854"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Retry</source>
         <translation type="unfinished">Reîncercare</translation>
     </message>
@@ -1007,22 +1007,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Anulare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3709"/>
+        <location filename="../app/Main.qml" line="3711"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3714"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3716"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3720"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -481,6 +481,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/GameInfoModal.qml" line="120"/>
+        <source>Could not load details. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/GameInfoModal.qml" line="169"/>
         <source>Loading image…</source>
         <translation type="unfinished"></translation>
@@ -549,27 +554,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="202"/>
+        <location filename="../screens/HubScreen.qml" line="203"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="209"/>
+        <location filename="../screens/HubScreen.qml" line="210"/>
         <source>Favorites</source>
         <translation>Favorite</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="215"/>
+        <location filename="../screens/HubScreen.qml" line="216"/>
         <source>Recently Played</source>
         <translation>Recent Jucate</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="222"/>
+        <location filename="../screens/HubScreen.qml" line="223"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="229"/>
+        <location filename="../screens/HubScreen.qml" line="230"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -578,7 +583,7 @@ Français - Wilfried</source>
         <translation type="vanished">Setări</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="816"/>
+        <location filename="../screens/HubScreen.qml" line="821"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Niciun sistem disponibil. Rulați Actualizare bază de date din Setări.</translation>
     </message>
@@ -623,13 +628,16 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="197"/>
-        <source>Upload failed: %1</source>
-        <translation>Încărcare eșuată: %1</translation>
+        <source>Upload failed. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197"/>
+        <source>Upload failed: %1</source>
+        <translation type="vanished">Încărcare eșuată: %1</translation>
+    </message>
+    <message>
         <source>Upload failed.</source>
-        <translation>Încărcare eșuată.</translation>
+        <translation type="vanished">Încărcare eșuată.</translation>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="227"/>
@@ -645,28 +653,28 @@ Français - Wilfried</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1746"/>
+        <location filename="../app/Main.qml" line="1757"/>
         <source>Launch core</source>
         <translation>Lansare core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1760"/>
-        <location filename="../app/Main.qml" line="2045"/>
+        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="2056"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Remove from favorites</source>
         <translation>Elimină din favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Add to favorites</source>
         <translation>Adaugă la favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1850"/>
+        <location filename="../app/Main.qml" line="1861"/>
         <source>Write to NFC token</source>
         <translation>Scriere pe token NFC</translation>
     </message>
@@ -675,201 +683,346 @@ Français - Wilfried</source>
         <translation type="vanished">Cod QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1829"/>
-        <location filename="../app/Main.qml" line="1864"/>
+        <location filename="../app/Main.qml" line="1840"/>
+        <location filename="../app/Main.qml" line="1875"/>
         <source>Launch game</source>
         <translation>Lansare joc</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2579"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2431"/>
-        <location filename="../app/Main.qml" line="2470"/>
-        <location filename="../app/Main.qml" line="2480"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2634"/>
+        <location filename="../app/Main.qml" line="2644"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2467"/>
+        <location filename="../app/Main.qml" line="2631"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3530"/>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Card write failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Could not write to this card. Check that it is writable and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3705"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3712"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1767"/>
-        <location filename="../app/Main.qml" line="1801"/>
+        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="1812"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizare bază de date media</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1770"/>
-        <location filename="../app/Main.qml" line="1804"/>
+        <location filename="../app/Main.qml" line="1781"/>
+        <location filename="../app/Main.qml" line="1815"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extragere metadate</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2052"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2677"/>
         <source>Default</source>
         <translation type="unfinished">Implicit</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
+        <location filename="../app/Main.qml" line="2052"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1755"/>
-        <location filename="../app/Main.qml" line="1796"/>
-        <location filename="../app/Main.qml" line="1813"/>
-        <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="1766"/>
+        <location filename="../app/Main.qml" line="1807"/>
+        <location filename="../app/Main.qml" line="1824"/>
+        <location filename="../app/Main.qml" line="1832"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2587"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
+        <location filename="../app/Main.qml" line="2623"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2593"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2681"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2606"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2521"/>
+        <location filename="../app/Main.qml" line="2685"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2450"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1854"/>
+        <location filename="../app/Main.qml" line="1865"/>
         <source>Write with QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Details unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2352"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2435"/>
+        <source>OK</source>
+        <translation type="unfinished">În regulă</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2396"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2405"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2406"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2408"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2411"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2412"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2414"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2415"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2417"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2418"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2420"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2421"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2424"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2426"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2427"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2446"/>
+        <source>QR code failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2430"/>
+        <source>Could not create the QR code for this item.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2432"/>
+        <source>Setting not saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2433"/>
+        <source>Could not save this setting. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Log upload failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Could not upload the logs. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
-        <location filename="../app/Main.qml" line="2477"/>
+        <location filename="../app/Main.qml" line="2627"/>
+        <location filename="../app/Main.qml" line="2641"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2495"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2659"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2655"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
+        <location filename="../app/Main.qml" line="2662"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2818"/>
+        <location filename="../app/Main.qml" line="2836"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2658"/>
+        <location filename="../app/Main.qml" line="2822"/>
+        <location filename="../app/Main.qml" line="2839"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="2852"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
-        <source>Error: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Retry</source>
         <translation type="unfinished">Reîncercare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
-        <translation type="unfinished">Anulare</translation>
+        <translation type="obsolete">Anulare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3534"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3541"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3543"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>
@@ -877,85 +1030,76 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Writing failed</source>
         <translation>Scriere eșuată</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Put a writable card near the reader</source>
         <translation>Apropiați un card inscriptibil de cititor</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="867"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="868"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="861"/>
-        <location filename="../app/MainLayout.qml" line="877"/>
-        <location filename="../app/MainLayout.qml" line="1186"/>
+        <location filename="../app/MainLayout.qml" line="320"/>
+        <location filename="../app/MainLayout.qml" line="869"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>OK</source>
         <translation type="unfinished">În regulă</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875"/>
-        <source>Random game</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <source>No matching games found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Are you sure you want to exit?</source>
         <translation>Sigur doriți să ieșiți?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1120"/>
-        <location filename="../app/MainLayout.qml" line="1197"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
         <source>Select</source>
         <translation>Selectare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1124"/>
-        <location filename="../app/MainLayout.qml" line="1138"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1164"/>
+        <location filename="../app/MainLayout.qml" line="1132"/>
+        <location filename="../app/MainLayout.qml" line="1146"/>
+        <location filename="../app/MainLayout.qml" line="1161"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1198"/>
         <source>Close</source>
         <translation>Închidere</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1131"/>
-        <location filename="../app/MainLayout.qml" line="1171"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1220"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1149"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
         <source>Done</source>
         <translation>Gata</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1187"/>
         <source>I understand</source>
         <translation>Am înțeles</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1208"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1231"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -964,89 +1108,89 @@ Français - Wilfried</source>
         <translation type="vanished">Pornire</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1433"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Scroll</source>
         <translation>Derulare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1332"/>
-        <location filename="../app/MainLayout.qml" line="1350"/>
-        <location filename="../app/MainLayout.qml" line="1482"/>
-        <location filename="../app/MainLayout.qml" line="1501"/>
+        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1370"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1521"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1193"/>
-        <location filename="../app/MainLayout.qml" line="1231"/>
-        <location filename="../app/MainLayout.qml" line="1268"/>
-        <location filename="../app/MainLayout.qml" line="1317"/>
-        <location filename="../app/MainLayout.qml" line="1373"/>
-        <location filename="../app/MainLayout.qml" line="1392"/>
-        <location filename="../app/MainLayout.qml" line="1465"/>
+        <location filename="../app/MainLayout.qml" line="1124"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1251"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1337"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1412"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
         <source>Move</source>
         <translation>Mutare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="190"/>
+        <location filename="../app/MainLayout.qml" line="191"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="433"/>
-        <location filename="../app/MainLayout.qml" line="435"/>
+        <location filename="../app/MainLayout.qml" line="440"/>
+        <location filename="../app/MainLayout.qml" line="442"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorite</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="437"/>
+        <location filename="../app/MainLayout.qml" line="444"/>
         <source>Recently Played</source>
         <translation type="unfinished">Recent Jucate</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="848"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="841"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1235"/>
-        <location filename="../app/MainLayout.qml" line="1273"/>
-        <location filename="../app/MainLayout.qml" line="1322"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
-        <location filename="../app/MainLayout.qml" line="1470"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1293"/>
+        <location filename="../app/MainLayout.qml" line="1342"/>
+        <location filename="../app/MainLayout.qml" line="1398"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
         <source>Open</source>
         <translation>Deschidere</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1265"/>
         <source>Quit</source>
         <translation>Ieșire</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1254"/>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1306"/>
-        <location filename="../app/MainLayout.qml" line="1336"/>
-        <location filename="../app/MainLayout.qml" line="1354"/>
-        <location filename="../app/MainLayout.qml" line="1366"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1416"/>
-        <location filename="../app/MainLayout.qml" line="1437"/>
-        <location filename="../app/MainLayout.qml" line="1446"/>
-        <location filename="../app/MainLayout.qml" line="1486"/>
-        <location filename="../app/MainLayout.qml" line="1505"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1310"/>
+        <location filename="../app/MainLayout.qml" line="1326"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1386"/>
+        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1436"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1506"/>
+        <location filename="../app/MainLayout.qml" line="1525"/>
         <source>Back</source>
         <translation>Înapoi</translation>
     </message>
@@ -1055,28 +1199,29 @@ Français - Wilfried</source>
         <translation type="vanished">Pagină</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1241"/>
-        <location filename="../app/MainLayout.qml" line="1276"/>
-        <location filename="../app/MainLayout.qml" line="1327"/>
-        <location filename="../app/MainLayout.qml" line="1475"/>
+        <location filename="../app/MainLayout.qml" line="1261"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
+        <location filename="../app/MainLayout.qml" line="1495"/>
         <source>Options</source>
         <translation>Opțiuni</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1160"/>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1344"/>
-        <location filename="../app/MainLayout.qml" line="1493"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1364"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
         <source>Retry</source>
         <translation>Reîncercare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1401"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Change</source>
         <translation>Schimbare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1407"/>
+        <location filename="../app/MainLayout.qml" line="1427"/>
         <source>Toggle</source>
         <translation>Comutare</translation>
     </message>
@@ -1117,7 +1262,7 @@ Français - Wilfried</source>
         <translation>Nu</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="258"/>
+        <location filename="../components/Modal.qml" line="260"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
@@ -1156,17 +1301,22 @@ Français - Wilfried</source>
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="29"/>
         <source>Nothing here</source>
         <translation>Nimic aici</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <source>Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScreenStateOverlay.qml" line="68"/>
         <source>Failed to load</source>
         <translation>Încărcare eșuată</translation>
     </message>
@@ -1719,24 +1869,24 @@ Français - Wilfried</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="252"/>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="253"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>%1 systems</source>
         <translation>%1 sisteme</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="253"/>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="254"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="399"/>
+        <location filename="../screens/SystemsScreen.qml" line="400"/>
         <source>No systems in this category</source>
         <translation>Niciun sistem în această categorie</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="400"/>
+        <location filename="../screens/SystemsScreen.qml" line="401"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -689,44 +689,44 @@ Français - Wilfried</source>
         <translation>Spustiť hru</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2579"/>
+        <location filename="../app/Main.qml" line="2581"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2595"/>
-        <location filename="../app/Main.qml" line="2634"/>
-        <location filename="../app/Main.qml" line="2644"/>
+        <location filename="../app/Main.qml" line="2597"/>
+        <location filename="../app/Main.qml" line="2636"/>
+        <location filename="../app/Main.qml" line="2646"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2631"/>
+        <location filename="../app/Main.qml" line="2633"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Card write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Could not write to this card. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3712"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3707"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
@@ -756,8 +756,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2052"/>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2677"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2679"/>
         <source>Default</source>
         <translation type="unfinished">Predvolené</translation>
     </message>
@@ -771,40 +771,40 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1807"/>
         <location filename="../app/Main.qml" line="1824"/>
         <location filename="../app/Main.qml" line="1832"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2587"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2589"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2623"/>
+        <location filename="../app/Main.qml" line="2625"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2595"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2681"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2683"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2608"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2685"/>
+        <location filename="../app/Main.qml" line="2687"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -825,180 +825,180 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2352"/>
-        <location filename="../app/Main.qml" line="2372"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2435"/>
+        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2437"/>
         <source>OK</source>
         <translation type="unfinished">V poriadku</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2398"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2405"/>
+        <location filename="../app/Main.qml" line="2407"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2406"/>
+        <location filename="../app/Main.qml" line="2408"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2408"/>
+        <location filename="../app/Main.qml" line="2410"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2413"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2412"/>
+        <location filename="../app/Main.qml" line="2414"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2414"/>
+        <location filename="../app/Main.qml" line="2416"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2417"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2417"/>
+        <location filename="../app/Main.qml" line="2419"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2418"/>
+        <location filename="../app/Main.qml" line="2420"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2420"/>
+        <location filename="../app/Main.qml" line="2422"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2421"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2424"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2428"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2431"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2430"/>
+        <location filename="../app/Main.qml" line="2432"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2432"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2433"/>
+        <location filename="../app/Main.qml" line="2435"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Favorites</source>
         <translation type="unfinished">Obľúbené</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2627"/>
-        <location filename="../app/Main.qml" line="2641"/>
+        <location filename="../app/Main.qml" line="2629"/>
+        <location filename="../app/Main.qml" line="2643"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2659"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2661"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2657"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2662"/>
+        <location filename="../app/Main.qml" line="2664"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2818"/>
-        <location filename="../app/Main.qml" line="2836"/>
+        <location filename="../app/Main.qml" line="2820"/>
+        <location filename="../app/Main.qml" line="2838"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2822"/>
-        <location filename="../app/Main.qml" line="2839"/>
+        <location filename="../app/Main.qml" line="2824"/>
+        <location filename="../app/Main.qml" line="2841"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2423"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2505"/>
-        <location filename="../app/Main.qml" line="2852"/>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="2507"/>
+        <location filename="../app/Main.qml" line="2854"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Retry</source>
         <translation type="unfinished">Skúsiť znova</translation>
     </message>
@@ -1007,22 +1007,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3709"/>
+        <location filename="../app/Main.qml" line="3711"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3714"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3716"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3720"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -481,6 +481,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/GameInfoModal.qml" line="120"/>
+        <source>Could not load details. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/GameInfoModal.qml" line="169"/>
         <source>Loading image…</source>
         <translation type="unfinished"></translation>
@@ -549,27 +554,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="202"/>
+        <location filename="../screens/HubScreen.qml" line="203"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="209"/>
+        <location filename="../screens/HubScreen.qml" line="210"/>
         <source>Favorites</source>
         <translation>Obľúbené</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="215"/>
+        <location filename="../screens/HubScreen.qml" line="216"/>
         <source>Recently Played</source>
         <translation>Nedávno hrané</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="222"/>
+        <location filename="../screens/HubScreen.qml" line="223"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="229"/>
+        <location filename="../screens/HubScreen.qml" line="230"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -578,7 +583,7 @@ Français - Wilfried</source>
         <translation type="vanished">Nastavenia</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="816"/>
+        <location filename="../screens/HubScreen.qml" line="821"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Žiadne systémy nie sú dostupné. Spustite Aktualizovať databázu médií v Nastaveniach.</translation>
     </message>
@@ -623,13 +628,16 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="197"/>
-        <source>Upload failed: %1</source>
-        <translation>Nahrávanie zlyhalo: %1</translation>
+        <source>Upload failed. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197"/>
+        <source>Upload failed: %1</source>
+        <translation type="vanished">Nahrávanie zlyhalo: %1</translation>
+    </message>
+    <message>
         <source>Upload failed.</source>
-        <translation>Nahrávanie zlyhalo.</translation>
+        <translation type="vanished">Nahrávanie zlyhalo.</translation>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="227"/>
@@ -645,28 +653,28 @@ Français - Wilfried</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1746"/>
+        <location filename="../app/Main.qml" line="1757"/>
         <source>Launch core</source>
         <translation>Spustiť core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1760"/>
-        <location filename="../app/Main.qml" line="2045"/>
+        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="2056"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Remove from favorites</source>
         <translation>Odstrániť z obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Add to favorites</source>
         <translation>Pridať do obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1850"/>
+        <location filename="../app/Main.qml" line="1861"/>
         <source>Write to NFC token</source>
         <translation>Zapísať na NFC token</translation>
     </message>
@@ -675,201 +683,346 @@ Français - Wilfried</source>
         <translation type="vanished">QR kód</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1829"/>
-        <location filename="../app/Main.qml" line="1864"/>
+        <location filename="../app/Main.qml" line="1840"/>
+        <location filename="../app/Main.qml" line="1875"/>
         <source>Launch game</source>
         <translation>Spustiť hru</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2579"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2431"/>
-        <location filename="../app/Main.qml" line="2470"/>
-        <location filename="../app/Main.qml" line="2480"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2634"/>
+        <location filename="../app/Main.qml" line="2644"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2467"/>
+        <location filename="../app/Main.qml" line="2631"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3530"/>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Card write failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Could not write to this card. Check that it is writable and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3705"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3712"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1767"/>
-        <location filename="../app/Main.qml" line="1801"/>
+        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="1812"/>
         <source>Update media database</source>
         <translation type="unfinished">Aktualizovať databázu médií</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1770"/>
-        <location filename="../app/Main.qml" line="1804"/>
+        <location filename="../app/Main.qml" line="1781"/>
+        <location filename="../app/Main.qml" line="1815"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Získať metadáta</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2052"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2677"/>
         <source>Default</source>
         <translation type="unfinished">Predvolené</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
+        <location filename="../app/Main.qml" line="2052"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1755"/>
-        <location filename="../app/Main.qml" line="1796"/>
-        <location filename="../app/Main.qml" line="1813"/>
-        <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="1766"/>
+        <location filename="../app/Main.qml" line="1807"/>
+        <location filename="../app/Main.qml" line="1824"/>
+        <location filename="../app/Main.qml" line="1832"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2587"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
+        <location filename="../app/Main.qml" line="2623"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2593"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2681"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2606"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2521"/>
+        <location filename="../app/Main.qml" line="2685"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2450"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1854"/>
+        <location filename="../app/Main.qml" line="1865"/>
         <source>Write with QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Details unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2352"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2435"/>
+        <source>OK</source>
+        <translation type="unfinished">V poriadku</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2396"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2405"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2406"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2408"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2411"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2412"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2414"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2415"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2417"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2418"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2420"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2421"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2424"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2426"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2427"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2446"/>
+        <source>QR code failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2430"/>
+        <source>Could not create the QR code for this item.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2432"/>
+        <source>Setting not saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2433"/>
+        <source>Could not save this setting. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Log upload failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Could not upload the logs. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Favorites</source>
         <translation type="unfinished">Obľúbené</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
-        <location filename="../app/Main.qml" line="2477"/>
+        <location filename="../app/Main.qml" line="2627"/>
+        <location filename="../app/Main.qml" line="2641"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2495"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2659"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2655"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
+        <location filename="../app/Main.qml" line="2662"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2818"/>
+        <location filename="../app/Main.qml" line="2836"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2658"/>
+        <location filename="../app/Main.qml" line="2822"/>
+        <location filename="../app/Main.qml" line="2839"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="2852"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
-        <source>Error: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Retry</source>
         <translation type="unfinished">Skúsiť znova</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
-        <translation type="unfinished">Zrušiť</translation>
+        <translation type="obsolete">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3534"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3541"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3543"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>
@@ -877,85 +1030,76 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Writing failed</source>
         <translation>Zápis zlyhal</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Put a writable card near the reader</source>
         <translation>Priložte zapisovateľnú kartu k čítačke</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="867"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="868"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="861"/>
-        <location filename="../app/MainLayout.qml" line="877"/>
-        <location filename="../app/MainLayout.qml" line="1186"/>
+        <location filename="../app/MainLayout.qml" line="320"/>
+        <location filename="../app/MainLayout.qml" line="869"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>OK</source>
         <translation type="unfinished">V poriadku</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875"/>
-        <source>Random game</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <source>No matching games found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Are you sure you want to exit?</source>
         <translation>Naozaj chcete ukončiť?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1120"/>
-        <location filename="../app/MainLayout.qml" line="1197"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
         <source>Select</source>
         <translation>Vybrať</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1124"/>
-        <location filename="../app/MainLayout.qml" line="1138"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1164"/>
+        <location filename="../app/MainLayout.qml" line="1132"/>
+        <location filename="../app/MainLayout.qml" line="1146"/>
+        <location filename="../app/MainLayout.qml" line="1161"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1198"/>
         <source>Close</source>
         <translation>Zavrieť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1131"/>
-        <location filename="../app/MainLayout.qml" line="1171"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1220"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1149"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
         <source>Done</source>
         <translation>Hotovo</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1187"/>
         <source>I understand</source>
         <translation>Rozumiem</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1208"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1231"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -964,89 +1108,89 @@ Français - Wilfried</source>
         <translation type="vanished">Spustiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1433"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Scroll</source>
         <translation>Posúvať</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1332"/>
-        <location filename="../app/MainLayout.qml" line="1350"/>
-        <location filename="../app/MainLayout.qml" line="1482"/>
-        <location filename="../app/MainLayout.qml" line="1501"/>
+        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1370"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1521"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1193"/>
-        <location filename="../app/MainLayout.qml" line="1231"/>
-        <location filename="../app/MainLayout.qml" line="1268"/>
-        <location filename="../app/MainLayout.qml" line="1317"/>
-        <location filename="../app/MainLayout.qml" line="1373"/>
-        <location filename="../app/MainLayout.qml" line="1392"/>
-        <location filename="../app/MainLayout.qml" line="1465"/>
+        <location filename="../app/MainLayout.qml" line="1124"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1251"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1337"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1412"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
         <source>Move</source>
         <translation>Presunúť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="190"/>
+        <location filename="../app/MainLayout.qml" line="191"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="433"/>
-        <location filename="../app/MainLayout.qml" line="435"/>
+        <location filename="../app/MainLayout.qml" line="440"/>
+        <location filename="../app/MainLayout.qml" line="442"/>
         <source>Favorites</source>
         <translation type="unfinished">Obľúbené</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="437"/>
+        <location filename="../app/MainLayout.qml" line="444"/>
         <source>Recently Played</source>
         <translation type="unfinished">Nedávno hrané</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="848"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="841"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1235"/>
-        <location filename="../app/MainLayout.qml" line="1273"/>
-        <location filename="../app/MainLayout.qml" line="1322"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
-        <location filename="../app/MainLayout.qml" line="1470"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1293"/>
+        <location filename="../app/MainLayout.qml" line="1342"/>
+        <location filename="../app/MainLayout.qml" line="1398"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
         <source>Open</source>
         <translation>Otvoriť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1265"/>
         <source>Quit</source>
         <translation>Ukončiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1254"/>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1306"/>
-        <location filename="../app/MainLayout.qml" line="1336"/>
-        <location filename="../app/MainLayout.qml" line="1354"/>
-        <location filename="../app/MainLayout.qml" line="1366"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1416"/>
-        <location filename="../app/MainLayout.qml" line="1437"/>
-        <location filename="../app/MainLayout.qml" line="1446"/>
-        <location filename="../app/MainLayout.qml" line="1486"/>
-        <location filename="../app/MainLayout.qml" line="1505"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1310"/>
+        <location filename="../app/MainLayout.qml" line="1326"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1386"/>
+        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1436"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1506"/>
+        <location filename="../app/MainLayout.qml" line="1525"/>
         <source>Back</source>
         <translation>Späť</translation>
     </message>
@@ -1055,28 +1199,29 @@ Français - Wilfried</source>
         <translation type="vanished">Stránka</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1241"/>
-        <location filename="../app/MainLayout.qml" line="1276"/>
-        <location filename="../app/MainLayout.qml" line="1327"/>
-        <location filename="../app/MainLayout.qml" line="1475"/>
+        <location filename="../app/MainLayout.qml" line="1261"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
+        <location filename="../app/MainLayout.qml" line="1495"/>
         <source>Options</source>
         <translation>Možnosti</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1160"/>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1344"/>
-        <location filename="../app/MainLayout.qml" line="1493"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1364"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
         <source>Retry</source>
         <translation>Skúsiť znova</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1401"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Change</source>
         <translation>Zmeniť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1407"/>
+        <location filename="../app/MainLayout.qml" line="1427"/>
         <source>Toggle</source>
         <translation>Prepínať</translation>
     </message>
@@ -1117,7 +1262,7 @@ Français - Wilfried</source>
         <translation>Nie</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="258"/>
+        <location filename="../components/Modal.qml" line="260"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
@@ -1156,17 +1301,22 @@ Français - Wilfried</source>
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="29"/>
         <source>Nothing here</source>
         <translation>Nič tu nie je</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <source>Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScreenStateOverlay.qml" line="68"/>
         <source>Failed to load</source>
         <translation>Načítanie zlyhalo</translation>
     </message>
@@ -1719,24 +1869,24 @@ Français - Wilfried</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="252"/>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="253"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>%1 systems</source>
         <translation>%1 systémov</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="253"/>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="254"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="399"/>
+        <location filename="../screens/SystemsScreen.qml" line="400"/>
         <source>No systems in this category</source>
         <translation>V tejto kategórii nie sú žiadne systémy</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="400"/>
+        <location filename="../screens/SystemsScreen.qml" line="401"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -689,44 +689,44 @@ Français - Wilfried</source>
         <translation>Запустити гру</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2579"/>
+        <location filename="../app/Main.qml" line="2581"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2595"/>
-        <location filename="../app/Main.qml" line="2634"/>
-        <location filename="../app/Main.qml" line="2644"/>
+        <location filename="../app/Main.qml" line="2597"/>
+        <location filename="../app/Main.qml" line="2636"/>
+        <location filename="../app/Main.qml" line="2646"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2631"/>
+        <location filename="../app/Main.qml" line="2633"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Card write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Could not write to this card. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3712"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3707"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
@@ -756,8 +756,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2052"/>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2677"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2679"/>
         <source>Default</source>
         <translation type="unfinished">Типовий</translation>
     </message>
@@ -771,40 +771,40 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1807"/>
         <location filename="../app/Main.qml" line="1824"/>
         <location filename="../app/Main.qml" line="1832"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2587"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2589"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2623"/>
+        <location filename="../app/Main.qml" line="2625"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2595"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2681"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2683"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2608"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2685"/>
+        <location filename="../app/Main.qml" line="2687"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -825,180 +825,180 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2352"/>
-        <location filename="../app/Main.qml" line="2372"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2435"/>
+        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2437"/>
         <source>OK</source>
         <translation type="unfinished">Гаразд</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2398"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2405"/>
+        <location filename="../app/Main.qml" line="2407"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2406"/>
+        <location filename="../app/Main.qml" line="2408"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2408"/>
+        <location filename="../app/Main.qml" line="2410"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2413"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2412"/>
+        <location filename="../app/Main.qml" line="2414"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2414"/>
+        <location filename="../app/Main.qml" line="2416"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2417"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2417"/>
+        <location filename="../app/Main.qml" line="2419"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2418"/>
+        <location filename="../app/Main.qml" line="2420"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2420"/>
+        <location filename="../app/Main.qml" line="2422"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2421"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2424"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2428"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2431"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2430"/>
+        <location filename="../app/Main.qml" line="2432"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2432"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2433"/>
+        <location filename="../app/Main.qml" line="2435"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Favorites</source>
         <translation type="unfinished">Вибране</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2627"/>
-        <location filename="../app/Main.qml" line="2641"/>
+        <location filename="../app/Main.qml" line="2629"/>
+        <location filename="../app/Main.qml" line="2643"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2659"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2661"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2657"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2662"/>
+        <location filename="../app/Main.qml" line="2664"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2818"/>
-        <location filename="../app/Main.qml" line="2836"/>
+        <location filename="../app/Main.qml" line="2820"/>
+        <location filename="../app/Main.qml" line="2838"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2822"/>
-        <location filename="../app/Main.qml" line="2839"/>
+        <location filename="../app/Main.qml" line="2824"/>
+        <location filename="../app/Main.qml" line="2841"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2423"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2505"/>
-        <location filename="../app/Main.qml" line="2852"/>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="2507"/>
+        <location filename="../app/Main.qml" line="2854"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Retry</source>
         <translation type="unfinished">Повторити</translation>
     </message>
@@ -1007,22 +1007,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3709"/>
+        <location filename="../app/Main.qml" line="3711"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3714"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3716"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3720"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -481,6 +481,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/GameInfoModal.qml" line="120"/>
+        <source>Could not load details. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/GameInfoModal.qml" line="169"/>
         <source>Loading image…</source>
         <translation type="unfinished"></translation>
@@ -549,27 +554,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="202"/>
+        <location filename="../screens/HubScreen.qml" line="203"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="209"/>
+        <location filename="../screens/HubScreen.qml" line="210"/>
         <source>Favorites</source>
         <translation>Вибране</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="215"/>
+        <location filename="../screens/HubScreen.qml" line="216"/>
         <source>Recently Played</source>
         <translation>Нещодавно зіграні</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="222"/>
+        <location filename="../screens/HubScreen.qml" line="223"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="229"/>
+        <location filename="../screens/HubScreen.qml" line="230"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -578,7 +583,7 @@ Français - Wilfried</source>
         <translation type="vanished">Налаштування</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="816"/>
+        <location filename="../screens/HubScreen.qml" line="821"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Немає доступних систем. Запустіть Оновлення бази даних з Налаштувань.</translation>
     </message>
@@ -623,13 +628,16 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="197"/>
-        <source>Upload failed: %1</source>
-        <translation>Помилка завантаження: %1</translation>
+        <source>Upload failed. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197"/>
+        <source>Upload failed: %1</source>
+        <translation type="vanished">Помилка завантаження: %1</translation>
+    </message>
+    <message>
         <source>Upload failed.</source>
-        <translation>Помилка завантаження.</translation>
+        <translation type="vanished">Помилка завантаження.</translation>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="227"/>
@@ -645,28 +653,28 @@ Français - Wilfried</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1746"/>
+        <location filename="../app/Main.qml" line="1757"/>
         <source>Launch core</source>
         <translation>Запустити core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1760"/>
-        <location filename="../app/Main.qml" line="2045"/>
+        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="2056"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Remove from favorites</source>
         <translation>Видалити з вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Add to favorites</source>
         <translation>Додати до вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1850"/>
+        <location filename="../app/Main.qml" line="1861"/>
         <source>Write to NFC token</source>
         <translation>Записати на NFC-токен</translation>
     </message>
@@ -675,201 +683,346 @@ Français - Wilfried</source>
         <translation type="vanished">QR-код</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1829"/>
-        <location filename="../app/Main.qml" line="1864"/>
+        <location filename="../app/Main.qml" line="1840"/>
+        <location filename="../app/Main.qml" line="1875"/>
         <source>Launch game</source>
         <translation>Запустити гру</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2579"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2431"/>
-        <location filename="../app/Main.qml" line="2470"/>
-        <location filename="../app/Main.qml" line="2480"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2634"/>
+        <location filename="../app/Main.qml" line="2644"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2467"/>
+        <location filename="../app/Main.qml" line="2631"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3530"/>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Card write failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Could not write to this card. Check that it is writable and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3705"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3712"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1767"/>
-        <location filename="../app/Main.qml" line="1801"/>
+        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="1812"/>
         <source>Update media database</source>
         <translation type="unfinished">Оновити базу медіа</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1770"/>
-        <location filename="../app/Main.qml" line="1804"/>
+        <location filename="../app/Main.qml" line="1781"/>
+        <location filename="../app/Main.qml" line="1815"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Отримати метадані</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2052"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2677"/>
         <source>Default</source>
         <translation type="unfinished">Типовий</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
+        <location filename="../app/Main.qml" line="2052"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1755"/>
-        <location filename="../app/Main.qml" line="1796"/>
-        <location filename="../app/Main.qml" line="1813"/>
-        <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="1766"/>
+        <location filename="../app/Main.qml" line="1807"/>
+        <location filename="../app/Main.qml" line="1824"/>
+        <location filename="../app/Main.qml" line="1832"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2587"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
+        <location filename="../app/Main.qml" line="2623"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2593"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2681"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2606"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2521"/>
+        <location filename="../app/Main.qml" line="2685"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2450"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1854"/>
+        <location filename="../app/Main.qml" line="1865"/>
         <source>Write with QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Details unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2352"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2435"/>
+        <source>OK</source>
+        <translation type="unfinished">Гаразд</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2396"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2405"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2406"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2408"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2411"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2412"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2414"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2415"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2417"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2418"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2420"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2421"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2424"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2426"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2427"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2446"/>
+        <source>QR code failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2430"/>
+        <source>Could not create the QR code for this item.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2432"/>
+        <source>Setting not saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2433"/>
+        <source>Could not save this setting. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Log upload failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Could not upload the logs. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Favorites</source>
         <translation type="unfinished">Вибране</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
-        <location filename="../app/Main.qml" line="2477"/>
+        <location filename="../app/Main.qml" line="2627"/>
+        <location filename="../app/Main.qml" line="2641"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2495"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2659"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2655"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
+        <location filename="../app/Main.qml" line="2662"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2818"/>
+        <location filename="../app/Main.qml" line="2836"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2658"/>
+        <location filename="../app/Main.qml" line="2822"/>
+        <location filename="../app/Main.qml" line="2839"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="2852"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
-        <source>Error: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Retry</source>
         <translation type="unfinished">Повторити</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
-        <translation type="unfinished">Скасувати</translation>
+        <translation type="obsolete">Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3534"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3541"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3543"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>
@@ -877,85 +1030,76 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Writing failed</source>
         <translation>Помилка запису</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Put a writable card near the reader</source>
         <translation>Прикладіть картку для запису до зчитувача</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="867"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="868"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="861"/>
-        <location filename="../app/MainLayout.qml" line="877"/>
-        <location filename="../app/MainLayout.qml" line="1186"/>
+        <location filename="../app/MainLayout.qml" line="320"/>
+        <location filename="../app/MainLayout.qml" line="869"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>OK</source>
         <translation type="unfinished">Гаразд</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875"/>
-        <source>Random game</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <source>No matching games found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Are you sure you want to exit?</source>
         <translation>Ви впевнені, що хочете вийти?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1120"/>
-        <location filename="../app/MainLayout.qml" line="1197"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
         <source>Select</source>
         <translation>Вибрати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1124"/>
-        <location filename="../app/MainLayout.qml" line="1138"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1164"/>
+        <location filename="../app/MainLayout.qml" line="1132"/>
+        <location filename="../app/MainLayout.qml" line="1146"/>
+        <location filename="../app/MainLayout.qml" line="1161"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1198"/>
         <source>Close</source>
         <translation>Закрити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1131"/>
-        <location filename="../app/MainLayout.qml" line="1171"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1220"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1149"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
         <source>Done</source>
         <translation>Готово</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1187"/>
         <source>I understand</source>
         <translation>Я розумію</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1208"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1231"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -964,89 +1108,89 @@ Français - Wilfried</source>
         <translation type="vanished">Почати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1433"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Scroll</source>
         <translation>Прокрутка</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1332"/>
-        <location filename="../app/MainLayout.qml" line="1350"/>
-        <location filename="../app/MainLayout.qml" line="1482"/>
-        <location filename="../app/MainLayout.qml" line="1501"/>
+        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1370"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1521"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1193"/>
-        <location filename="../app/MainLayout.qml" line="1231"/>
-        <location filename="../app/MainLayout.qml" line="1268"/>
-        <location filename="../app/MainLayout.qml" line="1317"/>
-        <location filename="../app/MainLayout.qml" line="1373"/>
-        <location filename="../app/MainLayout.qml" line="1392"/>
-        <location filename="../app/MainLayout.qml" line="1465"/>
+        <location filename="../app/MainLayout.qml" line="1124"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1251"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1337"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1412"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
         <source>Move</source>
         <translation>Переміщення</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="190"/>
+        <location filename="../app/MainLayout.qml" line="191"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="433"/>
-        <location filename="../app/MainLayout.qml" line="435"/>
+        <location filename="../app/MainLayout.qml" line="440"/>
+        <location filename="../app/MainLayout.qml" line="442"/>
         <source>Favorites</source>
         <translation type="unfinished">Вибране</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="437"/>
+        <location filename="../app/MainLayout.qml" line="444"/>
         <source>Recently Played</source>
         <translation type="unfinished">Нещодавно зіграні</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="848"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="841"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1235"/>
-        <location filename="../app/MainLayout.qml" line="1273"/>
-        <location filename="../app/MainLayout.qml" line="1322"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
-        <location filename="../app/MainLayout.qml" line="1470"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1293"/>
+        <location filename="../app/MainLayout.qml" line="1342"/>
+        <location filename="../app/MainLayout.qml" line="1398"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1265"/>
         <source>Quit</source>
         <translation>Вийти</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1254"/>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1306"/>
-        <location filename="../app/MainLayout.qml" line="1336"/>
-        <location filename="../app/MainLayout.qml" line="1354"/>
-        <location filename="../app/MainLayout.qml" line="1366"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1416"/>
-        <location filename="../app/MainLayout.qml" line="1437"/>
-        <location filename="../app/MainLayout.qml" line="1446"/>
-        <location filename="../app/MainLayout.qml" line="1486"/>
-        <location filename="../app/MainLayout.qml" line="1505"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1310"/>
+        <location filename="../app/MainLayout.qml" line="1326"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1386"/>
+        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1436"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1506"/>
+        <location filename="../app/MainLayout.qml" line="1525"/>
         <source>Back</source>
         <translation>Назад</translation>
     </message>
@@ -1055,28 +1199,29 @@ Français - Wilfried</source>
         <translation type="vanished">Сторінка</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1241"/>
-        <location filename="../app/MainLayout.qml" line="1276"/>
-        <location filename="../app/MainLayout.qml" line="1327"/>
-        <location filename="../app/MainLayout.qml" line="1475"/>
+        <location filename="../app/MainLayout.qml" line="1261"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
+        <location filename="../app/MainLayout.qml" line="1495"/>
         <source>Options</source>
         <translation>Параметри</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1160"/>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1344"/>
-        <location filename="../app/MainLayout.qml" line="1493"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1364"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
         <source>Retry</source>
         <translation>Повторити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1401"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Change</source>
         <translation>Змінити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1407"/>
+        <location filename="../app/MainLayout.qml" line="1427"/>
         <source>Toggle</source>
         <translation>Перемкнути</translation>
     </message>
@@ -1117,7 +1262,7 @@ Français - Wilfried</source>
         <translation>Ні</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="258"/>
+        <location filename="../components/Modal.qml" line="260"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
@@ -1156,17 +1301,22 @@ Français - Wilfried</source>
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="29"/>
         <source>Nothing here</source>
         <translation>Тут нічого немає</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <source>Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScreenStateOverlay.qml" line="68"/>
         <source>Failed to load</source>
         <translation>Не вдалося завантажити</translation>
     </message>
@@ -1719,24 +1869,24 @@ Français - Wilfried</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="252"/>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="253"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>%1 systems</source>
         <translation>%1 систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="253"/>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="254"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="399"/>
+        <location filename="../screens/SystemsScreen.qml" line="400"/>
         <source>No systems in this category</source>
         <translation>У цій категорії немає систем</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="400"/>
+        <location filename="../screens/SystemsScreen.qml" line="401"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -475,6 +475,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/GameInfoModal.qml" line="120"/>
+        <source>Could not load details. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/GameInfoModal.qml" line="169"/>
         <source>Loading image…</source>
         <translation type="unfinished"></translation>
@@ -543,27 +548,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="202"/>
+        <location filename="../screens/HubScreen.qml" line="203"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="209"/>
+        <location filename="../screens/HubScreen.qml" line="210"/>
         <source>Favorites</source>
         <translation>收藏</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="215"/>
+        <location filename="../screens/HubScreen.qml" line="216"/>
         <source>Recently Played</source>
         <translation>最近游玩</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="222"/>
+        <location filename="../screens/HubScreen.qml" line="223"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="229"/>
+        <location filename="../screens/HubScreen.qml" line="230"/>
         <source>Settings &amp; Utilities</source>
         <translation type="unfinished"></translation>
     </message>
@@ -572,7 +577,7 @@ Français - Wilfried</source>
         <translation type="vanished">设置</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="816"/>
+        <location filename="../screens/HubScreen.qml" line="821"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>没有可用系统。请在“设置”中运行“更新媒体数据库”。</translation>
     </message>
@@ -617,13 +622,16 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="197"/>
-        <source>Upload failed: %1</source>
-        <translation>上传失败：%1</translation>
+        <source>Upload failed. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/LogUploadModal.qml" line="197"/>
+        <source>Upload failed: %1</source>
+        <translation type="vanished">上传失败：%1</translation>
+    </message>
+    <message>
         <source>Upload failed.</source>
-        <translation>上传失败。</translation>
+        <translation type="vanished">上传失败。</translation>
     </message>
     <message>
         <location filename="../components/LogUploadModal.qml" line="227"/>
@@ -639,58 +647,58 @@ Français - Wilfried</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="1746"/>
+        <location filename="../app/Main.qml" line="1757"/>
         <source>Launch core</source>
         <translation>启动核心</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1760"/>
-        <location filename="../app/Main.qml" line="2045"/>
+        <location filename="../app/Main.qml" line="1771"/>
+        <location filename="../app/Main.qml" line="2056"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1767"/>
-        <location filename="../app/Main.qml" line="1801"/>
+        <location filename="../app/Main.qml" line="1778"/>
+        <location filename="../app/Main.qml" line="1812"/>
         <source>Update media database</source>
         <translation type="unfinished">更新媒体数据库</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1770"/>
-        <location filename="../app/Main.qml" line="1804"/>
+        <location filename="../app/Main.qml" line="1781"/>
+        <location filename="../app/Main.qml" line="1815"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">抓取元数据</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1775"/>
-        <location filename="../app/Main.qml" line="1784"/>
+        <location filename="../app/Main.qml" line="1786"/>
+        <location filename="../app/Main.qml" line="1795"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1829"/>
-        <location filename="../app/Main.qml" line="1864"/>
+        <location filename="../app/Main.qml" line="1840"/>
+        <location filename="../app/Main.qml" line="1875"/>
         <source>Launch game</source>
         <translation>启动游戏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Remove from favorites</source>
         <translation>从收藏中移除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1845"/>
+        <location filename="../app/Main.qml" line="1856"/>
         <source>Add to favorites</source>
         <translation>添加到收藏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1850"/>
+        <location filename="../app/Main.qml" line="1861"/>
         <source>Write to NFC token</source>
         <translation>写入 NFC 令牌</translation>
     </message>
@@ -699,171 +707,316 @@ Français - Wilfried</source>
         <translation type="vanished">二维码</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2513"/>
+        <location filename="../app/Main.qml" line="2052"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2677"/>
         <source>Default</source>
         <translation type="unfinished">默认</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2041"/>
+        <location filename="../app/Main.qml" line="2052"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2579"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1755"/>
-        <location filename="../app/Main.qml" line="1796"/>
-        <location filename="../app/Main.qml" line="1813"/>
-        <location filename="../app/Main.qml" line="1821"/>
-        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="1766"/>
+        <location filename="../app/Main.qml" line="1807"/>
+        <location filename="../app/Main.qml" line="1824"/>
+        <location filename="../app/Main.qml" line="1832"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2587"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2446"/>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2610"/>
         <source>Favorites</source>
         <translation type="unfinished">收藏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2431"/>
-        <location filename="../app/Main.qml" line="2470"/>
-        <location filename="../app/Main.qml" line="2480"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2634"/>
+        <location filename="../app/Main.qml" line="2644"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2459"/>
+        <location filename="../app/Main.qml" line="2623"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2593"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2502"/>
-        <location filename="../app/Main.qml" line="2517"/>
+        <location filename="../app/Main.qml" line="2666"/>
+        <location filename="../app/Main.qml" line="2681"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
-        <location filename="../app/Main.qml" line="2442"/>
+        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2606"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2521"/>
+        <location filename="../app/Main.qml" line="2685"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2450"/>
+        <location filename="../app/Main.qml" line="2614"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1854"/>
+        <location filename="../app/Main.qml" line="1865"/>
         <source>Write with QR code</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2463"/>
-        <location filename="../app/Main.qml" line="2477"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Details unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2197"/>
+        <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2352"/>
+        <location filename="../app/Main.qml" line="2372"/>
+        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2435"/>
+        <source>OK</source>
+        <translation type="unfinished">确定</translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2396"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2405"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2406"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2408"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2409"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2411"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2412"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2414"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2415"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2417"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2418"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2420"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2421"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2424"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2426"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2427"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2429"/>
+        <source>QR code failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2430"/>
+        <source>Could not create the QR code for this item.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2432"/>
+        <source>Setting not saved</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2433"/>
+        <source>Could not save this setting. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Log upload failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2505"/>
+        <source>Could not upload the logs. Check the network connection and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2627"/>
+        <location filename="../app/Main.qml" line="2641"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2467"/>
+        <location filename="../app/Main.qml" line="2631"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2495"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2659"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2484"/>
-        <location filename="../app/Main.qml" line="2491"/>
+        <location filename="../app/Main.qml" line="2648"/>
+        <location filename="../app/Main.qml" line="2655"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2498"/>
+        <location filename="../app/Main.qml" line="2662"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2818"/>
+        <location filename="../app/Main.qml" line="2836"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2658"/>
+        <location filename="../app/Main.qml" line="2822"/>
+        <location filename="../app/Main.qml" line="2839"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2672"/>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Card write failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3093"/>
+        <source>Could not write to this card. Check that it is writable and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2423"/>
+        <location filename="../app/Main.qml" line="2852"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2676"/>
-        <source>Error: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2680"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Retry</source>
         <translation type="unfinished">重试</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2684"/>
         <source>Cancel</source>
-        <translation type="unfinished">取消</translation>
+        <translation type="obsolete">取消</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3530"/>
+        <location filename="../app/Main.qml" line="3705"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3534"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3537"/>
+        <location filename="../app/Main.qml" line="3712"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3541"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3543"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>
@@ -871,136 +1024,128 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Writing failed</source>
         <translation>写入失败</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="824"/>
+        <location filename="../app/MainLayout.qml" line="832"/>
         <source>Put a writable card near the reader</source>
         <translation>将可写卡片放在读卡器附近</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="190"/>
+        <location filename="../app/MainLayout.qml" line="191"/>
         <source>Zaparoo Frontend</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="433"/>
-        <location filename="../app/MainLayout.qml" line="435"/>
+        <location filename="../app/MainLayout.qml" line="440"/>
+        <location filename="../app/MainLayout.qml" line="442"/>
         <source>Favorites</source>
         <translation type="unfinished">收藏</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="437"/>
+        <location filename="../app/MainLayout.qml" line="444"/>
         <source>Recently Played</source>
         <translation type="unfinished">最近游玩</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="840"/>
+        <location filename="../app/MainLayout.qml" line="848"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="841"/>
+        <location filename="../app/MainLayout.qml" line="849"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="859"/>
+        <location filename="../app/MainLayout.qml" line="867"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="860"/>
+        <location filename="../app/MainLayout.qml" line="868"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="861"/>
-        <location filename="../app/MainLayout.qml" line="877"/>
-        <location filename="../app/MainLayout.qml" line="1186"/>
+        <location filename="../app/MainLayout.qml" line="320"/>
+        <location filename="../app/MainLayout.qml" line="869"/>
+        <location filename="../app/MainLayout.qml" line="1205"/>
         <source>OK</source>
         <translation type="unfinished">确定</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="875"/>
-        <source>Random game</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="876"/>
-        <source>No matching games found.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/MainLayout.qml" line="969"/>
+        <location filename="../app/MainLayout.qml" line="977"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="970"/>
+        <location filename="../app/MainLayout.qml" line="978"/>
         <source>Are you sure you want to exit?</source>
         <translation>确定要退出吗？</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1116"/>
-        <location filename="../app/MainLayout.qml" line="1193"/>
-        <location filename="../app/MainLayout.qml" line="1231"/>
-        <location filename="../app/MainLayout.qml" line="1268"/>
-        <location filename="../app/MainLayout.qml" line="1317"/>
-        <location filename="../app/MainLayout.qml" line="1373"/>
-        <location filename="../app/MainLayout.qml" line="1392"/>
-        <location filename="../app/MainLayout.qml" line="1465"/>
+        <location filename="../app/MainLayout.qml" line="1124"/>
+        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1251"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1337"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1412"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
         <source>Move</source>
         <translation>移动</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1120"/>
-        <location filename="../app/MainLayout.qml" line="1197"/>
+        <location filename="../app/MainLayout.qml" line="1128"/>
+        <location filename="../app/MainLayout.qml" line="1216"/>
         <source>Select</source>
         <translation>选择</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1124"/>
-        <location filename="../app/MainLayout.qml" line="1138"/>
-        <location filename="../app/MainLayout.qml" line="1153"/>
-        <location filename="../app/MainLayout.qml" line="1164"/>
+        <location filename="../app/MainLayout.qml" line="1132"/>
+        <location filename="../app/MainLayout.qml" line="1146"/>
+        <location filename="../app/MainLayout.qml" line="1161"/>
+        <location filename="../app/MainLayout.qml" line="1172"/>
+        <location filename="../app/MainLayout.qml" line="1198"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1131"/>
-        <location filename="../app/MainLayout.qml" line="1171"/>
-        <location filename="../app/MainLayout.qml" line="1201"/>
+        <location filename="../app/MainLayout.qml" line="1139"/>
+        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1220"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1149"/>
+        <location filename="../app/MainLayout.qml" line="1157"/>
         <source>Done</source>
         <translation>完成</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1160"/>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1344"/>
-        <location filename="../app/MainLayout.qml" line="1493"/>
+        <location filename="../app/MainLayout.qml" line="1168"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1364"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
         <source>Retry</source>
         <translation>重试</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1179"/>
+        <location filename="../app/MainLayout.qml" line="1187"/>
         <source>I understand</source>
         <translation>我明白了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1208"/>
+        <location filename="../app/MainLayout.qml" line="1227"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1212"/>
+        <location filename="../app/MainLayout.qml" line="1231"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1009,41 +1154,41 @@ Français - Wilfried</source>
         <translation type="vanished">开始</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1235"/>
-        <location filename="../app/MainLayout.qml" line="1273"/>
-        <location filename="../app/MainLayout.qml" line="1322"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
-        <location filename="../app/MainLayout.qml" line="1470"/>
+        <location filename="../app/MainLayout.qml" line="1255"/>
+        <location filename="../app/MainLayout.qml" line="1293"/>
+        <location filename="../app/MainLayout.qml" line="1342"/>
+        <location filename="../app/MainLayout.qml" line="1398"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1245"/>
+        <location filename="../app/MainLayout.qml" line="1265"/>
         <source>Quit</source>
         <translation>退出</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1254"/>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1306"/>
-        <location filename="../app/MainLayout.qml" line="1336"/>
-        <location filename="../app/MainLayout.qml" line="1354"/>
-        <location filename="../app/MainLayout.qml" line="1366"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1416"/>
-        <location filename="../app/MainLayout.qml" line="1437"/>
-        <location filename="../app/MainLayout.qml" line="1446"/>
-        <location filename="../app/MainLayout.qml" line="1486"/>
-        <location filename="../app/MainLayout.qml" line="1505"/>
+        <location filename="../app/MainLayout.qml" line="1274"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1310"/>
+        <location filename="../app/MainLayout.qml" line="1326"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1386"/>
+        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1436"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1506"/>
+        <location filename="../app/MainLayout.qml" line="1525"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1332"/>
-        <location filename="../app/MainLayout.qml" line="1350"/>
-        <location filename="../app/MainLayout.qml" line="1482"/>
-        <location filename="../app/MainLayout.qml" line="1501"/>
+        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1370"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1521"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1052,25 +1197,25 @@ Français - Wilfried</source>
         <translation type="vanished">页面</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1241"/>
-        <location filename="../app/MainLayout.qml" line="1276"/>
-        <location filename="../app/MainLayout.qml" line="1327"/>
-        <location filename="../app/MainLayout.qml" line="1475"/>
+        <location filename="../app/MainLayout.qml" line="1261"/>
+        <location filename="../app/MainLayout.qml" line="1296"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
+        <location filename="../app/MainLayout.qml" line="1495"/>
         <source>Options</source>
         <translation>选项</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1401"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Change</source>
         <translation>更改</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1407"/>
+        <location filename="../app/MainLayout.qml" line="1427"/>
         <source>Toggle</source>
         <translation>切换</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1433"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Scroll</source>
         <translation>滚动</translation>
     </message>
@@ -1111,7 +1256,7 @@ Français - Wilfried</source>
         <translation>否</translation>
     </message>
     <message>
-        <location filename="../components/Modal.qml" line="258"/>
+        <location filename="../components/Modal.qml" line="260"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
@@ -1150,17 +1295,22 @@ Français - Wilfried</source>
 <context>
     <name>ScreenStateOverlay</name>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="27"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="29"/>
         <source>Nothing here</source>
         <translation>这里什么都没有</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="28"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="65"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <source>Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScreenStateOverlay.qml" line="68"/>
         <source>Failed to load</source>
         <translation>加载失败</translation>
     </message>
@@ -1713,24 +1863,24 @@ Français - Wilfried</source>
 <context>
     <name>SystemsScreen</name>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="252"/>
-        <location filename="../screens/SystemsScreen.qml" line="364"/>
+        <location filename="../screens/SystemsScreen.qml" line="253"/>
+        <location filename="../screens/SystemsScreen.qml" line="365"/>
         <source>%1 systems</source>
         <translation>%1 个系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="253"/>
-        <location filename="../screens/SystemsScreen.qml" line="381"/>
+        <location filename="../screens/SystemsScreen.qml" line="254"/>
+        <location filename="../screens/SystemsScreen.qml" line="382"/>
         <source>%1 / %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="399"/>
+        <location filename="../screens/SystemsScreen.qml" line="400"/>
         <source>No systems in this category</source>
         <translation>此类别中没有系统</translation>
     </message>
     <message>
-        <location filename="../screens/SystemsScreen.qml" line="400"/>
+        <location filename="../screens/SystemsScreen.qml" line="401"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -708,8 +708,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2052"/>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2677"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2679"/>
         <source>Default</source>
         <translation type="unfinished">默认</translation>
     </message>
@@ -719,7 +719,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2579"/>
+        <location filename="../app/Main.qml" line="2581"/>
         <source>Go to...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -728,53 +728,53 @@ Français - Wilfried</source>
         <location filename="../app/Main.qml" line="1807"/>
         <location filename="../app/Main.qml" line="1824"/>
         <location filename="../app/Main.qml" line="1832"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2587"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2589"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2610"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2612"/>
         <source>Favorites</source>
         <translation type="unfinished">收藏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2595"/>
-        <location filename="../app/Main.qml" line="2634"/>
-        <location filename="../app/Main.qml" line="2644"/>
+        <location filename="../app/Main.qml" line="2597"/>
+        <location filename="../app/Main.qml" line="2636"/>
+        <location filename="../app/Main.qml" line="2646"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2623"/>
+        <location filename="../app/Main.qml" line="2625"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
+        <location filename="../app/Main.qml" line="2595"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2666"/>
-        <location filename="../app/Main.qml" line="2681"/>
+        <location filename="../app/Main.qml" line="2668"/>
+        <location filename="../app/Main.qml" line="2683"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2593"/>
-        <location filename="../app/Main.qml" line="2606"/>
+        <location filename="../app/Main.qml" line="2595"/>
+        <location filename="../app/Main.qml" line="2608"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2685"/>
+        <location filename="../app/Main.qml" line="2687"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2614"/>
+        <location filename="../app/Main.qml" line="2616"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -795,189 +795,189 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2352"/>
-        <location filename="../app/Main.qml" line="2372"/>
-        <location filename="../app/Main.qml" line="2396"/>
-        <location filename="../app/Main.qml" line="2435"/>
+        <location filename="../app/Main.qml" line="2374"/>
+        <location filename="../app/Main.qml" line="2398"/>
+        <location filename="../app/Main.qml" line="2437"/>
         <source>OK</source>
         <translation type="unfinished">确定</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2396"/>
+        <location filename="../app/Main.qml" line="2398"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2405"/>
+        <location filename="../app/Main.qml" line="2407"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2406"/>
+        <location filename="../app/Main.qml" line="2408"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2408"/>
+        <location filename="../app/Main.qml" line="2410"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2409"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2413"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2412"/>
+        <location filename="../app/Main.qml" line="2414"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2414"/>
+        <location filename="../app/Main.qml" line="2416"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2415"/>
+        <location filename="../app/Main.qml" line="2417"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2417"/>
+        <location filename="../app/Main.qml" line="2419"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2418"/>
+        <location filename="../app/Main.qml" line="2420"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2420"/>
+        <location filename="../app/Main.qml" line="2422"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2421"/>
+        <location filename="../app/Main.qml" line="2423"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2424"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2426"/>
+        <location filename="../app/Main.qml" line="2428"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2427"/>
+        <location filename="../app/Main.qml" line="2429"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2429"/>
+        <location filename="../app/Main.qml" line="2431"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2430"/>
+        <location filename="../app/Main.qml" line="2432"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2432"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2433"/>
+        <location filename="../app/Main.qml" line="2435"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2505"/>
+        <location filename="../app/Main.qml" line="2507"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2627"/>
-        <location filename="../app/Main.qml" line="2641"/>
+        <location filename="../app/Main.qml" line="2629"/>
+        <location filename="../app/Main.qml" line="2643"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2631"/>
+        <location filename="../app/Main.qml" line="2633"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2659"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2661"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2648"/>
-        <location filename="../app/Main.qml" line="2655"/>
+        <location filename="../app/Main.qml" line="2650"/>
+        <location filename="../app/Main.qml" line="2657"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2662"/>
+        <location filename="../app/Main.qml" line="2664"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2818"/>
-        <location filename="../app/Main.qml" line="2836"/>
+        <location filename="../app/Main.qml" line="2820"/>
+        <location filename="../app/Main.qml" line="2838"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2822"/>
-        <location filename="../app/Main.qml" line="2839"/>
+        <location filename="../app/Main.qml" line="2824"/>
+        <location filename="../app/Main.qml" line="2841"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Card write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Could not write to this card. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2423"/>
-        <location filename="../app/Main.qml" line="2852"/>
+        <location filename="../app/Main.qml" line="2425"/>
+        <location filename="../app/Main.qml" line="2854"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2505"/>
-        <location filename="../app/Main.qml" line="2852"/>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="2507"/>
+        <location filename="../app/Main.qml" line="2854"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>Retry</source>
         <translation type="unfinished">重试</translation>
     </message>
@@ -986,37 +986,37 @@ Français - Wilfried</source>
         <translation type="obsolete">取消</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3707"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3707"/>
+        <location filename="../app/Main.qml" line="3709"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3709"/>
+        <location filename="../app/Main.qml" line="3711"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3712"/>
+        <location filename="../app/Main.qml" line="3714"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3714"/>
+        <location filename="../app/Main.qml" line="3716"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3716"/>
+        <location filename="../app/Main.qml" line="3718"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3720"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -1035,7 +1035,13 @@ TestCase {
         main.presentActionError("next", "Second", "Second body", "OK", null);
         compare(main._actionErrorQueue.length, 1, "different failure waits behind current modal");
         main.handleAction("accept");
+        main.presentActionError("last", "Third", "Third body", "OK", null);
+        compare(main.actionErrorModalVisible, false, "new failure must wait during queued-modal handoff");
+        compare(main._actionErrorQueue.length, 2, "handoff preserves FIFO order");
         tryCompare(main, "actionErrorTitle", "Second");
+        compare(main._actionErrorQueue.length, 1);
+        main.handleAction("cancel");
+        tryCompare(main, "actionErrorTitle", "Third");
         compare(main._actionErrorQueue.length, 0);
         main.handleAction("cancel");
     }

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -10,6 +10,7 @@ import QtQuick
 import QtTest
 import Zaparoo.App
 import Zaparoo.Browse as Browse
+import Zaparoo.Screens
 import Zaparoo.Theme
 
 // Exercises the hub ↔ systems ↔ games navigation state machine defined
@@ -31,12 +32,28 @@ TestCase {
     property string _originalHubCategory: ""
     property int _originalHubSelectedRow: 0
     property string _originalHubSelectedAction: ""
+    property int _actionErrorCallbackCount: 0
+    property int _actionErrorDeliveredCount: 0
 
     Main {
         id: main
         fullScreen: false
         width: 1280
         height: 720
+    }
+
+    SignalSpy {
+        id: actionErrorBatchSpy
+
+        target: Browse.ActionError
+        signalName: "sequenceChanged"
+    }
+
+    Connections {
+        target: Browse.ActionError
+        function onSequenceChanged(): void {
+            testCase._actionErrorDeliveredCount += Browse.ActionError.event_sequences.length;
+        }
     }
 
     Component.onCompleted: {
@@ -98,16 +115,20 @@ TestCase {
         main._resetRapidNavigation();
         main._setFavoritesSystem("");
         Browse.Settings.set_favorites_grouping("none");
+        testCase._actionErrorCallbackCount = 0;
+        testCase._actionErrorDeliveredCount = 0;
     }
 
     function cleanup(): void {
         Motion.enabled = true;
         // A modal left open swallows every routed action, so the next test
         // would fail for a reason that has nothing to do with what it tests.
+        main._actionErrorQueue = [];
+        if (main.actionErrorModalVisible)
+            main.closeActionErrorModal(false);
         if (main.listPickerModalVisible)
             main.closeListPickerModal();
-        if (main.randomFailedModalVisible)
-            main.closeRandomFailedModal();
+        compare(ScreenManager.modalCount, 0, "test leaked modal stack ownership");
         // Restore persistent preferences changed by menu-routing tests.
         Browse.FavoritesModel.set_sort_mode(testCase._originalFavoritesSort);
         Browse.Settings.set_favorites_grouping(testCase._originalFavoritesGrouping);
@@ -311,6 +332,11 @@ TestCase {
     }
 
     function test_enter_on_bottom_landing_routes_to_expected_action(): void {
+        // This test exercises action routing, not optimistic catalog startup.
+        // Make catalog readiness authoritative so Settings does not correctly
+        // wait behind the startup transition cue on slower test runs.
+        const originalCatalogLoaded = Browse.CategoriesModel.loaded;
+        Browse.CategoriesModel.loaded = true;
         // qmllint disable compiler
         // Focus Update only when the build and current network state expose
         // it; otherwise Settings is the production empty-catalog fallback.
@@ -320,6 +346,7 @@ TestCase {
         // qmllint enable compiler
         main.handleKey(Qt.Key_Return);
         compare(main.activeScreen, expectedAction === "update" ? main.screenUpdate : main.screenSettings);
+        Browse.CategoriesModel.loaded = originalCatalogLoaded;
     }
 
     function test_favorite_systems_grid_matches_system_tile_layout(): void {
@@ -947,10 +974,12 @@ TestCase {
             tryCompare(main, "listPickerModalVisible", false);
         }
 
-        main.openListPickerModal("Orientation", [{
-            id: "horizontal",
-            label: "Horizontal"
-        }], "horizontal", "orientation");
+        main.openListPickerModal("Orientation", [
+            {
+                id: "horizontal",
+                label: "Horizontal"
+            }
+        ], "horizontal", "orientation");
         tryCompare(main, "listPickerModalVisible", true);
         main.handleAction("page_menu");
         compare(main.listPickerModalVisible, true, "View must not close an unrelated list picker");
@@ -977,10 +1006,109 @@ TestCase {
         // Harness has no browse scope, so model rejects before issuing RPC.
         Browse.GamesModel.launch_random();
         tryCompare(main, "randomFailedModalVisible", true);
+        compare(main.actionErrorModalVisible, true);
         verify((Browse.GamesModel.random_error ?? "") !== "", "failure reason recorded");
         main.handleAction("cancel");
         tryCompare(main, "randomFailedModalVisible", false);
+        compare(main.actionErrorModalVisible, false);
         compare(Browse.GamesModel.random_error, "", "dismissal clears reason");
+    }
+
+    function test_action_error_owns_input_and_dismisses(): void {
+        main.activeScreen = main.screenHub;
+        const startIndex = main.hubScreen.currentIndex;
+        main.presentActionError("launch:test", "Launch failed", "Safe explanation", "OK", null);
+        compare(main.actionErrorModalVisible, true);
+
+        main.handleAction("right");
+        compare(main.hubScreen.currentIndex, startIndex, "modal must own directional input");
+        main.handleAction("cancel");
+        compare(main.actionErrorModalVisible, false);
+    }
+
+    function test_action_error_deduplicates_and_queues(): void {
+        main.presentActionError("same", "First", "First body", "OK", null);
+        main.presentActionError("same", "Duplicate", "Duplicate body", "OK", null);
+        compare(main.actionErrorTitle, "First");
+        compare(main._actionErrorQueue.length, 0, "same visible failure is deduplicated");
+
+        main.presentActionError("next", "Second", "Second body", "OK", null);
+        compare(main._actionErrorQueue.length, 1, "different failure waits behind current modal");
+        main.handleAction("accept");
+        tryCompare(main, "actionErrorTitle", "Second");
+        compare(main._actionErrorQueue.length, 0);
+        main.handleAction("cancel");
+    }
+
+    function test_action_error_accept_dispatches_retry_once(): void {
+        main.presentActionError("retry", "Retry failed action", "Safe explanation", "Retry", function () {
+            testCase._actionErrorCallbackCount++;
+        });
+        main.handleAction("accept");
+        compare(testCase._actionErrorCallbackCount, 1);
+        compare(main.actionErrorModalVisible, false);
+        main.handleAction("accept");
+        compare(testCase._actionErrorCallbackCount, 1, "dismissed modal cannot repeat callback");
+    }
+
+    function test_action_error_rust_bridge_delivers_all_events(): void {
+        actionErrorBatchSpy.clear();
+        testCase._actionErrorDeliveredCount = 0;
+        const oversizedPayload = "x".repeat(5000);
+        Browse.QrCode.generate(oversizedPayload);
+        compare(Browse.QrCode.size, 0, "first oversized payload must fail generation");
+        Browse.QrCode.generate(oversizedPayload + "y");
+        compare(Browse.QrCode.size, 0, "second oversized payload must fail generation");
+
+        tryCompare(testCase, "_actionErrorDeliveredCount", 2, 1000, "Rust queue must retain both events across batches");
+        verify(actionErrorBatchSpy.count >= 1, "Rust bridge publishes at least one observable batch");
+        tryCompare(main, "actionErrorModalVisible", true);
+        compare(main.actionErrorTitle, "QR code failed");
+        compare(main.actionErrorBody, "Could not create the QR code for this item.");
+        compare(main._actionErrorQueue.length, 0, "same failure kind is deduplicated after bridge delivery");
+        main.handleAction("cancel");
+    }
+
+    function test_systems_error_retry_refetches_catalog(): void {
+        main.activeScreen = main.screenSystems;
+        const originalCategory = Browse.SystemsModel.current_category;
+        const originalError = Browse.SystemsModel.error_message;
+        const originalLoading = Browse.SystemsModel.loading;
+        Browse.SystemsModel.current_category = "Consoles";
+        Browse.SystemsModel.loading = false;
+        main.systemsScreen.optimisticLoading = false;
+        tryCompare(main.systemsScreen, "_overlayLoadingVisible", false);
+        Browse.SystemsModel.error_message = "catalog failed";
+        compare(Browse.SystemsModel.current_category, "Consoles");
+        compare(main.systemsScreen._state(), "error");
+
+        main.systemsScreen.handleAction("accept");
+        compare(Browse.SystemsModel.loading, true, "Retry starts a fresh catalog load");
+        compare(Browse.SystemsModel.error_message, "", "Retry clears terminal error while loading");
+
+        Browse.SystemsModel.current_category = originalCategory;
+        Browse.SystemsModel.error_message = originalError;
+        Browse.SystemsModel.loading = originalLoading;
+    }
+
+    function test_media_error_hides_live_content(): void {
+        main.activeScreen = main.screenGames;
+        const originalError = Browse.GamesModel.error_message;
+        Browse.GamesModel.error_message = "raw rpc detail";
+        compare(main.gamesScreen._gateHide, true);
+        compare(main.gamesScreen.gamesGrid.visible, false);
+        compare(main.gamesScreen.listCard.visible, false);
+        compare(main.gamesScreen.activeLabel.visible, false);
+        Browse.GamesModel.error_message = originalError;
+
+        main.activeScreen = main.screenSystems;
+        const originalSystemsError = Browse.SystemsModel.error_message;
+        Browse.SystemsModel.error_message = "raw catalog detail";
+        compare(main.systemsScreen._gateHide, true);
+        compare(main.systemsScreen.systemsGrid.visible, false);
+        compare(main.systemsScreen.listCard.visible, false);
+        compare(main.systemsScreen.activeLabel.visible, false);
+        Browse.SystemsModel.error_message = originalSystemsError;
     }
 
     function test_games_filter_selection_applies_and_persists(): void {


### PR DESCRIPTION
## Summary

- route recoverable action failures through a lossless Rust/QML event bridge into localized standard error modals
- deduplicate repeated failures, enforce modal input ownership, and provide Retry, Restart, or OK actions
- fully replace live screen content during eligible inline load errors and make Systems retry fetch fresh catalog data
- add routing, dismissal, retry, retained-event, and content-hiding coverage

## Testing

- `just lint`
- `just test`

Closes #328

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified action-error dialog for launch, media, favorite, QR, card, settings, and upload failures.
  * Added queued, deduplicated error notifications with contextual retry actions.
  * Added retry controls for favorites, recents, systems, catalog loading, game details, and other operations.
  * Improved error-state screens by hiding unavailable content and presenting clearer guidance.
* **Bug Fixes**
  * QR-code views now open only after successful generation.
  * Error messages are displayed as plain text with clearer network and loading guidance.
* **Translations**
  * Updated localized error, retry, loading, and navigation strings across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->