### PR TITLE
fix(browse): continue favorites and recents paging

### DIFF
--- a/rust/frontend/src/models/favorites.rs
+++ b/rust/frontend/src/models/favorites.rs
@@ -98,8 +98,6 @@ pub struct FavoritesModelRust {
     // action to this canonical Core system ID.
     current_system_id: QString,
     count: i32,
-    // Core's total across every cursor page. -1 means unknown.
-    total_items: i32,
     loading: bool,
     loading_more: bool,
     error_message: QString,
@@ -154,7 +152,6 @@ impl Default for FavoritesModelRust {
             sort_mode: QString::default(),
             current_system_id: QString::default(),
             count: 0,
-            total_items: -1,
             loading: false,
             loading_more: false,
             error_message: QString::default(),
@@ -207,7 +204,6 @@ pub mod ffi {
         #[qml_element]
         #[qml_singleton]
         #[qproperty(i32, count)]
-        #[qproperty(i32, total_items)]
         #[qproperty(bool, loading)]
         #[qproperty(bool, loading_more)]
         #[qproperty(QString, error_message)]
@@ -370,15 +366,7 @@ impl cxx_qt::Initialize for ffi::FavoritesModel {
 /// Snapshot of a single page that `apply_state` can write onto the
 /// model. Carried by value so the closure is `Send + 'static` for the
 /// `qt_thread` queue.
-type PageSnapshot = (Vec<MediaItem>, bool, Option<String>, i32);
-
-fn total_items_hint(total: i64) -> i32 {
-    if total < 0 {
-        -1
-    } else {
-        i32::try_from(total).unwrap_or(i32::MAX)
-    }
-}
+type PageSnapshot = (Vec<MediaItem>, bool, Option<String>);
 
 /// Project the resource status onto an `(Option<PageSnapshot>, error)`
 /// tuple. `Idle`/`Loading` map to the same `(None, "")` shape so the
@@ -390,7 +378,6 @@ fn project(status: &ResourceStatus<MediaSearchResult>) -> (Option<PageSnapshot>,
                 data.results.clone(),
                 data.has_next_page(),
                 data.next_cursor(),
-                total_items_hint(data.total),
             )),
             String::new(),
         ),
@@ -404,7 +391,7 @@ fn apply_state(
     (data, err): (Option<PageSnapshot>, String),
 ) {
     let apply_started = Instant::now();
-    if let Some((entries, has_next_page, next_cursor, total_items)) = data {
+    if let Some((entries, has_next_page, next_cursor)) = data {
         if model.nav_timing.is_none() {
             model.as_mut().rust_mut().nav_timing = Some(NavTiming::new("cache"));
         }
@@ -421,9 +408,6 @@ fn apply_state(
         clear_current_detail_state(model.as_mut());
         let count = i32::try_from(entries.len()).unwrap_or(i32::MAX);
         let displays = compute_favorites_disambig_displays(&entries, model.show_original_filenames);
-        if model.total_items != total_items {
-            model.as_mut().set_total_items(total_items);
-        }
         model.as_mut().begin_reset_model();
         {
             let mut rust = model.as_mut().rust_mut();
@@ -1721,6 +1705,14 @@ fn apply_append_page(
         }
         Err(e) => {
             warn!("media.search follow-up page failed: {}", e.message);
+            // A pending PagedGrid target chains another request whenever
+            // loading_more falls while has_next_page remains true. Disarm the
+            // failed cursor first so the grid settles and waits for explicit
+            // retry instead of spinning on the same RPC indefinitely.
+            model.as_mut().rust_mut().next_cursor = None;
+            if model.has_next_page {
+                model.as_mut().set_has_next_page(false);
+            }
             model
                 .as_mut()
                 .set_error_message(QString::from(e.message.as_str()));
@@ -1743,14 +1735,6 @@ mod tests {
             },
             ..Default::default()
         }
-    }
-
-    #[test]
-    fn total_items_hint_preserves_unknown_and_clamps_large_totals() {
-        assert_eq!(total_items_hint(-1), -1);
-        assert_eq!(total_items_hint(0), 0);
-        assert_eq!(total_items_hint(42), 42);
-        assert_eq!(total_items_hint(i64::MAX), i32::MAX);
     }
 
     #[test]

--- a/rust/frontend/src/models/recents.rs
+++ b/rust/frontend/src/models/recents.rs
@@ -1787,6 +1787,14 @@ fn apply_append_page(
         }
         Err(e) => {
             warn!("media.history follow-up page failed: {}", e.message);
+            // A pending PagedGrid target chains another request whenever
+            // loading_more falls while has_next_page remains true. Disarm the
+            // failed cursor first so the grid settles and waits for explicit
+            // retry instead of spinning on the same RPC indefinitely.
+            model.as_mut().rust_mut().next_cursor = None;
+            if model.has_next_page {
+                model.as_mut().set_has_next_page(false);
+            }
             model
                 .as_mut()
                 .set_error_message(QString::from(e.message.as_str()));

--- a/rust/mock-core/src/fixtures.rs
+++ b/rust/mock-core/src/fixtures.rs
@@ -210,8 +210,9 @@ pub fn media_search_response(params: &Value) -> Value {
     // rejects maxResults=0 outright; the mock just terminates the chain.
     let has_next_page = !results.is_empty() && next_offset < total;
 
-    // `total` is deprecated upstream and always returns -1; pagination
-    // info travels under the `pagination` envelope.
+    // Real Core keeps this deprecated field for compatibility, but it is only
+    // the current page length. Clients must use the pagination envelope.
+    let page_total = results.len();
     let mut pagination = json!({
         "hasNextPage": has_next_page,
         "pageSize": max,
@@ -221,7 +222,7 @@ pub fn media_search_response(params: &Value) -> Value {
     }
     json!({
         "results": results,
-        "total": -1,
+        "total": page_total,
         "pagination": pagination,
     })
 }

--- a/rust/mock-core/src/handler.rs
+++ b/rust/mock-core/src/handler.rs
@@ -206,14 +206,16 @@ mod tests {
         // A page that covers every row reports no next page and no cursor.
         let req = r#"{"jsonrpc":"2.0","id":"1","method":"media.search","params":{"systems":[],"maxResults":1000}}"#;
         let resp = parse(&dispatch(req));
+        let results = resp["result"]["results"].as_array().expect("array");
         let pagination = resp["result"]["pagination"]
             .as_object()
             .expect("pagination object");
         assert_eq!(pagination["hasNextPage"], Value::Bool(false));
         assert_eq!(pagination["pageSize"], Value::from(1000));
         assert!(!pagination.contains_key("nextCursor"));
-        // Deprecated but still present for backward compatibility.
-        assert_eq!(resp["result"]["total"], Value::from(-1));
+        // Deprecated current-page count, matching real Core. It is not the
+        // dataset total and must not be used to stop cursor pagination.
+        assert_eq!(resp["result"]["total"], Value::from(results.len()));
     }
 
     // Favorites uses cursor pagination. Short pages must advertise a next
@@ -225,6 +227,7 @@ mod tests {
         ));
         let page1 = first["result"]["results"].as_array().expect("array");
         assert_eq!(page1.len(), 5);
+        assert_eq!(first["result"]["total"], Value::from(5));
         assert_eq!(
             first["result"]["pagination"]["hasNextPage"],
             Value::Bool(true)

--- a/rust/zaparoo-core/src/media_types.rs
+++ b/rust/zaparoo-core/src/media_types.rs
@@ -204,9 +204,8 @@ pub struct MediaSearchResult {
     /// through, matching `MediaBrowseResult`/`MediaHistoryResult`.
     #[serde(default)]
     pub pagination: Option<Pagination>,
-    /// Total result count across all pages. Core can return `-1` to
-    /// signal "unknown / unbounded" so this is intentionally not used as
-    /// an iteration bound; treat it as a UI hint only.
+    /// Deprecated current-page result count. This is not a dataset total and
+    /// must never bound cursor pagination.
     #[serde(default)]
     pub total: i64,
 }

--- a/src/ui/components/PagedGrid.qml
+++ b/src/ui/components/PagedGrid.qml
@@ -182,7 +182,10 @@ Item {
     // this to their model's authoritative total so the thumb stays
     // stable while `fetch_more` grows the slice in the background.
     property int totalItemsOverride: -1
-    readonly property int totalItems: totalItemsOverride >= 0 ? totalItemsOverride : itemCount
+    // Unknown-length cursor lists must derive navigation only from loaded rows
+    // and `hasMorePages`. Ignore any stale/legacy total hint until a caller
+    // explicitly declares its total authoritative.
+    readonly property int totalItems: paginationTotalKnown && totalItemsOverride >= 0 ? totalItemsOverride : itemCount
     readonly property int totalPageCount: Math.max(1, Math.ceil(totalItems / pageSize))
     // False when a cursor chain has no authoritative final count. Navigation
     // continues forward by requesting another page instead of wrapping at the
@@ -444,11 +447,11 @@ Item {
         }
         if (root._pendingTargetPage < 0)
             return;
-        // Total may have shrunk under us (e.g. Core revised total_files
-        // downward); clamp the target to whatever the dataset reports
-        // now so we never overshoot.
+        // Known totals may shrink under us, so clamp to their reported final
+        // page. Unknown-length cursor lists cannot clamp while another page
+        // exists: their loaded total necessarily trails the pending target.
         const totalLast = root.totalPageCount - 1;
-        const targetPage = Math.min(root._pendingTargetPage, totalLast);
+        const targetPage = root.paginationTotalKnown || !root.hasMorePages ? Math.min(root._pendingTargetPage, totalLast) : root._pendingTargetPage;
         if (targetPage < 0) {
             root._pendingTargetPage = -1;
             return;

--- a/src/ui/screens/FavoritesScreen.qml
+++ b/src/ui/screens/FavoritesScreen.qml
@@ -24,7 +24,6 @@ MediaListScreen {
 
     property alias favoritesGrid: favorites.mediaGrid
     property string selectedSystemId: ""
-    readonly property int favoriteTotal: Browse.FavoritesModel.total_items
 
     mediaModel: Browse.FavoritesModel
     mediaState: Browse.FavoritesState
@@ -32,13 +31,10 @@ MediaListScreen {
     emptyText: qsTr("No favorites yet")
     loadingText: qsTr("Loading favorites…")
     detailShowTitle: false
-    totalItemsOverride: favorites.favoriteTotal > 0 ? favorites.favoriteTotal : -1
-    gridTotalItemsOverride: favorites.favoriteTotal > 0 ? favorites.favoriteTotal : -1
     gridHasMorePages: Browse.FavoritesModel.has_next_page
+    gridLoadingMore: Browse.FavoritesModel.loading_more
     paginationTotalKnown: false
     gridTileTopLabelProvider: favorites.selectedSystemId === "" ? (index => Browse.FavoritesModel.system_name_at(index)) : null
-    topStripTotalPagesProvider: () => favorites.mediaGrid.totalPageCount
-    topStripTotalTextProvider: () => favorites.favoriteTotal >= 0 ? qsTr("%n favorite(s)", "", favorites.favoriteTotal) : ""
     pageMenuEnabledWhenEmpty: true
     retryAction: () => Browse.FavoritesModel.retry()
 

--- a/src/ui/screens/RecentsScreen.qml
+++ b/src/ui/screens/RecentsScreen.qml
@@ -26,6 +26,7 @@ MediaListScreen {
     loadingText: qsTr("Loading recently played…")
     detailShowTitle: false
     gridHasMorePages: Browse.RecentsModel.has_next_page
+    gridLoadingMore: Browse.RecentsModel.loading_more
     paginationTotalKnown: false
     gridTileTopLabelProvider: index => Browse.RecentsModel.system_name_at(index)
     retryAction: () => Browse.RecentsModel.retry()

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -412,31 +412,19 @@ Français - Wilfried</source>
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="31"/>
+        <location filename="../screens/FavoritesScreen.qml" line="30"/>
         <source>Favorites</source>
         <translation>المفضلة</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="32"/>
+        <location filename="../screens/FavoritesScreen.qml" line="31"/>
         <source>No favorites yet</source>
         <translation>لا توجد مفضلات بعد</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="33"/>
+        <location filename="../screens/FavoritesScreen.qml" line="32"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../screens/FavoritesScreen.qml" line="41"/>
-        <source>%n favorite(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
     </message>
     <message>
         <source>%1 entries</source>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -404,27 +404,19 @@ Français - Wilfried</source>
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="31"/>
+        <location filename="../screens/FavoritesScreen.qml" line="30"/>
         <source>Favorites</source>
         <translation>Favoriten</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="32"/>
+        <location filename="../screens/FavoritesScreen.qml" line="31"/>
         <source>No favorites yet</source>
         <translation>Noch keine Favoriten</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="33"/>
+        <location filename="../screens/FavoritesScreen.qml" line="32"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../screens/FavoritesScreen.qml" line="41"/>
-        <source>%n favorite(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
     </message>
     <message>
         <source>%1 entries</source>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -404,27 +404,19 @@ Français - Wilfried</source>
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="31"/>
+        <location filename="../screens/FavoritesScreen.qml" line="30"/>
         <source>Favorites</source>
         <translation>Αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="32"/>
+        <location filename="../screens/FavoritesScreen.qml" line="31"/>
         <source>No favorites yet</source>
         <translation>Δεν υπάρχουν αγαπημένα ακόμα</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="33"/>
+        <location filename="../screens/FavoritesScreen.qml" line="32"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../screens/FavoritesScreen.qml" line="41"/>
-        <source>%n favorite(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
     </message>
     <message>
         <source>%1 entries</source>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -384,24 +384,23 @@ Français - Wilfried</source>
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="31"/>
+        <location filename="../screens/FavoritesScreen.qml" line="30"/>
         <source>Favorites</source>
         <translation>Favorites</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="32"/>
+        <location filename="../screens/FavoritesScreen.qml" line="31"/>
         <source>No favorites yet</source>
         <translation>No favorites yet</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="33"/>
+        <location filename="../screens/FavoritesScreen.qml" line="32"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../screens/FavoritesScreen.qml" line="41"/>
         <source>%n favorite(s)</source>
-        <translation>
+        <translation type="vanished">
             <numerusform>%n favorite</numerusform>
             <numerusform>%n favorites</numerusform>
         </translation>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -404,27 +404,19 @@ Français - Wilfried</source>
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="31"/>
+        <location filename="../screens/FavoritesScreen.qml" line="30"/>
         <source>Favorites</source>
         <translation>Favoritos</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="32"/>
+        <location filename="../screens/FavoritesScreen.qml" line="31"/>
         <source>No favorites yet</source>
         <translation>Aún no hay favoritos</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="33"/>
+        <location filename="../screens/FavoritesScreen.qml" line="32"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../screens/FavoritesScreen.qml" line="41"/>
-        <source>%n favorite(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
     </message>
     <message>
         <source>%1 entries</source>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -404,27 +404,19 @@ Français - Wilfried</source>
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="31"/>
+        <location filename="../screens/FavoritesScreen.qml" line="30"/>
         <source>Favorites</source>
         <translation>Gogokoak</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="32"/>
+        <location filename="../screens/FavoritesScreen.qml" line="31"/>
         <source>No favorites yet</source>
         <translation>Ez duzu gogokorik oraindik</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="33"/>
+        <location filename="../screens/FavoritesScreen.qml" line="32"/>
         <source>Loading favorites…</source>
         <translation type="unfinished">Gogokoak kargatzen...</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../screens/FavoritesScreen.qml" line="41"/>
-        <source>%n favorite(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
     </message>
     <message>
         <source>%1 entries</source>

--- a/src/ui/translations/frontend_fr.ts
+++ b/src/ui/translations/frontend_fr.ts
@@ -387,27 +387,19 @@ Français - Wilfried</translation>
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="31"/>
+        <location filename="../screens/FavoritesScreen.qml" line="30"/>
         <source>Favorites</source>
         <translation>Favoris</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="32"/>
+        <location filename="../screens/FavoritesScreen.qml" line="31"/>
         <source>No favorites yet</source>
         <translation>Aucun favori pour l&apos;instant</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="33"/>
+        <location filename="../screens/FavoritesScreen.qml" line="32"/>
         <source>Loading favorites…</source>
         <translation>Chargement des favoris…</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../screens/FavoritesScreen.qml" line="41"/>
-        <source>%n favorite(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
     </message>
 </context>
 <context>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -404,27 +404,19 @@ Français - Wilfried</source>
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="31"/>
+        <location filename="../screens/FavoritesScreen.qml" line="30"/>
         <source>Favorites</source>
         <translation>מועדפים</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="32"/>
+        <location filename="../screens/FavoritesScreen.qml" line="31"/>
         <source>No favorites yet</source>
         <translation>עדיין אין מועדפים</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="33"/>
+        <location filename="../screens/FavoritesScreen.qml" line="32"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../screens/FavoritesScreen.qml" line="41"/>
-        <source>%n favorite(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
     </message>
     <message>
         <source>%1 entries</source>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -404,27 +404,19 @@ Français - Wilfried</source>
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="31"/>
+        <location filename="../screens/FavoritesScreen.qml" line="30"/>
         <source>Favorites</source>
         <translation>पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="32"/>
+        <location filename="../screens/FavoritesScreen.qml" line="31"/>
         <source>No favorites yet</source>
         <translation>अभी तक कोई पसंदीदा नहीं</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="33"/>
+        <location filename="../screens/FavoritesScreen.qml" line="32"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../screens/FavoritesScreen.qml" line="41"/>
-        <source>%n favorite(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
     </message>
     <message>
         <source>%1 entries</source>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -404,27 +404,19 @@ Français - Wilfried</source>
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="31"/>
+        <location filename="../screens/FavoritesScreen.qml" line="30"/>
         <source>Favorites</source>
         <translation>Preferiti</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="32"/>
+        <location filename="../screens/FavoritesScreen.qml" line="31"/>
         <source>No favorites yet</source>
         <translation>Nessun preferito ancora</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="33"/>
+        <location filename="../screens/FavoritesScreen.qml" line="32"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../screens/FavoritesScreen.qml" line="41"/>
-        <source>%n favorite(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
     </message>
     <message>
         <source>%1 entries</source>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -402,26 +402,19 @@ Français - Wilfried</source>
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="31"/>
+        <location filename="../screens/FavoritesScreen.qml" line="30"/>
         <source>Favorites</source>
         <translation>お気に入り</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="32"/>
+        <location filename="../screens/FavoritesScreen.qml" line="31"/>
         <source>No favorites yet</source>
         <translation>お気に入りはまだありません</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="33"/>
+        <location filename="../screens/FavoritesScreen.qml" line="32"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../screens/FavoritesScreen.qml" line="41"/>
-        <source>%n favorite(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
     </message>
     <message>
         <source>%1 entries</source>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -402,26 +402,19 @@ Français - Wilfried</source>
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="31"/>
+        <location filename="../screens/FavoritesScreen.qml" line="30"/>
         <source>Favorites</source>
         <translation>즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="32"/>
+        <location filename="../screens/FavoritesScreen.qml" line="31"/>
         <source>No favorites yet</source>
         <translation>아직 즐겨찾기가 없습니다</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="33"/>
+        <location filename="../screens/FavoritesScreen.qml" line="32"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../screens/FavoritesScreen.qml" line="41"/>
-        <source>%n favorite(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
     </message>
     <message>
         <source>%1 entries</source>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -404,27 +404,19 @@ Français - Wilfried</source>
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="31"/>
+        <location filename="../screens/FavoritesScreen.qml" line="30"/>
         <source>Favorites</source>
         <translation>Favorieten</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="32"/>
+        <location filename="../screens/FavoritesScreen.qml" line="31"/>
         <source>No favorites yet</source>
         <translation>Nog geen favorieten</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="33"/>
+        <location filename="../screens/FavoritesScreen.qml" line="32"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../screens/FavoritesScreen.qml" line="41"/>
-        <source>%n favorite(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
     </message>
     <message>
         <source>%1 entries</source>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -406,28 +406,19 @@ Français - Wilfried</source>
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="31"/>
+        <location filename="../screens/FavoritesScreen.qml" line="30"/>
         <source>Favorites</source>
         <translation>Favorite</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="32"/>
+        <location filename="../screens/FavoritesScreen.qml" line="31"/>
         <source>No favorites yet</source>
         <translation>Nicio intrare la favorite</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="33"/>
+        <location filename="../screens/FavoritesScreen.qml" line="32"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../screens/FavoritesScreen.qml" line="41"/>
-        <source>%n favorite(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
     </message>
     <message>
         <source>%1 entries</source>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -406,28 +406,19 @@ Français - Wilfried</source>
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="31"/>
+        <location filename="../screens/FavoritesScreen.qml" line="30"/>
         <source>Favorites</source>
         <translation>Obľúbené</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="32"/>
+        <location filename="../screens/FavoritesScreen.qml" line="31"/>
         <source>No favorites yet</source>
         <translation>Zatiaľ žiadne obľúbené</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="33"/>
+        <location filename="../screens/FavoritesScreen.qml" line="32"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../screens/FavoritesScreen.qml" line="41"/>
-        <source>%n favorite(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
     </message>
     <message>
         <source>%1 entries</source>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -406,28 +406,19 @@ Français - Wilfried</source>
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="31"/>
+        <location filename="../screens/FavoritesScreen.qml" line="30"/>
         <source>Favorites</source>
         <translation>Вибране</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="32"/>
+        <location filename="../screens/FavoritesScreen.qml" line="31"/>
         <source>No favorites yet</source>
         <translation>Поки немає вибраного</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="33"/>
+        <location filename="../screens/FavoritesScreen.qml" line="32"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../screens/FavoritesScreen.qml" line="41"/>
-        <source>%n favorite(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-            <numerusform></numerusform>
-        </translation>
     </message>
     <message>
         <source>%1 entries</source>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -402,26 +402,19 @@ Français - Wilfried</source>
 <context>
     <name>FavoritesScreen</name>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="31"/>
+        <location filename="../screens/FavoritesScreen.qml" line="30"/>
         <source>Favorites</source>
         <translation>收藏</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="32"/>
+        <location filename="../screens/FavoritesScreen.qml" line="31"/>
         <source>No favorites yet</source>
         <translation>还没有收藏</translation>
     </message>
     <message>
-        <location filename="../screens/FavoritesScreen.qml" line="33"/>
+        <location filename="../screens/FavoritesScreen.qml" line="32"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
-    </message>
-    <message numerus="yes">
-        <location filename="../screens/FavoritesScreen.qml" line="41"/>
-        <source>%n favorite(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
-        </translation>
     </message>
     <message>
         <source>%1 entries</source>

--- a/tests/ui/tst_paged_grid.qml
+++ b/tests/ui/tst_paged_grid.qml
@@ -506,6 +506,55 @@ TestCase {
         compare(grid.hasPendingTarget, false);
     }
 
+    function test_unbounded_list_ignores_stale_total_hint(): void {
+        fillModel(24);
+        grid.totalItemsOverride = 5;
+        grid.paginationTotalKnown = false;
+        compare(grid.totalItems, 24);
+        compare(grid.totalPageCount, 2);
+    }
+
+    function test_unbounded_pending_page_commits_after_append(): void {
+        fillModel(24);
+        // Real Core's deprecated media.search total equals current page size.
+        // It must not clamp an unknown-length cursor chain.
+        grid.totalItemsOverride = 5;
+        grid.paginationTotalKnown = false;
+        grid.hasMorePages = true;
+        grid.setCurrentIndexImmediate(12);
+        compare(grid.pageBy(1), false);
+        compare(grid._pendingTargetPage, 2);
+
+        for (let i = 24; i < 36; i++)
+            model.append({
+                "name": "item-" + i,
+                "coverKey": "",
+                "favorite": 0
+            });
+        tryCompare(grid, "itemCount", 36);
+        compare(grid.currentIndex, 24);
+        compare(grid._pendingTargetPage, -1);
+    }
+
+    function test_failed_unbounded_page_does_not_auto_retry(): void {
+        fillModel(24);
+        grid.paginationTotalKnown = false;
+        grid.hasMorePages = true;
+        grid.loadingMore = true;
+        grid.setCurrentIndexImmediate(12);
+        compare(grid.pageBy(1), false);
+        compare(grid._pendingTargetPage, 2);
+
+        // Models publish hasMorePages=false before loadingMore=false on a
+        // failed cursor request. The first edge must settle pending navigation
+        // so the completion edge cannot request the same cursor again.
+        grid.hasMorePages = false;
+        compare(grid._pendingTargetPage, -1);
+        loadMoreSpy.clear();
+        grid.loadingMore = false;
+        compare(loadMoreSpy.count, 0);
+    }
+
     // ── Scroll thumb sizing (totalItemsOverride) ─────────────────────────
 
     function test_totalPageCount_uses_override(): void {


### PR DESCRIPTION
## Summary

- treat Favorites and Recents as unknown-length cursor lists and load pages until Core reports no continuation
- ignore deprecated page-local `media.search.total` values when calculating navigation
- settle failed follow-up requests for explicit retry instead of automatically retrying forever
- align mock Core behavior and add unknown-total, append, and failure regressions

## Verification

- `just fmt`
- `just lint`
- `just test`

Closes #381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved favorites and recents pagination after failed requests, preventing repeated retries.
  - Updated pagination behavior for lists with unknown totals, ensuring navigation remains available as more items load.
  - Favorites no longer display an unreliable overall item count.
  - Search result counts now accurately reflect the current page.
- **Localization**
  - Updated Favorites screen translations across supported languages and removed the obsolete favorite-count message.
- **Tests**
  - Added coverage for unknown-length pagination and failed page-load handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->