### PR TITLE
feat(browse): adopt Core's merged system-root browse view

### DIFF
--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -8,16 +8,19 @@
 // Two paths into the model:
 //
 //   * `set_system(id)` — entry from SystemsScreen accept. Issues
-//     `media.browse({systems: [id]})` (system-scoped roots). When the
-//     scoped roots collapse to a single folder entry, we auto-navigate
-//     into that folder so the user never sees a 1-item list — most
-//     systems have one root and showing it standalone would be empty
-//     ceremony.
+//     `media.browse({systems: [id]})`, which Core answers with a merged,
+//     one-level view of the system's launcher routes (`rootView:
+//     "contents"`, see `merged_root_view`) rather than a route to pick.
+//     The one remaining single-entry case worth auto-navigating past is a
+//     lone `root` row: either a virtual-only system Core never merges
+//     (MiSTer Arcade's single `mame-arcade://` route), or an older Core
+//     still returning its pre-merge routes list. See `decide_initial`.
 //
 //   * `set_path(path)` — entry from a folder accept inside the games
 //     screen. Issues `media.browse({path, systems: [current_system]})`.
 //     No auto-navigation; explicit folder navigation is treated as
-//     intent.
+//     intent (MiSTer's single-child-folder flatten aside, see
+//     `decide_initial`).
 //
 // `fetch_more()` advances pagination without resetting the model:
 // `begin_insert_rows` appends entries from the next cursor onto the
@@ -58,8 +61,8 @@ use zaparoo_core::endpoints::media_tags_update::MediaTagsUpdateMutation;
 use zaparoo_core::endpoints::readers_write::ReadersWriteMutation;
 use zaparoo_core::endpoints::run::RunMutation;
 use zaparoo_core::media_types::{
-    BrowseEntry, MediaBrowseIndexParams, MediaBrowseParams, MediaBrowseResult, MediaMeta,
-    MediaMetaParams, MediaTagsUpdateParams, ReadersWriteParams, RunParams, TagInfo,
+    merged_root_view, BrowseEntry, MediaBrowseIndexParams, MediaBrowseParams, MediaBrowseResult,
+    MediaMeta, MediaMetaParams, MediaTagsUpdateParams, ReadersWriteParams, RunParams, TagInfo,
 };
 use zaparoo_core::platform::{self, Platform};
 use zaparoo_core::remote_resource::ResourceStatus;
@@ -819,6 +822,7 @@ impl ffi::GamesModel {
         // append no longer belongs to the current page chain and
         // would corrupt the freshly-reset entries.
         let expected_prev_cursor = cursor.clone();
+        let root_view = merged_root_view(&path, &systems);
         global_handle().spawn(async move {
             let result = store
                 .client()
@@ -830,6 +834,7 @@ impl ffi::GamesModel {
                     tags,
                     letter: None,
                     sort: None,
+                    root_view,
                 })
                 .await;
             let _ = qt_thread.queue(move |model| {
@@ -848,18 +853,22 @@ impl ffi::GamesModel {
     /// user picks "Jump to letter".
     fn load_letter_index(mut self: Pin<&mut Self>) {
         let path = self.current_path.to_string();
-        // A root listing has no meaningful first-character rail.
-        if path.is_empty() {
-            self.as_mut().set_letter_index_json(QString::from("[]"));
-            self.as_mut().set_letter_index_scheme(QString::from("none"));
-            return;
-        }
         let sid = self.current_system_id.to_string();
         let systems = if sid.is_empty() {
             Vec::new()
         } else {
             vec![sid]
         };
+        let root_view = merged_root_view(&path, &systems);
+        // A pathless, systemless listing (the unscoped root) has no
+        // meaningful first-character rail. A merged system root
+        // (`root_view` is `Some`, see `merged_root_view`) is an ordinary
+        // media list and gets a rail like any folder.
+        if path.is_empty() && root_view.is_none() {
+            self.as_mut().set_letter_index_json(QString::from("[]"));
+            self.as_mut().set_letter_index_scheme(QString::from("none"));
+            return;
+        }
         let tags = favorites_tags(self.favorites_only);
         // Clear any facet from a prior scope to the loading state (empty groups,
         // empty scheme) so the rail shows "loading" rather than the previous
@@ -880,6 +889,7 @@ impl ffi::GamesModel {
                     systems,
                     tags,
                     sort: None,
+                    root_view,
                 })
                 .await;
             let _ = qt_thread.queue(move |mut model| {
@@ -1495,10 +1505,10 @@ impl ffi::GamesModel {
     /// queued callbacks bail unless the ticket still matches.
     ///
     /// `eligible_for_auto_nav` is set when this load came from
-    /// `set_system`. The single-root auto-nav case in
-    /// `apply_initial_page` consumes the flag to decide whether to skip
-    /// rendering the 1-item roots list and dive straight into that
-    /// root.
+    /// `set_system`. `decide_initial` consumes the flag to decide whether
+    /// to skip rendering a lone leftover `root` entry (a virtual-only
+    /// system, or an older Core's pre-merge routes list) and dive straight
+    /// into it.
     fn start_initial_browse(
         mut self: Pin<&mut Self>,
         path: String,
@@ -2848,17 +2858,36 @@ fn decide_initial(
     platform: Option<&Platform>,
     current_path: &str,
 ) -> InitialAction {
-    // On MiSTer, single-folder loads also flatten on `set_path`. MiSTer
-    // collections often unzip into nested single-child folders; the
-    // recursion in `apply_status` calls `start_initial_browse(... false)`
-    // on the auto-nav target, so a chain of single-child folders
-    // collapses all the way down on each navigation step.
-    let mister_set_path_flatten = matches!(platform, Some(Platform::Mister));
-    let single_entry_flatten = eligible_after_set_system || mister_set_path_flatten;
-    if !single_entry_flatten || result.entries.len() != 1 {
+    if result.entries.len() != 1 {
         return InitialAction::Apply;
     }
     let entry = &result.entries[0];
+    if current_path.is_empty() {
+        // At the top of a system, Core's merged root (`rootView: "contents"`,
+        // see `merged_root_view`) can legitimately render as one directory --
+        // that's just a system with one subfolder of games, not a route to
+        // skip past. Only a lone `root` entry is a route: either an older
+        // Core still returning the unmerged routes list, or a virtual-only
+        // system (e.g. MiSTer Arcade's single `mame-arcade://` route) that
+        // Core never merges. Diving into anything else here would be a trap:
+        // `Main.qml`'s `_navigateOutOfFolder` refuses to pop below the top
+        // of the path stack, so the user could never get back to this level.
+        if !eligible_after_set_system || entry.entry_type != "root" {
+            return InitialAction::Apply;
+        }
+    } else {
+        // On MiSTer, single-folder loads also flatten on `set_path`. MiSTer
+        // collections often unzip into nested single-child folders; the
+        // recursion in `apply_status` calls `start_initial_browse(... false)`
+        // on the auto-nav target, so a chain of single-child folders
+        // collapses all the way down on each navigation step. This only
+        // applies below the system root -- see the empty-`current_path`
+        // branch above for the root-level rule.
+        let mister_set_path_flatten = matches!(platform, Some(Platform::Mister));
+        if !eligible_after_set_system && !mister_set_path_flatten {
+            return InitialAction::Apply;
+        }
+    }
     // Cycle guard: refuse to auto-nav into the path we're already on.
     // Prevents stack overflow if Core erroneously returns a folder
     // whose path equals the parent.
@@ -2913,11 +2942,14 @@ fn display_name<'a>(raw: &'a str, platform: Option<&Platform>) -> std::borrow::C
 }
 
 /// Drop any root-type entry whose path is a strict ancestor of another
-/// root entry's path. Defends against Core occasionally surfacing the
-/// shared parent dir (e.g. `/media/fat/games`) as a system root alongside
-/// the actual per-system roots beneath it; the parent appears as a
-/// phantom option in the frontend's roots screen, and selecting it
-/// browses into a directory that contains every other system.
+/// root entry's path. A Core new enough to merge system roots
+/// (`merged_root_view`) never sends this shape; this now only defends the
+/// pre-merge routes list an older Core still returns, where the shared
+/// parent dir (e.g. `/media/fat/games`) can occasionally surface as a
+/// system root alongside the actual per-system roots beneath it. Left in
+/// place unchanged: the parent would otherwise appear as a phantom option
+/// in that fallback list, and selecting it browses into a directory that
+/// contains every other system.
 ///
 /// Only `root`-type entries participate. `directory` and `media` entries
 /// pass through unchanged — a normal directory listing where a folder
@@ -2951,16 +2983,17 @@ fn is_strict_ancestor_path(parent: &str, child: &str) -> bool {
         .is_some_and(|rest| rest.starts_with('/'))
 }
 
-/// Round 11 interim fix for the "which root do I pick" roots screen (a
-/// full client-side merge is deferred to Core -- see the round-11 plan).
-/// A system with multiple configured folders shows one identically-named
-/// `root` row per folder, with nothing distinguishing them; find the
-/// first path component where the page's root entries disagree and
-/// return that component per entry ("fat" vs "usb0", "games" vs
-/// "games2"). Returned `Vec` is the same length and order as `entries`;
-/// non-root entries and any root that never needed disambiguating (fewer
-/// than two roots on the page, or one identical to every sibling up to
-/// where paths run out) get `""`.
+/// Round 11's "which root do I pick" fix, kept as the fallback for a Core
+/// older than the merged-root view (`merged_root_view`): a system with
+/// multiple configured folders shows one identically-named `root` row per
+/// folder, with nothing distinguishing them; find the first path component
+/// where the page's root entries disagree and return that component per
+/// entry ("fat" vs "usb0", "games" vs "games2"). A Core new enough to merge
+/// system roots resolves this server-side and never sends the shape this
+/// function looks for. Returned `Vec` is the same length and order as
+/// `entries`; non-root entries and any root that never needed
+/// disambiguating (fewer than two roots on the page, or one identical to
+/// every sibling up to where paths run out) get `""`.
 ///
 /// Assumes `dedup_roots_drop_ancestors` already ran -- a root path being a
 /// strict prefix of a sibling's (the case that function exists to drop)
@@ -3139,7 +3172,23 @@ fn result_total_dirs(result: &MediaBrowseResult) -> i32 {
                 .filter(|entry| entry.is_folder())
                 .count()
         },
-        |total_dirs| usize::try_from(total_dirs).unwrap_or(usize::MAX),
+        |total_dirs| {
+            // Core's merged-root `totalDirs` counts only the merged
+            // physical directories; it excludes the virtual-scheme
+            // `root` entries the same response prepends ahead of them
+            // (`rootView: "contents"`, see `merged_root_view`). Every
+            // frontend consumer of `total_dirs` treats it as "rows
+            // before the first media row", so fold those roots in here
+            // rather than patching each call site. Outside the merged
+            // root, `entries` never carries a `root` type alongside a
+            // present `totalDirs`, so this is a no-op there.
+            let leading_roots = result
+                .entries
+                .iter()
+                .filter(|entry| entry.entry_type == "root")
+                .count();
+            usize::try_from(total_dirs).unwrap_or(usize::MAX) + leading_roots
+        },
     );
     i32::try_from(total_dirs).unwrap_or(i32::MAX)
 }
@@ -3851,6 +3900,41 @@ mod tests {
     }
 
     #[test]
+    fn total_dirs_adds_leading_virtual_roots() {
+        // Core's merged-root `totalDirs` counts only the merged physical
+        // directories; it excludes the virtual-scheme `root` entries the
+        // same response prepends ahead of them (`rootView: "contents"`).
+        let result = MediaBrowseResult {
+            entries: vec![
+                root("Arcade", "mame-arcade://", "Arcade"),
+                folder("Dir", "/games/Dir"),
+                media("Game", "/games/game.rom", "NES"),
+            ],
+            total_dirs: Some(1),
+            ..MediaBrowseResult::default()
+        };
+        assert_eq!(result_total_dirs(&result), 2);
+    }
+
+    #[test]
+    fn total_dirs_fallback_still_counts_roots_once() {
+        // Same case as `total_dirs_falls_back_to_folder_count_when_missing`,
+        // named to make explicit that the `None` fallback (an older Core
+        // without `totalDirs`) already counts `root` entries via
+        // `is_folder()` and must not be double-counted by the leading-roots
+        // fold, which only applies when `total_dirs` is present.
+        let result = MediaBrowseResult {
+            entries: vec![
+                root("NES", "/games/NES", "NES"),
+                media("Game", "/games/g", "NES"),
+            ],
+            total_dirs: None,
+            ..MediaBrowseResult::default()
+        };
+        assert_eq!(result_total_dirs(&result), 1);
+    }
+
+    #[test]
     fn same_sized_nonempty_pages_replace_rows_in_place() {
         assert_eq!(
             initial_row_replacement(10, 10),
@@ -3911,7 +3995,11 @@ mod tests {
     }
 
     #[test]
-    fn decide_initial_with_single_root_eligible_returns_auto_nav() {
+    fn decide_initial_auto_navigates_single_virtual_root_at_system_root() {
+        // A lone `root` entry at the system root is always a route to skip
+        // past: either a virtual-only system Core never merges (MiSTer
+        // Arcade's single `mame-arcade://` route), or an older Core still
+        // returning the unmerged routes list.
         let result = MediaBrowseResult {
             entries: vec![root("NES", "/roms/NES", "NES")],
             ..MediaBrowseResult::default()
@@ -3925,16 +4013,19 @@ mod tests {
     }
 
     #[test]
-    fn decide_initial_with_single_directory_eligible_returns_auto_nav() {
+    fn decide_initial_with_single_directory_at_merged_root_renders_as_apply() {
+        // A merged system root (`rootView: "contents"`, see
+        // `merged_root_view`) can legitimately render as one directory --
+        // that's a system with a single subfolder of games, not a route to
+        // skip past. Only a lone `root` entry (see the sibling test with a
+        // `root` entry above) is a route to auto-nav through.
         let result = MediaBrowseResult {
             entries: vec![folder("Games", "/roms/Shared/Games")],
             ..MediaBrowseResult::default()
         };
         assert_eq!(
             decide_initial(&result, true, None, ""),
-            InitialAction::AutoNavigate {
-                path: "/roms/Shared/Games".into()
-            }
+            InitialAction::Apply
         );
     }
 
@@ -3961,16 +4052,33 @@ mod tests {
     fn decide_initial_with_single_folder_not_eligible_flattens_on_mister() {
         // On MiSTer, a `set_path` load that returns exactly one folder
         // also flattens — collections often unzip into nested
-        // single-child folders.
+        // single-child folders. Only applies below the system root: a
+        // real parent path here (not the merged root's empty path)
+        // distinguishes this from the merged-root case above.
         let result = MediaBrowseResult {
             entries: vec![folder("Sub", "/x/Sub")],
             ..MediaBrowseResult::default()
         };
         assert_eq!(
-            decide_initial(&result, false, Some(&Platform::Mister), ""),
+            decide_initial(&result, false, Some(&Platform::Mister), "/x"),
             InitialAction::AutoNavigate {
                 path: "/x/Sub".into()
             },
+        );
+    }
+
+    #[test]
+    fn decide_initial_does_not_flatten_at_root_on_mister() {
+        // The MiSTer single-child flatten is a drill-down rule; it must
+        // not also swallow a genuine single-directory merged root (see
+        // `decide_initial_with_single_directory_at_merged_root_renders_as_apply`).
+        let result = MediaBrowseResult {
+            entries: vec![folder("Games", "/roms/Shared/Games")],
+            ..MediaBrowseResult::default()
+        };
+        assert_eq!(
+            decide_initial(&result, false, Some(&Platform::Mister), ""),
+            InitialAction::Apply,
         );
     }
 

--- a/rust/mock-core/src/fixtures.rs
+++ b/rust/mock-core/src/fixtures.rs
@@ -244,27 +244,10 @@ fn game_has_tag(game: &Value, filter: &str) -> bool {
         })
 }
 
-pub fn media_browse_response(params: &Value) -> Value {
-    let path = params.get("path").and_then(Value::as_str).unwrap_or("");
-    let systems = params
-        .get("systems")
-        .and_then(Value::as_array)
-        .map(|a| a.iter().filter_map(Value::as_str).collect::<Vec<_>>())
-        .unwrap_or_default();
-    let filters = params
-        .get("tags")
-        .and_then(Value::as_array)
-        .map(|a| a.iter().filter_map(Value::as_str).collect::<Vec<_>>())
-        .unwrap_or_default();
-    let max = params
-        .get("maxResults")
-        .and_then(Value::as_u64)
-        .unwrap_or(100) as usize;
-    let offset = params
-        .get("cursor")
-        .and_then(Value::as_str)
-        .and_then(|cursor| cursor.parse::<usize>().ok())
-        .unwrap_or(0);
+/// Media rows for `system` under `path_prefix`, filtered by `filters` and
+/// sorted by display name -- the shared core of every `media.browse`
+/// shape below.
+fn matching_media_rows(path_prefix: &str, systems: &[&str], filters: &[&str]) -> Vec<Value> {
     let mut matching: Vec<Value> = ALL_GAMES
         .iter()
         .enumerate()
@@ -272,7 +255,7 @@ pub fn media_browse_response(params: &Value) -> Value {
         .filter_map(|(index, (name, file, system))| {
             let row = json!({
                 "name": name,
-                "path": format!("{path}/{file}"),
+                "path": format!("{path_prefix}/{file}"),
                 "type": "media",
                 "systemId": system,
                 "zapScript": format!("@{system}/{file}"),
@@ -294,6 +277,162 @@ pub fn media_browse_response(params: &Value) -> Value {
             .unwrap_or_default()
             .to_lowercase()
     });
+    matching
+}
+
+fn mock_directory_entry(name: &str, path: &str, file_count: u64) -> Value {
+    json!({
+        "name": name,
+        "path": path,
+        "type": "directory",
+        "fileCount": file_count,
+        "hasCover": false,
+    })
+}
+
+/// A virtual-scheme route. Core never merges these into a system's
+/// contents view (`rootView: "contents"`) -- it prepends them ahead of
+/// the merged directories, and only on the page a cursor is absent from.
+fn mock_virtual_root_entry(system: &str) -> Value {
+    json!({
+        "name": "Mock Arcade",
+        "path": "mock-arcade://",
+        "type": "root",
+        "group": "mock",
+        "systemId": system,
+        "systemIds": [system],
+        "hasCover": false,
+    })
+}
+
+fn mock_route_root_entry(path: &str, system: &str, file_count: u64) -> Value {
+    json!({
+        // Real launcher routes are commonly named after the system
+        // itself, so two configured folders collide on name -- this is
+        // the shape `root_distinguishers`' fallback exists to label.
+        "name": system,
+        "path": path,
+        "type": "root",
+        "systemId": system,
+        "systemIds": [system],
+        "fileCount": file_count,
+        "hasCover": false,
+    })
+}
+
+/// Core's merged system-root view (`rootView: "contents"`): a virtual
+/// route (first page only), two mock directories, then the system's
+/// media, all under one pathless response. Mirrors
+/// `browseSystemRootContents` in zaparoo-core's `media_browse.go`.
+fn media_browse_root_contents_response(
+    system: &str,
+    filters: &[&str],
+    max: usize,
+    offset: usize,
+    cursor_present: bool,
+) -> Value {
+    let path_prefix = format!("/mock/games/{system}");
+    let dirs = if cursor_present {
+        Vec::new()
+    } else {
+        vec![
+            mock_directory_entry("Favorites", &format!("{path_prefix}/Favorites"), 1),
+            mock_directory_entry("Extras", &format!("{path_prefix}/Extras"), 1),
+        ]
+    };
+    let remaining = max.saturating_sub(dirs.len());
+    let matching = matching_media_rows(&path_prefix, &[system], filters);
+    let total_files = matching.len();
+    let media_page: Vec<Value> = matching.into_iter().skip(offset).take(remaining).collect();
+    let next_offset = offset.saturating_add(media_page.len());
+    let has_next_page = !media_page.is_empty() && next_offset < total_files;
+    let mut entries = Vec::new();
+    if !cursor_present {
+        entries.push(mock_virtual_root_entry(system));
+    }
+    entries.extend(dirs);
+    entries.extend(media_page);
+    let mut pagination = json!({
+        "hasNextPage": has_next_page,
+        "pageSize": max,
+    });
+    if has_next_page {
+        pagination["nextCursor"] = json!(next_offset.to_string());
+    }
+    json!({
+        "path": "",
+        "entries": entries,
+        // Virtual roots are excluded, mirroring Core: `totalDirs` counts
+        // merged physical directories only.
+        "totalDirs": 2,
+        "totalFiles": total_files,
+        "pagination": pagination,
+    })
+}
+
+/// Core's default, unmerged system-root view: one `root` entry per
+/// configured launcher route. Reachable in dev by omitting `rootView` on
+/// a pathless, system-scoped request -- the older-Core fallback path the
+/// frontend's `dedup_roots_drop_ancestors` / `root_distinguishers` still
+/// cover. The live frontend never sends this shape itself once
+/// `rootView: "contents"` is wired up, since a pathless single-system
+/// browse always includes it.
+fn media_browse_route_roots_response(systems: &[&str]) -> Value {
+    let entries: Vec<Value> = systems
+        .iter()
+        .flat_map(|system| {
+            let count = ALL_GAMES.iter().filter(|(_, _, s)| s == system).count() as u64;
+            vec![
+                mock_route_root_entry(&format!("/mock/games/{system}"), system, count),
+                mock_route_root_entry(&format!("/mock/usb0/{system}"), system, 0),
+            ]
+        })
+        .collect();
+    json!({
+        "path": "",
+        "entries": entries,
+        "totalFiles": 0,
+        "totalDirs": 0,
+    })
+}
+
+pub fn media_browse_response(params: &Value) -> Value {
+    let path = params.get("path").and_then(Value::as_str).unwrap_or("");
+    let systems = params
+        .get("systems")
+        .and_then(Value::as_array)
+        .map(|a| a.iter().filter_map(Value::as_str).collect::<Vec<_>>())
+        .unwrap_or_default();
+    let filters = params
+        .get("tags")
+        .and_then(Value::as_array)
+        .map(|a| a.iter().filter_map(Value::as_str).collect::<Vec<_>>())
+        .unwrap_or_default();
+    let max = params
+        .get("maxResults")
+        .and_then(Value::as_u64)
+        .unwrap_or(100) as usize;
+    let cursor = params.get("cursor").and_then(Value::as_str);
+    let offset = cursor
+        .and_then(|cursor| cursor.parse::<usize>().ok())
+        .unwrap_or(0);
+    if path.is_empty() {
+        let root_view = params.get("rootView").and_then(Value::as_str);
+        if root_view == Some("contents") {
+            if systems.len() == 1 {
+                return media_browse_root_contents_response(
+                    systems[0],
+                    &filters,
+                    max,
+                    offset,
+                    cursor.is_some(),
+                );
+            }
+        } else if !systems.is_empty() {
+            return media_browse_route_roots_response(&systems);
+        }
+    }
+    let matching = matching_media_rows(path, &systems, &filters);
     let total_files = matching.len();
     let entries: Vec<Value> = matching.into_iter().skip(offset).take(max).collect();
     let next_offset = offset.saturating_add(entries.len());
@@ -309,7 +448,8 @@ pub fn media_browse_response(params: &Value) -> Value {
         "path": path,
         "entries": entries,
         "totalFiles": total_files,
-        // Mock browse returns only media entries (no subdirectories).
+        // Mock browse returns only media entries (no subdirectories) for
+        // an ordinary path browse.
         "totalDirs": 0,
         "pagination": pagination,
     })
@@ -381,8 +521,18 @@ pub fn media_browse_index_response(params: &Value) -> Value {
         .map(|object| object.remove("cursor"));
     let browse = media_browse_response(&browse_params);
     let entries = browse["entries"].as_array().cloned().unwrap_or_default();
+    // Bucket by first character over media entries only. A merged-root
+    // page's leading `directory`/`root` entries aren't part of the
+    // ordered file list Core's `offset` describes ("excludes any
+    // directory entries the listing shows before files" -- see
+    // `media.browse.index`'s documented `offset` semantics), so they
+    // must not shift the file-position math below.
+    let media_entries: Vec<&Value> = entries
+        .iter()
+        .filter(|entry| entry["type"] == "media")
+        .collect();
     let mut groups: Vec<Value> = Vec::new();
-    for (offset, entry) in entries.iter().enumerate() {
+    for (offset, entry) in media_entries.iter().enumerate() {
         let first = entry["name"]
             .as_str()
             .and_then(|name| name.chars().next())

--- a/rust/mock-core/src/handler.rs
+++ b/rust/mock-core/src/handler.rs
@@ -381,6 +381,36 @@ mod tests {
     }
 
     #[test]
+    fn media_browse_root_contents_merges_directories_and_media() {
+        let req = r#"{"jsonrpc":"2.0","id":"1","method":"media.browse","params":{"systems":["NES"],"rootView":"contents"}}"#;
+        let resp = parse(&dispatch(req));
+        assert_eq!(resp["result"]["path"], Value::from(""));
+        let entries = resp["result"]["entries"].as_array().expect("array");
+        // Virtual root first, then the two mock directories, then media --
+        // mirrors `browseSystemRootContents`'s ordering in zaparoo-core.
+        assert_eq!(entries[0]["type"], Value::from("root"));
+        assert_eq!(entries[1]["type"], Value::from("directory"));
+        assert_eq!(entries[2]["type"], Value::from("directory"));
+        assert!(entries[3..].iter().all(|entry| entry["type"] == "media"));
+        // `totalDirs` counts the merged directories only, excluding the
+        // leading virtual root.
+        assert_eq!(resp["result"]["totalDirs"], Value::from(2));
+        assert!(resp["result"]["totalFiles"].as_u64().unwrap_or(0) > 0);
+    }
+
+    #[test]
+    fn media_browse_without_root_view_returns_route_roots() {
+        let req =
+            r#"{"jsonrpc":"2.0","id":"1","method":"media.browse","params":{"systems":["NES"]}}"#;
+        let resp = parse(&dispatch(req));
+        let entries = resp["result"]["entries"].as_array().expect("array");
+        assert!(entries.iter().all(|entry| entry["type"] == "root"));
+        assert_eq!(resp["result"]["totalFiles"], Value::from(0));
+        assert_eq!(resp["result"]["totalDirs"], Value::from(0));
+        assert!(resp["result"]["pagination"].is_null());
+    }
+
+    #[test]
     fn media_browse_index_matches_favorite_scope() {
         let req = r#"{"jsonrpc":"2.0","id":"1","method":"media.browse.index","params":{"path":"/games","tags":["user:favorite"]}}"#;
         let resp = parse(&dispatch(req));

--- a/rust/zaparoo-core/src/client.rs
+++ b/rust/zaparoo-core/src/client.rs
@@ -642,6 +642,7 @@ impl Client {
             cursor_set = params.cursor.is_some(),
             letter = ?params.letter,
             sort = ?params.sort,
+            root_view = ?params.root_view,
             "media.browse request",
         );
         let val = self.call("media.browse", &params).await?;

--- a/rust/zaparoo-core/src/endpoints/media_browse.rs
+++ b/rust/zaparoo-core/src/endpoints/media_browse.rs
@@ -10,7 +10,7 @@
 // because each follow-up has a different cursor.
 
 use crate::client::{Client, ClientError};
-use crate::media_types::{MediaBrowseParams, MediaBrowseResult};
+use crate::media_types::{merged_root_view, MediaBrowseParams, MediaBrowseResult};
 use crate::store::{Endpoint, Tag};
 use futures_util::future::BoxFuture;
 use std::sync::Arc;
@@ -51,6 +51,13 @@ impl BrowseArgs {
             max_results,
         }
     }
+
+    /// Core's merged system-root view for this scope. Derived, not stored:
+    /// the cache key already carries `path` and `systems`, so the view can
+    /// never drift from the key it was fetched under.
+    pub fn root_view(&self) -> Option<String> {
+        merged_root_view(&self.path, &self.systems)
+    }
 }
 
 #[derive(Debug)]
@@ -66,6 +73,7 @@ impl Endpoint for MediaBrowseEndpoint {
         args: Self::Args,
     ) -> BoxFuture<'static, Result<Self::Output, ClientError>> {
         Box::pin(async move {
+            let root_view = args.root_view();
             client
                 .media_browse(MediaBrowseParams {
                     path: args.path,
@@ -75,6 +83,7 @@ impl Endpoint for MediaBrowseEndpoint {
                     tags: args.tags,
                     letter: None,
                     sort: None,
+                    root_view,
                 })
                 .await
         })
@@ -154,5 +163,28 @@ mod tests {
         );
         assert_ne!(unfiltered, filtered);
         assert_eq!(filtered.tags, vec!["user:favorite"]);
+    }
+
+    #[test]
+    fn browse_args_root_view_is_contents_for_single_system_root() {
+        let args = BrowseArgs::new(String::new(), vec!["SNES".into()], 100, Vec::new());
+        assert_eq!(args.root_view(), Some("contents".to_string()));
+    }
+
+    #[test]
+    fn browse_args_root_view_is_none_for_path_browse() {
+        let args = BrowseArgs::new("/roms/SNES".into(), vec!["SNES".into()], 100, Vec::new());
+        assert_eq!(args.root_view(), None);
+    }
+
+    #[test]
+    fn browse_args_root_view_is_none_for_multi_system() {
+        let args = BrowseArgs::new(
+            String::new(),
+            vec!["SNES".into(), "NES".into()],
+            100,
+            Vec::new(),
+        );
+        assert_eq!(args.root_view(), None);
     }
 }

--- a/rust/zaparoo-core/src/media_types.rs
+++ b/rust/zaparoo-core/src/media_types.rs
@@ -248,6 +248,22 @@ pub struct MediaBrowseParams {
     /// `filename-asc`, `filename-desc`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<String>,
+    /// `contents` asks Core to replace a single system's filesystem routes
+    /// with one merged view of their immediate contents. Only honoured when
+    /// `path` is empty and exactly one system is set; omitted otherwise so
+    /// path browses are unchanged on the wire. Build with
+    /// [`merged_root_view`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub root_view: Option<String>,
+}
+
+/// Core's merged system-root view. Eligible only when browsing the top of
+/// exactly one system; Core rejects anything else with "rootView contents
+/// requires exactly one system". Every request in one page chain (the
+/// initial browse, each cursor page, and the letter index) must agree,
+/// because Core stamps the cursor with the view and rejects a mismatch.
+pub fn merged_root_view(path: &str, systems: &[String]) -> Option<String> {
+    (path.is_empty() && systems.len() == 1).then(|| "contents".to_string())
 }
 
 // `Default` is implemented manually below so that `has_cover` defaults to
@@ -370,6 +386,12 @@ pub struct MediaBrowseIndexParams {
     pub tags: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sort: Option<String>,
+    /// Same merged-root-view semantics as [`MediaBrowseParams::root_view`].
+    /// Must match the `root_view` of the `media.browse` page this index is
+    /// for, or Core's cursors will not line up. Build with
+    /// [`merged_root_view`].
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub root_view: Option<String>,
 }
 
 /// One first-character section of a browse list. `key`/`label` are opaque so a
@@ -1285,17 +1307,17 @@ mod tests {
     )]
 
     use super::{
-        BrowseEntry, BrowseIndexGroup, HealthResult, IndexingStatusResponse, LaunchersResult,
-        LogDownloadResult, MediaBrowseIndexParams, MediaBrowseIndexResult, MediaBrowseParams,
-        MediaBrowseResult, MediaHistoryEntry, MediaHistoryLatestResult, MediaHistoryParams,
-        MediaHistoryResult, MediaHistoryTopParams, MediaHistoryTopResult, MediaImageParams,
-        MediaImageResult, MediaIndexParams, MediaItem, MediaLookupParams, MediaLookupResult,
-        MediaMetaBatchParams, MediaMetaBatchResult, MediaMetaParams, MediaMetaResult, MediaResult,
-        MediaScrapeParams, MediaSearchParams, MediaSearchResult, MediaTagsParams, MediaTagsResult,
-        ReaderInfo, ReadersResult, ScrapersResult, ScrapingStatusResponse, SettingsResult,
-        SystemDefault, SystemsParams, SystemsResult, TagInfo, TokensHistoryResult, TokensResult,
-        UpdateSettingsParams, VersionResult, MEDIA_IMAGE_DELIVERY_LOCAL_PATH,
-        MEDIA_META_BATCH_MAX_ITEMS,
+        merged_root_view, BrowseEntry, BrowseIndexGroup, HealthResult, IndexingStatusResponse,
+        LaunchersResult, LogDownloadResult, MediaBrowseIndexParams, MediaBrowseIndexResult,
+        MediaBrowseParams, MediaBrowseResult, MediaHistoryEntry, MediaHistoryLatestResult,
+        MediaHistoryParams, MediaHistoryResult, MediaHistoryTopParams, MediaHistoryTopResult,
+        MediaImageParams, MediaImageResult, MediaIndexParams, MediaItem, MediaLookupParams,
+        MediaLookupResult, MediaMetaBatchParams, MediaMetaBatchResult, MediaMetaParams,
+        MediaMetaResult, MediaResult, MediaScrapeParams, MediaSearchParams, MediaSearchResult,
+        MediaTagsParams, MediaTagsResult, ReaderInfo, ReadersResult, ScrapersResult,
+        ScrapingStatusResponse, SettingsResult, SystemDefault, SystemsParams, SystemsResult,
+        TagInfo, TokensHistoryResult, TokensResult, UpdateSettingsParams, VersionResult,
+        MEDIA_IMAGE_DELIVERY_LOCAL_PATH, MEDIA_META_BATCH_MAX_ITEMS,
     };
 
     #[test]
@@ -1664,6 +1686,7 @@ mod tests {
             systems: vec!["SNES".into()],
             tags: vec!["user:favorite".into()],
             sort: None,
+            root_view: None,
         };
         let json = serde_json::to_value(&params).expect("serialise");
         let object = json.as_object().expect("object");
@@ -1717,6 +1740,7 @@ mod tests {
             tags: vec!["user:favorite".into()],
             letter: Some("M".into()),
             sort: Some("name-asc".into()),
+            root_view: None,
         };
         let json = serde_json::to_value(&params).expect("serialise");
         let object = json.as_object().expect("object");
@@ -1745,6 +1769,64 @@ mod tests {
             Some(1)
         );
         assert!(!object.contains_key("fuzzySystem"));
+    }
+
+    #[test]
+    fn media_browse_params_omits_root_view_for_path_browse() {
+        let params = MediaBrowseParams {
+            path: "/roms/SNES".into(),
+            ..MediaBrowseParams::default()
+        };
+        let json = serde_json::to_value(&params).expect("serialise");
+        assert!(!json.as_object().expect("object").contains_key("rootView"));
+    }
+
+    #[test]
+    fn media_browse_params_serialises_contents_root_view() {
+        let params = MediaBrowseParams {
+            systems: vec!["SNES".into()],
+            root_view: Some("contents".into()),
+            ..MediaBrowseParams::default()
+        };
+        let json = serde_json::to_value(&params).expect("serialise");
+        assert_eq!(
+            json.as_object()
+                .expect("object")
+                .get("rootView")
+                .and_then(|v| v.as_str()),
+            Some("contents")
+        );
+    }
+
+    #[test]
+    fn media_browse_index_params_serialises_contents_root_view() {
+        let params = MediaBrowseIndexParams {
+            systems: vec!["SNES".into()],
+            root_view: Some("contents".into()),
+            ..MediaBrowseIndexParams::default()
+        };
+        let json = serde_json::to_value(&params).expect("serialise");
+        assert_eq!(
+            json.as_object()
+                .expect("object")
+                .get("rootView")
+                .and_then(|v| v.as_str()),
+            Some("contents")
+        );
+    }
+
+    #[test]
+    fn merged_root_view_requires_empty_path_and_single_system() {
+        assert_eq!(
+            merged_root_view("", &["SNES".to_string()]),
+            Some("contents".to_string())
+        );
+        assert_eq!(merged_root_view("", &[]), None);
+        assert_eq!(
+            merged_root_view("", &["SNES".to_string(), "NES".to_string()]),
+            None
+        );
+        assert_eq!(merged_root_view("/roms/SNES", &["SNES".to_string()]), None);
     }
 
     #[test]


### PR DESCRIPTION
- Send Core's `rootView: "contents"` (zaparoo-core PR #1312) on every `media.browse`/`media.browse.index` call whose scope is the top of exactly one system, so picking a system lands directly on a merged, one-level view of its media instead of a route-picker screen. This is unconditional, with no new setting.
- Add a `merged_root_view(path, systems)` helper so the initial page, cursor pages, and the letter-index rail always agree on the view, since Core stamps the cursor with it and rejects a mismatch.
- Narrow `decide_initial`'s single-entry auto-navigate to only skip past a lone `root` entry at the system root (a virtual-only system such as MiSTer Arcade, or an older Core's routes list), so a merged root that happens to hold one directory renders instead of trapping the user with no way back to it.
- Fold the leading virtual-root count into `result_total_dirs` so page totals and jump-to-letter offsets stay correct with no QML changes.
- Keep the existing route-dedup and route-disambiguation helpers as the fallback for a Core older than #1312, which silently ignores the unknown `rootView` key and returns its previous routes list.
- Teach `mock-core` to model both the merged-root and routes-fallback response shapes for realistic local dev testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved browsing at the system root by combining virtual, physical, and media entries into one view.
  - Added support for configured game and USB launcher roots.
  - Letter indexes and pagination now reflect merged directory and media results accurately.

- **Bug Fixes**
  - Corrected automatic navigation behavior for single-entry system roots.
  - Improved directory and file totals by excluding virtual entries from counts.
  - Preserved proper browsing behavior for path-based and multi-system views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->