### PR TITLE
Beta feedback response: image cache, header title, Hub, theme, progress display

### DIFF
--- a/rust/frontend/src/media_image_cache.rs
+++ b/rust/frontend/src/media_image_cache.rs
@@ -32,7 +32,7 @@
 // `image://media-image/<...>`, which `requestImage` decodes back to a
 // `MediaKey` and looks up in the in-memory map.
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::ffi::{c_char, c_void};
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex, OnceLock, RwLock};
@@ -608,7 +608,13 @@ struct QueueEntry {
 
 #[derive(Debug)]
 struct MediaImageEntry {
-    bytes: Vec<u8>,
+    // `Arc`, not `Vec<u8>` directly: `get_bytes` used to clone the full
+    // 30-80 KiB buffer while holding CacheState's write lock, serialising
+    // every cover paint against every other reader/writer for the
+    // duration of a real memcpy. An `Arc` clone under the lock is an
+    // atomic refcount bump instead; the actual byte copy (`to_vec()`)
+    // happens after the lock is released. See `get_bytes`.
+    bytes: Arc<Vec<u8>>,
     #[allow(dead_code, reason = "ext is informational; provider only needs bytes")]
     ext: &'static str,
     /// Monotonically increasing usage counter used as the LRU clock.
@@ -652,6 +658,28 @@ impl NegativeMemo {
         }
         self.order.retain(|memo_key| memo_key != key);
     }
+
+    /// Drop every entry for `system_id`. Linear scan — this only runs on
+    /// an index/scrape *completion* edge (see
+    /// `MediaImageCache::invalidate_negative_memo_for_system`), a rare,
+    /// user-paced event, not the read/write hot path the rest of this
+    /// struct serves.
+    fn remove_system(&mut self, system_id: &str) {
+        let stale: Vec<MediaKey> = self
+            .set
+            .iter()
+            .filter(|key| &*key.system_id == system_id)
+            .cloned()
+            .collect();
+        for key in stale {
+            self.remove(&key);
+        }
+    }
+
+    fn clear(&mut self) {
+        self.set.clear();
+        self.order.clear();
+    }
 }
 
 #[derive(Debug)]
@@ -688,6 +716,23 @@ struct CacheState {
     /// Strictly increasing LRU clock. Bumped on every successful read
     /// or insert; the entry with the smallest value is the LRU.
     clock: u64,
+    /// LRU index into `map`, split into two independent trees (read vs
+    /// unread) rather than one composite-keyed tree — eviction always
+    /// prefers a read entry over an unread one regardless of how stale
+    /// the unread entry is (see `evict_until_fits`'s doc comment), so the
+    /// two populations must be independently orderable, not just sorted
+    /// within one shared key. Keyed on `last_used`, which `next_clock`
+    /// guarantees is unique across the cache's entire lifetime — that
+    /// uniqueness is what makes removing an entry from its tree by
+    /// `last_used` alone (no key comparison needed) correct. Replaces the
+    /// old O(N) linear scan over `map` that `evict_until_fits` used to do
+    /// per evicted entry; kept in sync exclusively through
+    /// `insert_entry`/`remove_entry`/`touch_entry` below — nothing else
+    /// may touch `map`, `read_lru`, or `unread_lru` directly, or the
+    /// index silently drifts out of sync with the data it's meant to
+    /// describe.
+    read_lru: BTreeMap<u64, MediaKey>,
+    unread_lru: BTreeMap<u64, MediaKey>,
 }
 
 impl CacheState {
@@ -703,6 +748,8 @@ impl CacheState {
             media_ids: HashMap::new(),
             resolved_types: HashMap::new(),
             clock: 0,
+            read_lru: BTreeMap::new(),
+            unread_lru: BTreeMap::new(),
         }
     }
 
@@ -711,33 +758,92 @@ impl CacheState {
         self.clock
     }
 
-    /// Drop entries until `total_bytes` fits under `cap_bytes`. Two-pass:
-    /// pick the LRU among **read** entries first, fall back to the LRU
-    /// among unread entries only when nothing has been read yet. This
-    /// means QML-consumed entries are eligible for eviction before
+    fn index_insert(&mut self, last_used: u64, read: bool, key: MediaKey) {
+        if read {
+            self.read_lru.insert(last_used, key);
+        } else {
+            self.unread_lru.insert(last_used, key);
+        }
+    }
+
+    fn index_remove(&mut self, last_used: u64, read: bool) {
+        if read {
+            self.read_lru.remove(&last_used);
+        } else {
+            self.unread_lru.remove(&last_used);
+        }
+    }
+
+    /// Insert a fresh entry, or replace an existing one, keeping
+    /// `read_lru`/`unread_lru` in sync. The only path that may write into
+    /// `map` — see the field doc comment on `read_lru` for why.
+    fn insert_entry(&mut self, key: MediaKey, entry: MediaImageEntry) -> Option<MediaImageEntry> {
+        let last_used = entry.last_used;
+        let read = entry.read;
+        let prev = self.map.insert(key.clone(), entry);
+        if let Some(ref prev) = prev {
+            self.index_remove(prev.last_used, prev.read);
+        }
+        self.index_insert(last_used, read, key);
+        prev
+    }
+
+    /// Remove `key`, keeping `read_lru`/`unread_lru` in sync. The only
+    /// path that may remove from `map` — see the field doc comment on
+    /// `read_lru` for why.
+    fn remove_entry(&mut self, key: &MediaKey) -> Option<MediaImageEntry> {
+        let removed = self.map.remove(key);
+        if let Some(ref removed) = removed {
+            self.index_remove(removed.last_used, removed.read);
+        }
+        removed
+    }
+
+    /// Bump `key`'s `last_used` to `next_clock` and mark it read, keeping
+    /// `read_lru`/`unread_lru` in sync. Returns the entry so the caller
+    /// can read its bytes without a second lookup. The only path that may
+    /// mutate an existing `map` entry in place — see the field doc
+    /// comment on `read_lru` for why.
+    fn touch_entry(&mut self, key: &MediaKey, next_clock: u64) -> Option<&MediaImageEntry> {
+        let entry = self.map.get_mut(key)?;
+        let old_last_used = entry.last_used;
+        let old_read = entry.read;
+        entry.last_used = next_clock;
+        entry.read = true;
+        self.index_remove(old_last_used, old_read);
+        self.index_insert(next_clock, true, key.clone());
+        self.map.get(key)
+    }
+
+    /// Drop entries until `total_bytes` fits under `cap_bytes`. Prefers
+    /// the LRU among **read** entries; falls back to the LRU among
+    /// unread entries only when nothing has been read yet. This means
+    /// QML-consumed entries are eligible for eviction before
     /// prefetched-but-not-yet-painted ones — without that ordering, a
     /// page-fill burst that overshoots the cap can drop entries before
-    /// the `QtQuick` provider's first paint pass reads them. Linear scan
-    /// over `map`; the cache holds at most a few hundred entries so
-    /// the O(N) pass per evicted entry is well below noise.
+    /// the `QtQuick` provider's first paint pass reads them.
+    ///
+    /// O(log N) per evicted entry via `read_lru`/`unread_lru` (a
+    /// `BTreeMap`'s first element is its smallest key, i.e. the oldest
+    /// `last_used`). Replaces an old O(N) linear scan over `map` per
+    /// evicted entry — fine at the "a few hundred entries" the cache was
+    /// originally sized for, but the cap comment on `CACHE_CAP_BYTES`
+    /// says 128 MiB holds "thousands of tiles" once `max_cover_size` is
+    /// set, and `get_bytes` takes the cache's write lock too, so every
+    /// cover paint was serialising against an eviction pass whose cost
+    /// scaled with total cache size once the cache was actually full.
     fn evict_until_fits(&mut self, cap_bytes: usize) {
         while self.total_bytes > cap_bytes {
             let victim = self
-                .map
-                .iter()
-                .filter(|(_, e)| e.read)
-                .min_by_key(|(_, e)| e.last_used)
-                .map(|(k, _)| k.clone())
-                .or_else(|| {
-                    self.map
-                        .iter()
-                        .min_by_key(|(_, e)| e.last_used)
-                        .map(|(k, _)| k.clone())
-                });
+                .read_lru
+                .values()
+                .next()
+                .or_else(|| self.unread_lru.values().next())
+                .cloned();
             let Some(victim) = victim else {
                 break;
             };
-            if let Some(entry) = self.map.remove(&victim) {
+            if let Some(entry) = self.remove_entry(&victim) {
                 self.total_bytes = self.total_bytes.saturating_sub(entry.bytes.len());
                 // Keep the sidecars in lock-step with `map` — without
                 // this the hint tables grow unboundedly past `cap_bytes`
@@ -819,18 +925,22 @@ impl MediaImageCache {
         self.max_cover_size.store(size, Ordering::Relaxed);
     }
 
-    /// Bytes for `key`, if cached. Bumps `last_used` so the entry's
-    /// LRU position reflects the read. Returns a clone — encoded
-    /// images are 30–80 KiB, the clone cost is below the cost of
-    /// holding a lock across Qt code on the requester thread.
+    /// Bytes for `key`, if cached. Bumps `last_used` so the entry's LRU
+    /// position reflects the read.
+    ///
+    /// The `Arc` clone happens under the write lock (cheap — a refcount
+    /// bump, not a copy); the real byte copy (`to_vec()`, 30-80 KiB) is
+    /// deferred until after the guard is dropped, so a cover paint no
+    /// longer holds every other cache reader/writer for the duration of
+    /// a memcpy. See `MediaImageEntry.bytes`'s doc comment.
     pub fn get_bytes(&self, key: &MediaKey) -> Option<Vec<u8>> {
-        #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
-        let mut guard = self.state.write().unwrap();
-        let next = guard.next_clock();
-        let entry = guard.map.get_mut(key)?;
-        entry.last_used = next;
-        entry.read = true;
-        Some(entry.bytes.clone())
+        let bytes = {
+            #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
+            let mut guard = self.state.write().unwrap();
+            let next = guard.next_clock();
+            guard.touch_entry(key, next)?.bytes.clone()
+        };
+        Some(bytes.to_vec())
     }
 
     /// Seed the cache with bytes read directly from disk rather than
@@ -857,10 +967,10 @@ impl MediaImageCache {
         }
         let clock = guard.next_clock();
         guard.total_bytes = guard.total_bytes.saturating_add(bytes.len());
-        guard.map.insert(
+        guard.insert_entry(
             key,
             MediaImageEntry {
-                bytes,
+                bytes: Arc::new(bytes),
                 // Core's own thumbnail cache always encodes WebP (see
                 // media_image.go's resize path) — informational only,
                 // the provider decodes by sniffing the byte content.
@@ -901,6 +1011,48 @@ impl MediaImageCache {
         #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
         let guard = self.state.read().unwrap();
         guard.soft_no_image.contains(key)
+    }
+
+    /// Drop every negative-memo entry (all three memos — `negative`,
+    /// `soft_no_image`, `search_seen`) for `system_id`. No-op for an empty
+    /// `system_id`.
+    ///
+    /// The negative memo is deliberately process-lifetime-only (see this
+    /// file's module doc comment) — a "no image" answer that was actually
+    /// a transient race (a NAS mount not yet up when the initial boot
+    /// index ran, say) stayed memoized for the rest of the process's life
+    /// with nothing to clear it, so a subsequently fixed system's covers
+    /// never came back without a full frontend restart. Called on that
+    /// system's index/scrape completion edge (`media_status.rs::apply`)
+    /// so a rescrape's answer actually gets a chance to land.
+    pub fn invalidate_negative_memo_for_system(&self, system_id: &str) {
+        if system_id.is_empty() {
+            return;
+        }
+        #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
+        let mut guard = self.state.write().unwrap();
+        guard.negative.remove_system(system_id);
+        guard.soft_no_image.remove_system(system_id);
+        guard.search_seen.remove_system(system_id);
+        debug!(
+            system_id,
+            "media_image_cache: invalidated negative memo for system"
+        );
+    }
+
+    /// Drop every negative-memo entry across all systems (all three
+    /// memos). Called on a whole-library index completion — indexing
+    /// carries no per-system scope (unlike a targeted scrape), so a
+    /// system-scoped call can't distinguish "this system's covers are
+    /// still genuinely missing" from "this system's covers failed during
+    /// the same race that just got fixed."
+    pub fn invalidate_negative_memo_all(&self) {
+        #[allow(clippy::unwrap_used, reason = "RwLock poisoning is unrecoverable")]
+        let mut guard = self.state.write().unwrap();
+        guard.negative.clear();
+        guard.soft_no_image.clear();
+        guard.search_seen.clear();
+        debug!("media_image_cache: invalidated negative memo for all systems");
     }
 
     /// Return the short image type that Core resolved for `key` on its last
@@ -1839,7 +1991,7 @@ fn finish_fetch(
                     "media_image_cache: payload exceeds cache cap, recording as negative",
                 );
                 if no_image_policy == NoImagePolicy::Memoize && !search_seen {
-                    if let Some(prev) = guard.map.remove(key) {
+                    if let Some(prev) = guard.remove_entry(key) {
                         guard.total_bytes = guard.total_bytes.saturating_sub(prev.bytes.len());
                     }
                     // Remove unconditionally: media_ids is written in
@@ -1860,12 +2012,12 @@ fn finish_fetch(
             let bytes_len = bytes.len();
             let next = guard.next_clock();
             let entry = MediaImageEntry {
-                bytes,
+                bytes: Arc::new(bytes),
                 ext,
                 last_used: next,
                 read: false,
             };
-            if let Some(prev) = guard.map.insert(key.clone(), entry) {
+            if let Some(prev) = guard.insert_entry(key.clone(), entry) {
                 guard.total_bytes = guard.total_bytes.saturating_sub(prev.bytes.len());
             }
             // Record the resolved type for carousel dedup. Non-empty only
@@ -1890,7 +2042,7 @@ fn finish_fetch(
         }
         FetchOutcome::NoImage => {
             if no_image_policy == NoImagePolicy::Memoize && !search_seen {
-                if let Some(prev) = guard.map.remove(key) {
+                if let Some(prev) = guard.remove_entry(key) {
                     guard.total_bytes = guard.total_bytes.saturating_sub(prev.bytes.len());
                 }
                 guard.media_ids.remove(key);
@@ -2112,6 +2264,66 @@ mod tests {
         assert_eq!(pop_one(&cache.queue).expect("second").key, second);
         assert_eq!(pop_one(&cache.queue).expect("third").key, third);
         assert!(pop_one(&cache.queue).is_none());
+    }
+
+    #[test]
+    fn invalidate_negative_memo_for_system_clears_only_the_matching_system() {
+        let cache = cache_for_test();
+        let stale_snes = key("SNES", "/a");
+        let stale_snes2 = key("SNES", "/b");
+        let unrelated_nes = key("NES", "/c");
+        {
+            let mut guard = cache.state.write().unwrap();
+            guard.negative.insert(stale_snes.clone());
+            guard.negative.insert(stale_snes2.clone());
+            guard.negative.insert(unrelated_nes.clone());
+            guard.soft_no_image.insert(stale_snes.clone());
+            guard.search_seen.insert(stale_snes.clone());
+        }
+
+        cache.invalidate_negative_memo_for_system("SNES");
+
+        let guard = cache.state.read().unwrap();
+        assert!(!guard.negative.contains(&stale_snes));
+        assert!(!guard.negative.contains(&stale_snes2));
+        assert!(!guard.soft_no_image.contains(&stale_snes));
+        assert!(!guard.search_seen.contains(&stale_snes));
+        // A different system's memoized "no image" answer is untouched --
+        // this is not a blunt full clear.
+        assert!(guard.negative.contains(&unrelated_nes));
+    }
+
+    #[test]
+    fn invalidate_negative_memo_for_system_is_a_noop_for_empty_system_id() {
+        let cache = cache_for_test();
+        let k = key("SNES", "/a");
+        cache.state.write().unwrap().negative.insert(k.clone());
+
+        cache.invalidate_negative_memo_for_system("");
+
+        assert!(cache.state.read().unwrap().negative.contains(&k));
+    }
+
+    #[test]
+    fn invalidate_negative_memo_all_clears_every_system() {
+        let cache = cache_for_test();
+        let snes = key("SNES", "/a");
+        let nes = key("NES", "/b");
+        {
+            let mut guard = cache.state.write().unwrap();
+            guard.negative.insert(snes.clone());
+            guard.negative.insert(nes.clone());
+            guard.soft_no_image.insert(snes.clone());
+            guard.search_seen.insert(nes.clone());
+        }
+
+        cache.invalidate_negative_memo_all();
+
+        let guard = cache.state.read().unwrap();
+        assert!(!guard.negative.contains(&snes));
+        assert!(!guard.negative.contains(&nes));
+        assert!(!guard.soft_no_image.contains(&snes));
+        assert!(!guard.search_seen.contains(&nes));
     }
 
     #[test]
@@ -2651,6 +2863,53 @@ mod tests {
         );
     }
 
+    // Re-fetching an already-cached, already-*read* key (a real path —
+    // e.g. a cover preference change re-requests a key the fetch driver
+    // already resolved once) must retire its OLD index entry before
+    // installing the new one. A gap here leaves a ghost key in
+    // `read_lru`/`unread_lru` pointing at a `last_used` no longer in
+    // `map` — `evict_until_fits` would then pick that ghost as its
+    // victim forever (`remove_entry` returns `None` for a key that isn't
+    // in `map`, so neither `total_bytes` shrinks nor the ghost index
+    // entry ever gets removed), hanging on the cache's write lock
+    // permanently. This asserts the invariant directly rather than
+    // relying on eviction happening to still terminate.
+    #[test]
+    fn replacing_a_read_entry_retires_its_old_index_slot() {
+        let state = Arc::new(RwLock::new(CacheState::new()));
+        let cap = 10_000;
+        let a = key("SNES", "/a");
+        ok_png(&state, cap, &a, 100);
+        {
+            let mut g = state.write().unwrap();
+            let next = g.next_clock();
+            g.touch_entry(&a, next).expect("a present");
+        }
+        {
+            let g = state.read().unwrap();
+            assert_eq!(g.read_lru.len(), 1, "a should be in read_lru after touch");
+            assert_eq!(g.unread_lru.len(), 0);
+        }
+
+        // Re-fetch the same key — the success path replaces the map
+        // entry with a fresh, unread one.
+        ok_png(&state, cap, &a, 150);
+
+        let g = state.read().unwrap();
+        assert_eq!(g.map.len(), 1);
+        assert_eq!(
+            g.read_lru.len() + g.unread_lru.len(),
+            g.map.len(),
+            "index must track map exactly, no stale/ghost slots"
+        );
+        assert_eq!(g.read_lru.len(), 0, "replacement resets read to false");
+        assert_eq!(g.unread_lru.len(), 1);
+        assert_eq!(
+            g.total_bytes, 150,
+            "old byte count fully replaced, not summed"
+        );
+    }
+
     #[test]
     fn eviction_drops_oldest_when_over_cap() {
         let state = Arc::new(RwLock::new(CacheState::new()));
@@ -2688,12 +2947,22 @@ mod tests {
         let c = key("SNES", "/c");
         ok_png(&state, cap, &a, 100);
         ok_png(&state, cap, &b, 100);
-        // Touch `a` so it becomes the most recent entry — `b` is
-        // now the LRU and should be evicted next.
+        // Touch `a`'s `last_used` only, deliberately not `read` -- this
+        // isolates within-population LRU ordering (does recency alone
+        // pick the right victim among still-unread entries) from the
+        // read-vs-unread priority `eviction_prefers_read_entries_over_unread`
+        // below already covers; `get_bytes`/`touch_entry` always bump both
+        // together, so this reaches into the index directly (same private
+        // access the rest of this test module already relies on for
+        // `map`/`negative`/etc.) rather than through the public API.
         {
             let mut g = state.write().unwrap();
             let next = g.next_clock();
-            g.map.get_mut(&a).expect("a present").last_used = next;
+            let entry = g.map.get_mut(&a).expect("a present");
+            let old_last_used = entry.last_used;
+            entry.last_used = next;
+            g.index_remove(old_last_used, false);
+            g.index_insert(next, false, a.clone());
         }
         ok_png(&state, cap, &c, 100);
         let g = state.read().unwrap();
@@ -2750,14 +3019,13 @@ mod tests {
         for k in [&a, &b, &c] {
             ok_png(&state, cap, k, 100);
         }
-        // Mark `a` as read. Mirrors what `get_bytes` would do: bump
-        // `last_used` and flip the read flag.
+        // Mark `a` as read via the same `touch_entry` path `get_bytes`
+        // itself calls, so this exercises the real production code, not
+        // a hand-rolled mirror of it.
         {
             let mut state_w = state.write().unwrap();
             let next = state_w.next_clock();
-            let entry = state_w.map.get_mut(&a).expect("a present");
-            entry.last_used = next;
-            entry.read = true;
+            state_w.touch_entry(&a, next).expect("a present");
         }
         ok_png(&state, cap, &d, 100);
         let state_r = state.read().unwrap();

--- a/rust/frontend/src/media_image_cache.rs
+++ b/rust/frontend/src/media_image_cache.rs
@@ -659,21 +659,19 @@ impl NegativeMemo {
         self.order.retain(|memo_key| memo_key != key);
     }
 
-    /// Drop every entry for `system_id`. Linear scan — this only runs on
-    /// an index/scrape *completion* edge (see
+    /// Drop every entry for `system_id`. One retain pass each over `set`
+    /// and `order` rather than a collect-then-remove-per-key loop (the
+    /// latter is O(K * `order.len()`) for K stale keys, since each `remove`
+    /// call does its own `order.retain` scan) — this only runs on an
+    /// index/scrape *completion* edge (see
     /// `MediaImageCache::invalidate_negative_memo_for_system`), a rare,
     /// user-paced event, not the read/write hot path the rest of this
-    /// struct serves.
+    /// struct serves, but a scrape that invalidates a large slice of one
+    /// system's entries is exactly the case the old approach scaled
+    /// worst for.
     fn remove_system(&mut self, system_id: &str) {
-        let stale: Vec<MediaKey> = self
-            .set
-            .iter()
-            .filter(|key| &*key.system_id == system_id)
-            .cloned()
-            .collect();
-        for key in stale {
-            self.remove(&key);
-        }
+        self.set.retain(|key| &*key.system_id != system_id);
+        self.order.retain(|key| self.set.contains(key));
     }
 
     fn clear(&mut self) {

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -53,7 +53,7 @@ use tokio::sync::broadcast::error::RecvError;
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 use zaparoo_core::client::ClientError;
-use zaparoo_core::endpoints::media_browse::{root_view_for, BrowseArgs, MediaBrowseEndpoint};
+use zaparoo_core::endpoints::media_browse::{BrowseArgs, MediaBrowseEndpoint};
 use zaparoo_core::endpoints::media_tags_update::MediaTagsUpdateMutation;
 use zaparoo_core::endpoints::readers_write::ReadersWriteMutation;
 use zaparoo_core::endpoints::run::RunMutation;
@@ -803,9 +803,6 @@ impl ffi::GamesModel {
         } else {
             vec![sid]
         };
-        // Must match the initial page's `BrowseArgs::new`-derived root view:
-        // Core embeds it in the cursor and validates follow-ups against it.
-        let root_view = root_view_for(&path, &systems);
         let tags = favorites_tags(self.favorites_only);
         // Read the active ticket WITHOUT bumping it. `fetch_more`
         // continues the same path's load — only `set_system` /
@@ -841,7 +838,6 @@ impl ffi::GamesModel {
                 .media_browse(MediaBrowseParams {
                     path,
                     systems,
-                    root_view,
                     max_results: Some(max_results),
                     cursor,
                     tags,
@@ -865,22 +861,18 @@ impl ffi::GamesModel {
     /// user picks "Jump to letter".
     fn load_letter_index(mut self: Pin<&mut Self>) {
         let path = self.current_path.to_string();
+        // A root listing has no meaningful first-character rail.
+        if path.is_empty() {
+            self.as_mut().set_letter_index_json(QString::from("[]"));
+            self.as_mut().set_letter_index_scheme(QString::from("none"));
+            return;
+        }
         let sid = self.current_system_id.to_string();
         let systems = if sid.is_empty() {
             Vec::new()
         } else {
             vec![sid]
         };
-        let root_view = root_view_for(&path, &systems);
-        // A route listing (multi-root/no-system pathless scope) has no
-        // meaningful first-character rail -- only a single system's merged
-        // root contents (PR #1312's `rootView: "contents"`) or an ordinary
-        // path below a system root does.
-        if path.is_empty() && root_view.is_none() {
-            self.as_mut().set_letter_index_json(QString::from("[]"));
-            self.as_mut().set_letter_index_scheme(QString::from("none"));
-            return;
-        }
         let tags = favorites_tags(self.favorites_only);
         // Clear any facet from a prior scope to the loading state (empty groups,
         // empty scheme) so the rail shows "loading" rather than the previous
@@ -899,7 +891,6 @@ impl ffi::GamesModel {
                 .media_browse_index(MediaBrowseIndexParams {
                     path,
                     systems,
-                    root_view,
                     tags,
                     sort: None,
                 })

--- a/rust/frontend/src/models/games.rs
+++ b/rust/frontend/src/models/games.rs
@@ -53,7 +53,7 @@ use tokio::sync::broadcast::error::RecvError;
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 use zaparoo_core::client::ClientError;
-use zaparoo_core::endpoints::media_browse::{BrowseArgs, MediaBrowseEndpoint};
+use zaparoo_core::endpoints::media_browse::{root_view_for, BrowseArgs, MediaBrowseEndpoint};
 use zaparoo_core::endpoints::media_tags_update::MediaTagsUpdateMutation;
 use zaparoo_core::endpoints::readers_write::ReadersWriteMutation;
 use zaparoo_core::endpoints::run::RunMutation;
@@ -632,7 +632,20 @@ impl ffi::GamesModel {
                 .as_str(),
             )),
             ENTRY_TYPE_ROLE => QVariant::from(&QString::from(entry.entry_type.as_str())),
-            FILE_COUNT_ROLE => QVariant::from(&i32::try_from(entry.file_count).unwrap_or(i32::MAX)),
+            // 0 for a media-capable directory (Core already resolved it to
+            // a single playable item -- `media_id` set, or a direct
+            // `zap_script`; see `is_media_capable_entry`) so
+            // `Format.folderCountSuffix`'s existing `fileCount <= 0`
+            // early-out suppresses the count everywhere it renders (grid,
+            // list, active label) from this one source instead of each
+            // caller re-deriving the same collapse. A tile the cover-art
+            // path already renders as the game itself showing a stray "1"
+            // beside it read as a bug, not a folder count.
+            FILE_COUNT_ROLE => QVariant::from(&if is_media_capable_entry(entry) {
+                0
+            } else {
+                i32::try_from(entry.file_count).unwrap_or(i32::MAX)
+            }),
             FAVORITE_ROLE => QVariant::from(&favorite_role_value(&entry.tags)),
             DESCRIPTION_ROLE => QVariant::from(&QString::from(entry.description.as_str())),
             FILE_STEM_ROLE => {
@@ -790,6 +803,9 @@ impl ffi::GamesModel {
         } else {
             vec![sid]
         };
+        // Must match the initial page's `BrowseArgs::new`-derived root view:
+        // Core embeds it in the cursor and validates follow-ups against it.
+        let root_view = root_view_for(&path, &systems);
         let tags = favorites_tags(self.favorites_only);
         // Read the active ticket WITHOUT bumping it. `fetch_more`
         // continues the same path's load — only `set_system` /
@@ -825,6 +841,7 @@ impl ffi::GamesModel {
                 .media_browse(MediaBrowseParams {
                     path,
                     systems,
+                    root_view,
                     max_results: Some(max_results),
                     cursor,
                     tags,
@@ -848,18 +865,22 @@ impl ffi::GamesModel {
     /// user picks "Jump to letter".
     fn load_letter_index(mut self: Pin<&mut Self>) {
         let path = self.current_path.to_string();
-        // A root listing has no meaningful first-character rail.
-        if path.is_empty() {
-            self.as_mut().set_letter_index_json(QString::from("[]"));
-            self.as_mut().set_letter_index_scheme(QString::from("none"));
-            return;
-        }
         let sid = self.current_system_id.to_string();
         let systems = if sid.is_empty() {
             Vec::new()
         } else {
             vec![sid]
         };
+        let root_view = root_view_for(&path, &systems);
+        // A route listing (multi-root/no-system pathless scope) has no
+        // meaningful first-character rail -- only a single system's merged
+        // root contents (PR #1312's `rootView: "contents"`) or an ordinary
+        // path below a system root does.
+        if path.is_empty() && root_view.is_none() {
+            self.as_mut().set_letter_index_json(QString::from("[]"));
+            self.as_mut().set_letter_index_scheme(QString::from("none"));
+            return;
+        }
         let tags = favorites_tags(self.favorites_only);
         // Clear any facet from a prior scope to the loading state (empty groups,
         // empty scheme) so the rail shows "loading" rather than the previous
@@ -878,6 +899,7 @@ impl ffi::GamesModel {
                 .media_browse_index(MediaBrowseIndexParams {
                     path,
                     systems,
+                    root_view,
                     tags,
                     sort: None,
                 })
@@ -1444,7 +1466,13 @@ impl ffi::GamesModel {
         if index < 0 || index >= self.count {
             return 0;
         }
-        i32::try_from(self.entries[index as usize].file_count).unwrap_or(i32::MAX)
+        let entry = &self.entries[index as usize];
+        // See FILE_COUNT_ROLE's data-arm comment: 0 for a media-capable
+        // directory suppresses the folder-count suffix at the source.
+        if is_media_capable_entry(entry) {
+            return 0;
+        }
+        i32::try_from(entry.file_count).unwrap_or(i32::MAX)
     }
 
     fn is_media_capable_at(&self, index: i32) -> bool {

--- a/rust/frontend/src/models/media_status.rs
+++ b/rust/frontend/src/models/media_status.rs
@@ -24,6 +24,7 @@
 // errors are logged but not surfaced as a Q_PROPERTY because the
 // notification stream is the source of truth for what the UI renders.
 
+use crate::media_image_cache::global_media_image_cache;
 use crate::models::action_error::report_action_error;
 use cxx_qt::{Initialize, Threading};
 use cxx_qt_lib::{QString, QStringList};
@@ -515,6 +516,19 @@ impl ffi::MediaStatus {
     reason = "27 fields × diff-and-set is mechanical; folding it loses the per-field NOTIFY suppression"
 )]
 fn apply(mut model: Pin<&mut ffi::MediaStatus>, s: Snapshot) {
+    // Edge detection for the negative image-cache memo -- see
+    // media_image_cache.rs's invalidate_negative_memo_for_system/_all doc
+    // comments for why: a "no image" answer memoized during a transient
+    // race (a NAS mount not yet up at boot, say) otherwise stays memoized
+    // for the rest of the process's life with nothing to clear it, so a
+    // subsequent successful reindex/rescrape never actually reaches the
+    // cache. Captured against the model's state going INTO this update
+    // (before anything below reads or moves out of `s`), so this is a
+    // "was busy a moment ago, now idle" edge, not a same-frame no-op.
+    let index_just_finished = model.indexing && !s.indexing;
+    let scrape_just_finished = model.scraping && !s.scraping;
+    let scrape_system_id = s.scrape_system_id.to_string();
+
     if model.seeded != s.seeded {
         model.as_mut().set_seeded(s.seeded);
     }
@@ -633,6 +647,22 @@ fn apply(mut model: Pin<&mut ffi::MediaStatus>, s: Snapshot) {
         model
             .as_mut()
             .set_scrape_current_skipped(s.scrape_current_skipped);
+    }
+
+    // Indexing carries no per-system scope (a whole-library operation),
+    // so a completion can only invalidate globally. A completed scrape
+    // targeting one system (`start_scrape_for_system`) invalidates just
+    // that system; an untargeted "all systems" scrape (empty
+    // scrape_system_id) invalidates globally, same as indexing.
+    if index_just_finished {
+        global_media_image_cache().invalidate_negative_memo_all();
+    }
+    if scrape_just_finished {
+        if scrape_system_id.is_empty() {
+            global_media_image_cache().invalidate_negative_memo_all();
+        } else {
+            global_media_image_cache().invalidate_negative_memo_for_system(&scrape_system_id);
+        }
     }
 }
 

--- a/rust/zaparoo-core/src/client.rs
+++ b/rust/zaparoo-core/src/client.rs
@@ -638,7 +638,6 @@ impl Client {
         debug!(
             path = %params.path,
             systems = ?params.systems,
-            root_view = ?params.root_view,
             max_results = ?params.max_results,
             cursor_set = params.cursor.is_some(),
             letter = ?params.letter,
@@ -662,7 +661,6 @@ impl Client {
         debug!(
             path = %params.path,
             systems = ?params.systems,
-            root_view = ?params.root_view,
             sort = ?params.sort,
             "media.browse.index request",
         );

--- a/rust/zaparoo-core/src/client.rs
+++ b/rust/zaparoo-core/src/client.rs
@@ -638,6 +638,7 @@ impl Client {
         debug!(
             path = %params.path,
             systems = ?params.systems,
+            root_view = ?params.root_view,
             max_results = ?params.max_results,
             cursor_set = params.cursor.is_some(),
             letter = ?params.letter,
@@ -661,6 +662,7 @@ impl Client {
         debug!(
             path = %params.path,
             systems = ?params.systems,
+            root_view = ?params.root_view,
             sort = ?params.sort,
             "media.browse.index request",
         );

--- a/rust/zaparoo-core/src/endpoints/media_browse.rs
+++ b/rust/zaparoo-core/src/endpoints/media_browse.rs
@@ -31,15 +31,6 @@ pub struct BrowseArgs {
     /// a fetch (in practice each screen has a fixed page size, so
     /// duplicates inside one process are rare).
     pub max_results: u32,
-    /// `media.browse`'s pathless `rootView` (PR #1312) -- `Some("contents")`
-    /// whenever `path` is empty and `systems` names exactly one system,
-    /// `None` otherwise. Derived here rather than accepted as a
-    /// constructor parameter so no caller can forget it; a field on the
-    /// struct rather than computed inline at the call site so it
-    /// participates in the derived `Eq`/`Hash` the store's cache keys on,
-    /// even though in practice it can never actually vary independently
-    /// of `path`/`systems` for a given cache entry.
-    pub root_view: Option<String>,
 }
 
 impl BrowseArgs {
@@ -53,30 +44,13 @@ impl BrowseArgs {
         systems.dedup();
         tags.sort();
         tags.dedup();
-        let root_view = root_view_for(&path, &systems);
         Self {
             path,
             systems,
             tags,
             max_results,
-            root_view,
         }
     }
-}
-
-/// The one rule that decides `media.browse`/`media.browse.index`'s
-/// pathless `rootView` (PR #1312): `Some("contents")` for a pathless
-/// browse scoped to exactly one system, `None` otherwise (multi-system,
-/// no system, or already below a path -- Core ignores the field there
-/// anyway). `BrowseArgs::new` is the only caller that goes through the
-/// cached `Endpoint` path; every direct `Client::media_browse`/
-/// `media_browse_index` call elsewhere (cursor follow-ups, the letter
-/// index) must derive the same value the initial page did, since Core
-/// embeds the root view in the browse cursor and validates follow-ups
-/// against it -- exported so those call sites share this exact function
-/// rather than re-deriving the rule and risking drift.
-pub fn root_view_for(path: &str, systems: &[String]) -> Option<String> {
-    (path.is_empty() && systems.len() == 1).then(|| "contents".to_string())
 }
 
 #[derive(Debug)]
@@ -96,7 +70,6 @@ impl Endpoint for MediaBrowseEndpoint {
                 .media_browse(MediaBrowseParams {
                     path: args.path,
                     systems: args.systems,
-                    root_view: args.root_view,
                     max_results: Some(args.max_results),
                     cursor: None,
                     tags: args.tags,
@@ -181,36 +154,5 @@ mod tests {
         );
         assert_ne!(unfiltered, filtered);
         assert_eq!(filtered.tags, vec!["user:favorite"]);
-    }
-
-    #[test]
-    fn browse_args_requests_root_contents_only_for_a_pathless_single_system() {
-        let args = BrowseArgs::new(String::new(), vec!["SNES".into()], 15, Vec::new());
-        assert_eq!(args.root_view.as_deref(), Some("contents"));
-    }
-
-    #[test]
-    fn browse_args_leaves_root_view_unset_below_the_system_root() {
-        let args = BrowseArgs::new("/roms/SNES".into(), vec!["SNES".into()], 15, Vec::new());
-        assert_eq!(args.root_view, None);
-    }
-
-    #[test]
-    fn browse_args_leaves_root_view_unset_for_multiple_systems() {
-        let args = BrowseArgs::new(
-            String::new(),
-            vec!["SNES".into(), "NES".into()],
-            15,
-            Vec::new(),
-        );
-        assert_eq!(args.root_view, None);
-    }
-
-    #[test]
-    fn browse_args_leaves_root_view_unset_with_no_system_scope() {
-        // The category-browse "Systems" screen root: no system selected yet,
-        // Core returns launcher routes for every configured system.
-        let args = BrowseArgs::new(String::new(), Vec::new(), 15, Vec::new());
-        assert_eq!(args.root_view, None);
     }
 }

--- a/rust/zaparoo-core/src/endpoints/media_browse.rs
+++ b/rust/zaparoo-core/src/endpoints/media_browse.rs
@@ -31,6 +31,15 @@ pub struct BrowseArgs {
     /// a fetch (in practice each screen has a fixed page size, so
     /// duplicates inside one process are rare).
     pub max_results: u32,
+    /// `media.browse`'s pathless `rootView` (PR #1312) -- `Some("contents")`
+    /// whenever `path` is empty and `systems` names exactly one system,
+    /// `None` otherwise. Derived here rather than accepted as a
+    /// constructor parameter so no caller can forget it; a field on the
+    /// struct rather than computed inline at the call site so it
+    /// participates in the derived `Eq`/`Hash` the store's cache keys on,
+    /// even though in practice it can never actually vary independently
+    /// of `path`/`systems` for a given cache entry.
+    pub root_view: Option<String>,
 }
 
 impl BrowseArgs {
@@ -44,13 +53,30 @@ impl BrowseArgs {
         systems.dedup();
         tags.sort();
         tags.dedup();
+        let root_view = root_view_for(&path, &systems);
         Self {
             path,
             systems,
             tags,
             max_results,
+            root_view,
         }
     }
+}
+
+/// The one rule that decides `media.browse`/`media.browse.index`'s
+/// pathless `rootView` (PR #1312): `Some("contents")` for a pathless
+/// browse scoped to exactly one system, `None` otherwise (multi-system,
+/// no system, or already below a path -- Core ignores the field there
+/// anyway). `BrowseArgs::new` is the only caller that goes through the
+/// cached `Endpoint` path; every direct `Client::media_browse`/
+/// `media_browse_index` call elsewhere (cursor follow-ups, the letter
+/// index) must derive the same value the initial page did, since Core
+/// embeds the root view in the browse cursor and validates follow-ups
+/// against it -- exported so those call sites share this exact function
+/// rather than re-deriving the rule and risking drift.
+pub fn root_view_for(path: &str, systems: &[String]) -> Option<String> {
+    (path.is_empty() && systems.len() == 1).then(|| "contents".to_string())
 }
 
 #[derive(Debug)]
@@ -70,6 +96,7 @@ impl Endpoint for MediaBrowseEndpoint {
                 .media_browse(MediaBrowseParams {
                     path: args.path,
                     systems: args.systems,
+                    root_view: args.root_view,
                     max_results: Some(args.max_results),
                     cursor: None,
                     tags: args.tags,
@@ -154,5 +181,36 @@ mod tests {
         );
         assert_ne!(unfiltered, filtered);
         assert_eq!(filtered.tags, vec!["user:favorite"]);
+    }
+
+    #[test]
+    fn browse_args_requests_root_contents_only_for_a_pathless_single_system() {
+        let args = BrowseArgs::new(String::new(), vec!["SNES".into()], 15, Vec::new());
+        assert_eq!(args.root_view.as_deref(), Some("contents"));
+    }
+
+    #[test]
+    fn browse_args_leaves_root_view_unset_below_the_system_root() {
+        let args = BrowseArgs::new("/roms/SNES".into(), vec!["SNES".into()], 15, Vec::new());
+        assert_eq!(args.root_view, None);
+    }
+
+    #[test]
+    fn browse_args_leaves_root_view_unset_for_multiple_systems() {
+        let args = BrowseArgs::new(
+            String::new(),
+            vec!["SNES".into(), "NES".into()],
+            15,
+            Vec::new(),
+        );
+        assert_eq!(args.root_view, None);
+    }
+
+    #[test]
+    fn browse_args_leaves_root_view_unset_with_no_system_scope() {
+        // The category-browse "Systems" screen root: no system selected yet,
+        // Core returns launcher routes for every configured system.
+        let args = BrowseArgs::new(String::new(), Vec::new(), 15, Vec::new());
+        assert_eq!(args.root_view, None);
     }
 }

--- a/rust/zaparoo-core/src/media_types.rs
+++ b/rust/zaparoo-core/src/media_types.rs
@@ -233,15 +233,6 @@ pub struct MediaBrowseParams {
     pub path: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub systems: Vec<String>,
-    /// Pathless system-root presentation (`media.browse` PR #1312).
-    /// `"contents"` replaces a single system's filesystem routes with a
-    /// one-level, display-only merge of their immediate children —
-    /// requires exactly one entry in `systems`. Omitted (Core default:
-    /// `"routes"`) returns today's separate populated routes. Ignored by
-    /// Core when `path` is non-empty. See `BrowseArgs::new` for the one
-    /// rule that decides when the frontend sets this.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub root_view: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_results: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -375,11 +366,6 @@ pub struct MediaBrowseIndexParams {
     pub path: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub systems: Vec<String>,
-    /// See `MediaBrowseParams::root_view` -- same field, same rule, kept in
-    /// sync so a letter-index request against a merged root validates
-    /// against the same cursor `media.browse` itself would issue.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub root_view: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1676,7 +1662,6 @@ mod tests {
         let params = MediaBrowseIndexParams {
             path: "/roms/SNES".into(),
             systems: vec!["SNES".into()],
-            root_view: None,
             tags: vec!["user:favorite".into()],
             sort: None,
         };
@@ -1727,7 +1712,6 @@ mod tests {
         let params = MediaBrowseParams {
             path: "/roms/SNES".into(),
             systems: vec!["SNES".into()],
-            root_view: None,
             max_results: Some(100),
             cursor: Some("opaque".into()),
             tags: vec!["user:favorite".into()],
@@ -1761,33 +1745,6 @@ mod tests {
             Some(1)
         );
         assert!(!object.contains_key("fuzzySystem"));
-    }
-
-    #[test]
-    fn media_browse_params_omits_root_view_when_unset() {
-        let params = MediaBrowseParams {
-            systems: vec!["SNES".into()],
-            ..MediaBrowseParams::default()
-        };
-        let json = serde_json::to_value(&params).expect("serialise");
-        assert!(!json.as_object().expect("object").contains_key("rootView"));
-    }
-
-    #[test]
-    fn media_browse_params_serialises_root_view_contents() {
-        let params = MediaBrowseParams {
-            systems: vec!["SNES".into()],
-            root_view: Some("contents".into()),
-            ..MediaBrowseParams::default()
-        };
-        let json = serde_json::to_value(&params).expect("serialise");
-        assert_eq!(
-            json.as_object()
-                .expect("object")
-                .get("rootView")
-                .and_then(|v| v.as_str()),
-            Some("contents")
-        );
     }
 
     #[test]

--- a/rust/zaparoo-core/src/media_types.rs
+++ b/rust/zaparoo-core/src/media_types.rs
@@ -233,6 +233,15 @@ pub struct MediaBrowseParams {
     pub path: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub systems: Vec<String>,
+    /// Pathless system-root presentation (`media.browse` PR #1312).
+    /// `"contents"` replaces a single system's filesystem routes with a
+    /// one-level, display-only merge of their immediate children —
+    /// requires exactly one entry in `systems`. Omitted (Core default:
+    /// `"routes"`) returns today's separate populated routes. Ignored by
+    /// Core when `path` is non-empty. See `BrowseArgs::new` for the one
+    /// rule that decides when the frontend sets this.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub root_view: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_results: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -366,6 +375,11 @@ pub struct MediaBrowseIndexParams {
     pub path: String,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub systems: Vec<String>,
+    /// See `MediaBrowseParams::root_view` -- same field, same rule, kept in
+    /// sync so a letter-index request against a merged root validates
+    /// against the same cursor `media.browse` itself would issue.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub root_view: Option<String>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub tags: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1662,6 +1676,7 @@ mod tests {
         let params = MediaBrowseIndexParams {
             path: "/roms/SNES".into(),
             systems: vec!["SNES".into()],
+            root_view: None,
             tags: vec!["user:favorite".into()],
             sort: None,
         };
@@ -1712,6 +1727,7 @@ mod tests {
         let params = MediaBrowseParams {
             path: "/roms/SNES".into(),
             systems: vec!["SNES".into()],
+            root_view: None,
             max_results: Some(100),
             cursor: Some("opaque".into()),
             tags: vec!["user:favorite".into()],
@@ -1745,6 +1761,33 @@ mod tests {
             Some(1)
         );
         assert!(!object.contains_key("fuzzySystem"));
+    }
+
+    #[test]
+    fn media_browse_params_omits_root_view_when_unset() {
+        let params = MediaBrowseParams {
+            systems: vec!["SNES".into()],
+            ..MediaBrowseParams::default()
+        };
+        let json = serde_json::to_value(&params).expect("serialise");
+        assert!(!json.as_object().expect("object").contains_key("rootView"));
+    }
+
+    #[test]
+    fn media_browse_params_serialises_root_view_contents() {
+        let params = MediaBrowseParams {
+            systems: vec!["SNES".into()],
+            root_view: Some("contents".into()),
+            ..MediaBrowseParams::default()
+        };
+        let json = serde_json::to_value(&params).expect("serialise");
+        assert_eq!(
+            json.as_object()
+                .expect("object")
+                .get("rootView")
+                .and_then(|v| v.as_str()),
+            Some("contents")
+        );
     }
 
     #[test]

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -151,6 +151,33 @@ int main(int argc, char* argv[]) // NOLINT
             Qt::HighDpiScaleFactorRoundingPolicy::Floor);
     }
 
+    // Qt Quick's own decoded-pixmap cache (QQuickPixmapStore) has no
+    // documented default cap tuned for this app, and every cover `Image`
+    // in Tile.qml deliberately leaves `cache: true` (see that file's
+    // doc comment -- a constant `sourceSize` needs the pixmap cache so a
+    // reload short-circuits to it instead of re-decoding). That cache
+    // sits on top of, not instead of, the Rust-side media_image_cache's
+    // own 128 MiB encoded-bytes budget: a decoded RGBA cover is several
+    // times its encoded size, so an unbounded pixmap cache can make the
+    // real image-memory ceiling far exceed what CACHE_CAP_BYTES's own
+    // sizing math assumed (see that constant's doc comment -- it was
+    // sized as if it were the only image-memory consumer). On MiSTer's
+    // swap-free ~492 MiB this reads as a gradual system-wide slowdown
+    // (page cache eviction), not an OOM, which is easy to miss without
+    // an explicit cap to point at. 32 MiB is a conservative starting
+    // point -- room for a full grid page or two of decoded tiles without
+    // competing heavily with the encoded-bytes budget or the rest of
+    // what MiSTer needs (Core, the FPGA wrapper, the active core); tune
+    // with a real long-session capture (ZAPAROO_DEBUG=1) rather than
+    // guessing further from here. QML_PIXMAP_CACHE_LIMIT is in
+    // kilobytes and must be set before the QML engine's first image
+    // decode, so this has to happen this early, ahead of both
+    // QGuiApplication and QQmlApplicationEngine construction.
+    if (qEnvironmentVariableIsEmpty("QML_PIXMAP_CACHE_LIMIT"))
+    {
+        qputenv("QML_PIXMAP_CACHE_LIMIT", QByteArrayLiteral("32768"));
+    }
+
     QGuiApplication::setApplicationName("Zaparoo Frontend");
     QGuiApplication::setApplicationVersion(ZAPAROO_VERSION);
     QGuiApplication::setOrganizationName("Zaparoo");

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -1002,8 +1002,26 @@ MainLayout {
         if (root.hubScreen === null)
             return;
         const entries = root.hubScreen.buildAddEntries();
-        if (entries.length === 0)
+        if (entries.length === 0) {
+            // `buildAddEntries()` only ever offers detected categories and
+            // built-in actions (see its own doc comment) -- once every one
+            // of those is already placed, this is a legitimate "nothing
+            // left to add" state, not a bug. Returning silently here used
+            // to read as the button doing nothing at all.
+            //
+            // Tried and rejected: opening the same picker with one
+            // informational, non-actionable row. NN/G's empty-state
+            // guidance is to teach, not just announce -- "use the empty
+            // state to provide help cues; tell the user what could be
+            // displayed, and how to populate the area with that content" --
+            // and a bare "everything's already on the Hub" row doesn't say
+            // where to go next. Route through the existing action_error
+            // modal instead, which already carries a body for exactly this:
+            // point at the real add path, "Add to Hub" on a Systems/Games/
+            // Favorites/Recents row's Options menu, not this menu.
+            root.presentActionError("hub_add_empty", qsTr("Nothing left to add"), qsTr("All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose \"Add to Hub\"."), qsTr("OK"), null);
             return;
+        }
         root.openListPickerModal(qsTr("Add item"), entries, entries[0].id, "hub_add_pick");
     }
 
@@ -2229,10 +2247,13 @@ MainLayout {
                 return [];
             if (entryType === "directory" && !mediaCapable) {
                 // A plain browsable folder has no media-scoped actions of
-                // its own -- the only thing worth offering is a Hub
-                // shortcut to it, and only on Games (a Favorites row is
-                // already a saved shortcut of its own kind, so this
-                // doesn't extend there).
+                // its own, and Favorites never contains a directory row (it
+                // is a flat list of games) -- only Games can reach this
+                // branch, so the empty-array side never actually executes.
+                // Left as an explicit owner check rather than an
+                // unconditional entry so a directory row on a future
+                // Favorites-like owner doesn't silently inherit a folder
+                // shortcut action.
                 return owner === "games" ? [
                     {
                         id: "add_to_hub",
@@ -2270,11 +2291,10 @@ MainLayout {
                     id: "discover",
                     label: qsTr("Discover alt. versions")
                 });
-            if (owner === "games")
-                entries.push({
-                    id: "add_to_hub",
-                    label: qsTr("Add to Hub")
-                });
+            entries.push({
+                id: "add_to_hub",
+                label: qsTr("Add to Hub")
+            });
             return entries;
         }
         return [];
@@ -2635,11 +2655,12 @@ MainLayout {
     }
 
     // "Add to Hub" — creates a `system`/`folder`/`zapscript` shortcut from a
-    // Systems/Games row via `Browse.HubLayout.add_target_item`. Only
-    // `system` and `games` reach here (see `buildContextMenuEntries`);
+    // Systems/Games/Favorites/Recents row via `Browse.HubLayout.add_target_item`.
     // `owner === "games"` covers both a plain directory (folder shortcut)
-    // and a media row (game shortcut). A game shortcut's `name` is the one
-    // place this layout caches a value resolved from Core — a deliberate,
+    // and a media row (game shortcut); Favorites/Recents are always a flat
+    // list of games, so they only ever create a zapscript shortcut, the
+    // same as a Games media row. A game shortcut's `name` is the one place
+    // this layout caches a value resolved from Core — a deliberate,
     // user-approved exception to the no-Core-metadata rule (see
     // `zaparoo_core::hub_layout`'s doc comment on `add_target_item`), so the
     // tile has a real title without needing Core reachable to render, and
@@ -2651,21 +2672,36 @@ MainLayout {
                 Browse.HubLayout.add_target_item("system", systemId, "", "", "", "", "");
             return;
         }
-        if (owner !== "games")
-            return;
-        const entryType = Browse.GamesModel.entry_type_at(index);
-        const systemId = Browse.GamesModel.current_system_id;
-        if (entryType === "directory") {
+        if (owner === "games") {
+            const entryType = Browse.GamesModel.entry_type_at(index);
+            const systemId = Browse.GamesModel.current_system_id;
+            if (entryType === "directory") {
+                const path = Browse.GamesModel.path_at(index);
+                if (path !== "")
+                    Browse.HubLayout.add_target_item("folder", "", path, "", "", "", systemId);
+                return;
+            }
             const path = Browse.GamesModel.path_at(index);
-            if (path !== "")
-                Browse.HubLayout.add_target_item("folder", "", path, "", "", "", systemId);
+            const script = Browse.GamesModel.launch_text_at(index);
+            if (script === "")
+                return;
+            const name = Browse.GamesModel.name_at(index);
+            Browse.HubLayout.add_target_item("zapscript", "", path, script, name, "", systemId);
             return;
         }
-        const path = Browse.GamesModel.path_at(index);
-        const script = Browse.GamesModel.launch_text_at(index);
+        // Favorites/Recents rows: same accessor shape openGameInfo already
+        // uses for these two owners a few lines below, since neither model
+        // has a single "current system" the way a Games browse does --
+        // each row carries its own system_id_at(index).
+        if (owner !== "favorites" && owner !== "recents")
+            return;
+        const model = owner === "favorites" ? Browse.FavoritesModel : Browse.RecentsModel;
+        const systemId = model.system_id_at(index);
+        const path = model.path_at(index);
+        const script = model.launch_text_at(index);
         if (script === "")
             return;
-        const name = Browse.GamesModel.name_at(index);
+        const name = model.name_at(index);
         Browse.HubLayout.add_target_item("zapscript", "", path, script, name, "", systemId);
     }
 
@@ -3091,10 +3127,12 @@ MainLayout {
     // already uses to decide whether to offer "index_category"/
     // "scrape_category" at all.
     function _buildSystemScopeEntries(): var {
-        const entries = [{
-            id: root._systemScopeAll,
-            label: qsTr("All systems")
-        }];
+        const entries = [
+            {
+                id: root._systemScopeAll,
+                label: qsTr("All systems")
+            }
+        ];
         for (let i = 0; i < Browse.CategoriesModel.count; i++) {
             const category = Browse.CategoriesModel.category_at(i);
             if (category === "" || Browse.SystemsModel.system_ids_for_category(category).length === 0)

--- a/src/ui/components/Format.qml
+++ b/src/ui/components/Format.qml
@@ -41,26 +41,31 @@ QtObject {
         return Number(n).toLocaleString(root.locale(), "f", 0);
     }
 
-    // The dim suffix for a folder/root row -- the bare item count, or
-    // "<distinguisher> · N" when the row needed disambiguating from a
-    // same-named sibling root (see games.rs's `root_distinguishers`, which
-    // overlays the distinguisher onto the same `disambiguatingTags` channel
-    // a folder normally leaves blank). No "item(s)" word: this slot is
-    // shared with ScrollingCaption's short 2-4 char disambiguating tags
-    // ("US"/"EU"), which `Text.ElideLeft`s from the front when it overflows
-    // -- a translated word phrase reliably overflowed and truncated down to
-    // a bare "...tem(s)", while the number alone reads unambiguously since
-    // a folder row never shows anything else in this slot. Hidden (empty
+    // The dim suffix for a folder/root row -- the row's distinguisher (see
+    // games.rs's `root_distinguishers`, which overlays a sibling-diffed
+    // distinguisher onto the same `disambiguatingTags` channel a folder
+    // normally leaves blank) when it has one, otherwise the bare item
+    // count. Never both: a distinguisher only ever appears on a `root` row
+    // (disambiguating same-named sibling roots), a count only ever appears
+    // on a `directory` row Core hasn't already collapsed to a single
+    // playable item (see `fileCount`'s own doc comment on `games.rs`'s
+    // `FILE_COUNT_ROLE` -- a media-capable directory reports 0 here), and
+    // those two cases don't overlap -- so no separator between them is
+    // needed. No "item(s)" word on the count: this slot is shared with
+    // ScrollingCaption's short 2-4 char disambiguating tags ("US"/"EU"),
+    // which `Text.ElideLeft`s from the front when it overflows -- a
+    // translated word phrase reliably overflowed and truncated down to a
+    // bare "...tem(s)", while the number alone reads unambiguously since a
+    // folder row never shows anything else in this slot. Hidden (empty
     // string) when `fileCount` is 0 -- Core omits the field on a root whose
     // exact count it couldn't compute in time, so 0 doesn't reliably mean
     // "empty," and showing "0" next to a folder that likely has content
     // would be actively misleading. One shared implementation for every
     // caller (BrowseList row, grid Tile caption, footer ActiveLabel).
     function folderCountSuffix(distinguisher: string, fileCount: int): string {
-        if (fileCount <= 0)
+        if (distinguisher !== "")
             return distinguisher;
-        const label = root.count(fileCount);
-        return distinguisher !== "" ? distinguisher + " · " + label : label;
+        return fileCount > 0 ? root.count(fileCount) : "";
     }
 
     // Chooses between a game row's own disambiguation tags and a folder/

--- a/src/ui/components/StatusLine.qml
+++ b/src/ui/components/StatusLine.qml
@@ -26,20 +26,25 @@ import Zaparoo.Theme
 // docs/style.md already sanctions for the global Loading cue and
 // TopStatusStrip titles.
 //
-// Content is a right-aligned pair -- label, then track -- hugging the
-// header's own right margin, not stretched across the full row the way
-// the old pill's replacement first was. The track is the rightmost
-// element; there is no trailing count next to it. That was tried (a
-// step ratio, then an absolute file/record count) and cut both times:
-// the bar already conveys progress on its own, same as the mobile app,
-// and a separate number cell kept adding layout complexity -- a
-// reserved-width void when the number was absent, a shifting anchor
-// point when it wasn't -- for information nobody needed to read twice.
-// A short message just sits closer to the right edge; the label
+// Content is a right-aligned cluster -- label, then a percentage, then
+// the track -- hugging the header's own right margin, not stretched
+// across the full row the way the old pill's replacement first was. The
+// track is the rightmost element. A trailing count next to it was tried
+// twice before this (a step ratio, then an absolute file/record count)
+// and cut both times: a variable-width number cell kept adding layout
+// complexity -- a reserved-width void when the number was absent, a
+// shifting anchor point when it wasn't. The percentage here is not that
+// same mistake a third time: its slot is fixed-width, measured once from
+// "100%" and reserved whenever the track itself is shown (see
+// `_percentReserve`), so neither failure mode reproduces. It also isn't
+// a re-display of the same information the 12-cell track already shows
+// -- the track quantises whatever Core's real step count is down to 12
+// visible states, the percentage keeps the underlying resolution. A
+// short message just sits closer to the right edge; the label
 // shrink-wraps to its own content and only elides once it would run
-// past the logo, so idle space moves to the left of the pair instead of
-// sitting in the middle of the message, and long system names still get
-// real room instead of forcing CRT-only abbreviations ("Idx…", "Scr…").
+// past the logo, so idle space moves to the left of the cluster instead
+// of sitting in the middle of the message, and long system names still
+// get real room instead of forcing CRT-only abbreviations ("Idx…", "Scr…").
 Item {
     id: root
 
@@ -227,12 +232,43 @@ Item {
     // `track.width` short of the right edge even while the track is
     // hidden.
     readonly property int _trackReserve: root._showTrack ? track.width + root._cellsSpacing : 0
+    // Round N: a percentage reading between the label and the track,
+    // derived from the same `_taskCurrentStep`/`_taskTotalSteps` the
+    // track's own cell fill uses. The bare 12-cell track quantises
+    // whatever Core's real step count is down to 12 visible states; this
+    // keeps the underlying resolution instead of re-showing the same
+    // coarse jumps as a second visual. It is NOT the raw step ordinals
+    // ("step 7 of 12") -- those were shown as literal text for two
+    // months by mistake, never meant to be user-facing (an internal
+    // progress signal for the Zaparoo mobile app) -- a normalised
+    // percentage is the correct way to surface that signal, not the
+    // ordinals themselves.
+    readonly property bool _percentKnown: root._taskTotalKnown && root._taskTotalSteps > 0
+    readonly property int _percentValue: Math.round(Math.max(0, Math.min(1, root._taskCurrentStep / Math.max(1, root._taskTotalSteps))) * 100)
+    readonly property string _percentText: root._percentKnown ? qsTr("%1%").arg(root._percentValue) : ""
+    // Fixed-width slot sized once to "100%" (`percentMetrics` below), not
+    // to whatever the current text measures -- a trailing count next to
+    // this track was tried twice before and cut twice for exactly the
+    // reflow a variable-width slot causes (see this file's own doc
+    // comment): a reserved-width void when the number was absent, a
+    // shifting anchor point when it wasn't. Reserved whenever the track
+    // itself is shown, even during the one phase with no percentage to
+    // display (optimize/vacuum -- `_percentKnown` false), so the track's
+    // own position never moves as a run passes through that phase.
+    readonly property int _percentReserve: root._showTrack ? Sizing.px(percentMetrics.advanceWidth) + root._cellsSpacing : 0
     readonly property int _labelNaturalWidth: Math.ceil(Math.max(labelMetrics.advanceWidth, labelMetrics.boundingRect.width))
-    readonly property int _labelWidth: Math.min(root._labelNaturalWidth, Math.max(0, root.width - root._trackReserve))
+    readonly property int _labelWidth: Math.min(root._labelNaturalWidth, Math.max(0, root.width - root._trackReserve - root._percentReserve))
 
     TextMetrics {
         id: labelMetrics
         text: root._label
+        font.family: Theme.fontUi
+        font.pixelSize: Sizing.fontSmall
+    }
+
+    TextMetrics {
+        id: percentMetrics
+        text: "100%"
         font.family: Theme.fontUi
         font.pixelSize: Sizing.fontSmall
     }
@@ -250,6 +286,29 @@ Item {
         totalSteps: root._taskTotalSteps
     }
 
+    // Right-aligned within its fixed-width slot -- not centered, see
+    // CLAUDE.md's integer-pixel rule -- so the boundary against the track
+    // never moves: the ones digit and "%" sit flush there, and growth
+    // (1% -> 100%) eats into the slot leftward instead of shifting the
+    // track's own position. `track.left` is always a valid anchor target
+    // regardless of `track.visible` (its own `width` is fixed
+    // independent of visibility, same as the comment on `_trackReserve`
+    // above notes), so this doesn't need parent.right as a fallback.
+    Text {
+        objectName: "statusLinePercent"
+        anchors.right: track.left
+        anchors.rightMargin: root._cellsSpacing
+        anchors.verticalCenter: parent.verticalCenter
+        width: Sizing.px(percentMetrics.advanceWidth)
+        visible: root._showTrack
+        horizontalAlignment: Text.AlignRight
+        text: root._percentText
+        font.family: Theme.fontUi
+        font.pixelSize: Sizing.fontSmall
+        color: Theme.textPrimary
+        renderType: Text.NativeRendering
+    }
+
     // Shrink-wraps to its own content (`width` is the natural measured
     // width, not the full available span) so it hugs the track instead of
     // leaving a gap -- any slack space lands to the left of this item
@@ -259,7 +318,7 @@ Item {
     Text {
         objectName: "statusLineLabel"
         anchors.right: parent.right
-        anchors.rightMargin: root._trackReserve
+        anchors.rightMargin: root._trackReserve + root._percentReserve
         anchors.verticalCenter: parent.verticalCenter
         width: root._labelWidth
         elide: Text.ElideRight

--- a/src/ui/components/StatusLine.qml
+++ b/src/ui/components/StatusLine.qml
@@ -268,7 +268,7 @@ Item {
 
     TextMetrics {
         id: percentMetrics
-        text: "100%"
+        text: qsTr("%1%").arg(100)
         font.family: Theme.fontUi
         font.pixelSize: Sizing.fontSmall
     }

--- a/src/ui/screens/GamesScreen.qml
+++ b/src/ui/screens/GamesScreen.qml
@@ -145,9 +145,19 @@ MediaListScreen {
     }
     showTopStrip: games._statusProfile ? games._statusProfile.topStripVisible : true
     topStripTitleProvider: () => {
-        const folderName = games._folderNameForPath(Browse.GamesModel.current_path);
-        if (folderName !== "")
-            return folderName;
+        // Only trust the folder-basename title once actually below the
+        // system root -- `current_path` is non-empty at the root too (it's
+        // the system's own root browse path), so a bare non-empty check
+        // here mistook root browsing for folder browsing and printed the
+        // raw directory name ("SMS", "MegaDrive") instead of the resolved
+        // system name ("Master System", "Genesis"). `_atFolderLevel()` is
+        // the same "are we actually inside a navigated folder" signal
+        // `cancelAction` above already uses for back routing.
+        if (games._atFolderLevel()) {
+            const folderName = games._folderNameForPath(Browse.GamesModel.current_path);
+            if (folderName !== "")
+                return folderName;
+        }
         const sid = Browse.GamesModel.current_system_id;
         if (sid === "")
             return "";
@@ -203,7 +213,18 @@ MediaListScreen {
         if (!games._listLayout)
             Browse.GamesModel.prefetch_around(first);
     }
-    activeLabelTextProvider: () => games.gamesGrid.itemCount > 0 ? Browse.GamesModel.name_at(games.gamesGrid.currentIndex) : ""
+    activeLabelTextProvider: () => {
+        // name_at() is a #[qinvokable], not a Q_PROPERTY -- calling it alone
+        // establishes no binding dependency on the row's own data, only on
+        // itemCount/currentIndex below. A folder swap that lands on the same
+        // index with the same item count (a common in-place-replacement
+        // case) left this label showing the previous folder's row name.
+        // rows_revision bumps on exactly that in-place-replacement path
+        // (games.rs's apply_initial_page); reading it here -- unused, but
+        // read -- makes it a tracked dependency so the label refires too.
+        void Browse.GamesModel.rows_revision;
+        return games.gamesGrid.itemCount > 0 ? Browse.GamesModel.name_at(games.gamesGrid.currentIndex) : "";
+    }
     activeLabelAtBottom: true
     activeLabelBottomMargin: games._footerProfile ? games._footerProfile.activeLabelBottomMargin : Sizing.pctH(8)
     activeLabelHeight: games._footerProfile ? games._footerProfile.activeLabelHeight : Sizing.pctH(7)

--- a/src/ui/screens/HubScreen.qml
+++ b/src/ui/screens/HubScreen.qml
@@ -1355,6 +1355,14 @@ Item {
             }
         } else if (action === "page_menu") {
             hub.requestPageMenu();
+        } else if (action === "cancel") {
+            // Deliberate no-op. Cancel used to quit the app from the Hub
+            // root screen; that's now exclusively a View-menu action (see
+            // Main.qml's "hub_quit" -> openQuitConfirmModal), so a stray
+            // Cancel/B press here must not do anything, including falling
+            // through to whatever the caller does with an unhandled
+            // action. Explicit branch rather than silent fall-through so
+            // the intent reads here instead of as an accidental gap.
         }
     }
 

--- a/src/ui/theme/ColorSchemes.qml
+++ b/src/ui/theme/ColorSchemes.qml
@@ -412,6 +412,74 @@ QtObject {
         return candidate;
     }
 
+    // Ambient accent-carrying edge roles (`tileEdge`/`controlEdge`): the
+    // resting front-edge strip on every tile and button, painted
+    // regardless of focus. These were the only two accent-carrying roles
+    // still on `_mix` (sRGB per-channel lerp) instead of this file's OKLCh
+    // path -- at the old 0.44/0.54 mix fractions toward a saturated accent
+    // this was not the near-neutral mix `_mix`'s own module doc says is
+    // fine, so it landed inconsistently loud across the catalog: hot on
+    // high-chroma presets (`nes`, `virtual-boy`, `game-boy`,
+    // `synthwave-84`), muddy on others. Reported independently by two beta
+    // testers as overpowering cover art.
+    //
+    // Chroma is CAPPED, not scaled: proportional scaling preserves the
+    // loudness ordering (the presets already flagged as too loud stay
+    // loudest), a cap pulls the loud ones down to the same ceiling the
+    // quiet presets already sit near. `controlEdge` gets a slightly higher
+    // factor and cap than `tileEdge` so it stays a touch stronger even at
+    // the ceiling -- the old 0.44/0.54 mix fractions kept that ordering by
+    // construction, a shared cap alone would have erased it on
+    // high-chroma presets.
+    //
+    // Lightness is SOLVED for a minimum separation ratio against `card`
+    // rather than a fixed offset: a fixed delta cleared only ~1.27:1 at
+    // the dark end of the catalog, under the 1.5:1 floor
+    // `test_edge_reads_as_a_lit_bevel` asserts. Walking L away from
+    // `card`'s own lightness until the ratio clears (the same
+    // walk-until-it-clears pattern `_clampAccent`/`_onAccentFor` already
+    // use) holds the floor by construction on every preset instead of
+    // needing per-preset eyeballing.
+    // `card` is the surface the edge sits directly against (giving the
+    // "raised surface" 3D separation cue); `ground` is what's typically
+    // behind the whole component (the Hub's deep background for a tile,
+    // a settings panel for a menu-row-style control) —
+    // `tst_pressable_surface.qml`'s `test_edge_uses_contextual_middle_tone`
+    // asserts against `ground`, this file's own
+    // `test_edge_reads_as_a_lit_bevel` asserts against `card`. Both must
+    // clear at once: `card`/`panel`/`bgDeep` sit on the same neutral
+    // ladder (consecutive rungs stepping from `primary` toward `text`), so
+    // walking L away from whichever pole `card` itself leans toward moves
+    // away from all of them together, not just the one the loop happens
+    // to check last.
+    function _edgeFor(accent: color, card: color, chromaFactor: real, chromaCap: real, cardMinContrast: real, ground: color, groundMinContrast: real): color {
+        const accentLch = _toLch(_srgbToOklab(accent));
+        const cardLab = _srgbToOklab(card);
+        const cardLch = _toLch(cardLab);
+        // Guaranteed separation from the card's OWN chroma, not just an
+        // absolute ceiling independent of it. `_mix` is a plain sRGB lerp,
+        // not OKLab-space, so it doesn't preserve chroma proportionally —
+        // a near-black primary mixed even slightly toward a high-chroma
+        // accent (e.g. `game-boy`'s saturated yellow-green over its
+        // near-black primary) can push the card's own perceptual chroma up
+        // more than the small mix fraction suggests, exactly the general
+        // risk this file's own module doc already names for mixing a
+        // saturated accent toward a near-black pole. A fixed cap alone
+        // doesn't account for that; comparing against the card's measured
+        // chroma does.
+        const chroma = Math.max(Math.min(accentLch.C * chromaFactor, chromaCap), cardLch.C + 0.01);
+        const direction = cardLab.L > 0.5 ? -1 : 1;
+        let L = cardLab.L;
+        let candidate = _gamutFit(L, chroma, accentLch.h);
+        for (let i = 0; i < 80 && (_contrastRatio(candidate, card) < cardMinContrast || _contrastRatio(candidate, ground) < groundMinContrast); i++) {
+            L = Math.max(0, Math.min(1, L + direction * 0.01));
+            candidate = _gamutFit(L, chroma, accentLch.h);
+            if (L <= 0 || L >= 1)
+                break;
+        }
+        return candidate;
+    }
+
     function _hueDegrees(radians: real): real {
         let deg = radians * 180 / Math.PI;
         while (deg < 0)
@@ -482,11 +550,6 @@ QtObject {
         const mid = _mix(_mix(primary, text, 0.32), accent, 0.05);
         const variant = _mix(_mix(primary, text, 0.58), accent, 0.14);
 
-        // The pressable front edge rides the accent ramp. It starts one rung
-        // up the neutral ladder so it keeps a little body on a near-black
-        // primary instead of collapsing into the background.
-        const edgeBase = _mix(primary, text, 0.06);
-
         // Semantic tier — see the derivation functions above.
         const onAccent = _onAccentFor(accent, primary, text);
         const onAccentMuted = _onAccentMutedFor(onAccent, accent);
@@ -508,8 +571,8 @@ QtObject {
             "bgPanel": panel,
             "bgBar": _mix(primary, ink, 0.35),
             "surfaceCard": card,
-            "tileEdge": _mix(edgeBase, accent, 0.44),
-            "controlEdge": _mix(edgeBase, accent, 0.54),
+            "tileEdge": _edgeFor(accent, card, 0.5, 0.05, 1.5, primary, 1.8),
+            "controlEdge": _edgeFor(accent, card, 0.6, 0.06, 1.65, panel, 2.0),
             "scrim": "#cc000000",
             "borderSubtle": subtle,
             "borderMid": mid,

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -480,13 +480,13 @@ Français - Wilfried</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
-        <location filename="../screens/GamesScreen.qml" line="217"/>
+        <location filename="../screens/GamesScreen.qml" line="176"/>
+        <location filename="../screens/GamesScreen.qml" line="238"/>
         <source>%1 games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="184"/>
         <source>Loading more…</source>
         <translation>جارٍ تحميل المزيد…</translation>
     </message>
@@ -577,7 +577,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1583"/>
+        <location filename="../screens/HubScreen.qml" line="1591"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>لا توجد أنظمة متاحة. شغّل تحديث قاعدة بيانات الوسائط من الإعدادات.</translation>
     </message>
@@ -683,81 +683,81 @@ Français - Wilfried</source>
         <translation type="vanished">تشغيل النواة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2109"/>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2127"/>
+        <location filename="../app/Main.qml" line="2563"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2124"/>
-        <location filename="../app/Main.qml" line="2159"/>
+        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Update media database</source>
         <translation type="unfinished">تحديث قاعدة بيانات الوسائط</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2145"/>
+        <location filename="../app/Main.qml" line="2180"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">استخراج البيانات الوصفية</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
+        <location filename="../app/Main.qml" line="2136"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1035"/>
+        <location filename="../app/Main.qml" line="1053"/>
         <source>Settings</source>
         <translation type="unfinished">الإعدادات</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2076"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2095"/>
+        <location filename="../app/Main.qml" line="2113"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2195"/>
-        <location filename="../app/Main.qml" line="2246"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Launch game</source>
         <translation>تشغيل اللعبة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2199"/>
-        <location filename="../app/Main.qml" line="2250"/>
+        <location filename="../app/Main.qml" line="2217"/>
+        <location filename="../app/Main.qml" line="2271"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2313"/>
+        <location filename="../app/Main.qml" line="2237"/>
+        <location filename="../app/Main.qml" line="2292"/>
+        <location filename="../app/Main.qml" line="2333"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Remove from favorites</source>
         <translation>إزالة من المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Add to favorites</source>
         <translation>أضف إلى المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2205"/>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Write to NFC token</source>
         <translation>الكتابة إلى رمز NFC</translation>
     </message>
@@ -766,358 +766,369 @@ Français - Wilfried</source>
         <translation type="vanished">رمز QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3333"/>
+        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3371"/>
         <source>Default</source>
         <translation type="unfinished">افتراضي</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
+        <location filename="../app/Main.qml" line="2559"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2104"/>
-        <location filename="../app/Main.qml" line="2154"/>
-        <location filename="../app/Main.qml" line="2171"/>
-        <location filename="../app/Main.qml" line="2179"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="3226"/>
+        <location filename="../app/Main.qml" line="2122"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2189"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="3264"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3258"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3296"/>
         <source>Favorites</source>
         <translation type="unfinished">المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1042"/>
-        <location filename="../app/Main.qml" line="3243"/>
-        <location filename="../app/Main.qml" line="3290"/>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="3281"/>
+        <location filename="../app/Main.qml" line="3328"/>
+        <location filename="../app/Main.qml" line="3338"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3309"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
+        <location filename="../app/Main.qml" line="3270"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3337"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3375"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3254"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3292"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3341"/>
+        <location filename="../app/Main.qml" line="3379"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3262"/>
+        <location filename="../app/Main.qml" line="3300"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1007"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1027"/>
+        <location filename="../app/Main.qml" line="1045"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1031"/>
+        <location filename="../app/Main.qml" line="1049"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1039"/>
+        <location filename="../app/Main.qml" line="1057"/>
         <source>Quit</source>
         <translation type="unfinished">إنهاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2114"/>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2239"/>
-        <location filename="../app/Main.qml" line="2276"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2241"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2296"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2209"/>
-        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2340"/>
+        <location filename="../app/Main.qml" line="2360"/>
         <source>Move</source>
         <translation type="unfinished">تحريك</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2523"/>
+        <location filename="../app/Main.qml" line="2543"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2871"/>
-        <location filename="../app/Main.qml" line="2893"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="2959"/>
+        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="2907"/>
+        <location filename="../app/Main.qml" line="2929"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2995"/>
         <source>OK</source>
         <translation type="unfinished">حسنًا</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2917"/>
-        <source>No matching games found.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2926"/>
-        <source>Action failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2927"/>
-        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2929"/>
-        <source>Launch failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start %1. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start this item. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2932"/>
-        <source>Favorite update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2933"/>
-        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2935"/>
-        <source>Media update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2936"/>
-        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2938"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2939"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2941"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2942"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2944"/>
-        <source>Cancel failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2945"/>
-        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2948"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2950"/>
-        <source>Alternate versions unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2951"/>
-        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2953"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2962"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2963"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2965"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2968"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2969"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2971"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2972"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2974"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2975"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2977"/>
+        <source>Scraper list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2978"/>
+        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2980"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2981"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2984"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2986"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2987"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2989"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2954"/>
+        <location filename="../app/Main.qml" line="2990"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2956"/>
+        <location filename="../app/Main.qml" line="2992"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2957"/>
+        <location filename="../app/Main.qml" line="2993"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3096"/>
+        <location filename="../app/Main.qml" line="3133"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3218"/>
+        <location filename="../app/Main.qml" line="3256"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3241"/>
-        <location filename="../app/Main.qml" line="3287"/>
+        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3325"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3275"/>
-        <location filename="../app/Main.qml" line="3297"/>
+        <location filename="../app/Main.qml" line="3313"/>
+        <location filename="../app/Main.qml" line="3335"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3317"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3315"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3353"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3311"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3349"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3518"/>
-        <location filename="../app/Main.qml" line="3536"/>
+        <location filename="../app/Main.qml" line="3556"/>
+        <location filename="../app/Main.qml" line="3574"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3522"/>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3560"/>
+        <location filename="../app/Main.qml" line="3577"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2947"/>
-        <location filename="../app/Main.qml" line="3552"/>
+        <location filename="../app/Main.qml" line="2983"/>
+        <location filename="../app/Main.qml" line="3590"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
-        <location filename="../app/Main.qml" line="3144"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Retry</source>
         <translation type="unfinished">إعادة المحاولة</translation>
     </message>
@@ -1126,37 +1137,37 @@ Français - Wilfried</source>
         <translation type="obsolete">إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4565"/>
+        <location filename="../app/Main.qml" line="4603"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4567"/>
+        <location filename="../app/Main.qml" line="4605"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4569"/>
+        <location filename="../app/Main.qml" line="4607"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4572"/>
+        <location filename="../app/Main.qml" line="4610"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4574"/>
+        <location filename="../app/Main.qml" line="4612"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4576"/>
+        <location filename="../app/Main.qml" line="4614"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4578"/>
+        <location filename="../app/Main.qml" line="4616"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>
@@ -2366,68 +2377,73 @@ Français - Wilfried</source>
 <context>
     <name>StatusLine</name>
     <message>
-        <location filename="../components/StatusLine.qml" line="66"/>
-        <location filename="../components/StatusLine.qml" line="70"/>
+        <location filename="../components/StatusLine.qml" line="71"/>
+        <location filename="../components/StatusLine.qml" line="75"/>
         <source>Disconnected</source>
         <translation type="unfinished">غير متصل</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="68"/>
+        <location filename="../components/StatusLine.qml" line="73"/>
         <source>Reconnecting…</source>
         <translation type="unfinished">جارٍ إعادة الاتصال…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="72"/>
+        <location filename="../components/StatusLine.qml" line="77"/>
         <source>Connecting…</source>
         <translation type="unfinished">جارٍ الاتصال…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error</source>
         <translation type="unfinished">خطأ في النواة</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing…</source>
         <translation type="unfinished">جارٍ الفهرسة…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping…</source>
         <translation type="unfinished">جارٍ الاستخراج…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="248"/>
+        <source>%1%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="88"/>
+        <location filename="../components/StatusLine.qml" line="93"/>
         <source>Indexing paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="100"/>
+        <location filename="../components/StatusLine.qml" line="105"/>
         <source>Scraping paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2440,27 +2456,27 @@ Français - Wilfried</source>
         <translation type="obsolete">تم استخراج %1</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexed %1 files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scraped %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="187"/>
+        <location filename="../components/StatusLine.qml" line="192"/>
         <source>Playtime limit in %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -2414,6 +2414,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
+        <location filename="../components/StatusLine.qml" line="271"/>
         <source>%1%</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -462,8 +462,8 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
-        <location filename="../screens/GamesScreen.qml" line="217"/>
+        <location filename="../screens/GamesScreen.qml" line="176"/>
+        <location filename="../screens/GamesScreen.qml" line="238"/>
         <source>%1 games</source>
         <translation type="unfinished"></translation>
     </message>
@@ -473,7 +473,7 @@ Français - Wilfried</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="184"/>
         <source>Loading more…</source>
         <translation>Mehr laden…</translation>
     </message>
@@ -569,7 +569,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1583"/>
+        <location filename="../screens/HubScreen.qml" line="1591"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Keine Systeme verfügbar. Bitte Mediendatenbank unter Einstellungen aktualisieren.</translation>
     </message>
@@ -675,24 +675,24 @@ Français - Wilfried</source>
         <translation type="vanished">Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2109"/>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2127"/>
+        <location filename="../app/Main.qml" line="2563"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Remove from favorites</source>
         <translation>Aus Favoriten entfernen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Add to favorites</source>
         <translation>Zu Favoriten hinzufügen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2205"/>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Write to NFC token</source>
         <translation>Auf NFC-Token schreiben</translation>
     </message>
@@ -701,430 +701,441 @@ Français - Wilfried</source>
         <translation type="vanished">QR-Code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2195"/>
-        <location filename="../app/Main.qml" line="2246"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Launch game</source>
         <translation>Spiel starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1042"/>
-        <location filename="../app/Main.qml" line="3243"/>
-        <location filename="../app/Main.qml" line="3290"/>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="3281"/>
+        <location filename="../app/Main.qml" line="3328"/>
+        <location filename="../app/Main.qml" line="3338"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3317"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4565"/>
+        <location filename="../app/Main.qml" line="4603"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4572"/>
+        <location filename="../app/Main.qml" line="4610"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4567"/>
+        <location filename="../app/Main.qml" line="4605"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2124"/>
-        <location filename="../app/Main.qml" line="2159"/>
+        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediendatenbank aktualisieren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2145"/>
+        <location filename="../app/Main.qml" line="2180"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadaten abrufen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
+        <location filename="../app/Main.qml" line="2136"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1035"/>
+        <location filename="../app/Main.qml" line="1053"/>
         <source>Settings</source>
         <translation type="unfinished">Einstellungen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2076"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2095"/>
+        <location filename="../app/Main.qml" line="2113"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2199"/>
-        <location filename="../app/Main.qml" line="2250"/>
+        <location filename="../app/Main.qml" line="2217"/>
+        <location filename="../app/Main.qml" line="2271"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2313"/>
+        <location filename="../app/Main.qml" line="2237"/>
+        <location filename="../app/Main.qml" line="2292"/>
+        <location filename="../app/Main.qml" line="2333"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3333"/>
+        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3371"/>
         <source>Default</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
+        <location filename="../app/Main.qml" line="2559"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2104"/>
-        <location filename="../app/Main.qml" line="2154"/>
-        <location filename="../app/Main.qml" line="2171"/>
-        <location filename="../app/Main.qml" line="2179"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="3226"/>
+        <location filename="../app/Main.qml" line="2122"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2189"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="3264"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3309"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
+        <location filename="../app/Main.qml" line="3270"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3337"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3375"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3254"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3292"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3341"/>
+        <location filename="../app/Main.qml" line="3379"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3262"/>
+        <location filename="../app/Main.qml" line="3300"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1007"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1027"/>
+        <location filename="../app/Main.qml" line="1045"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1031"/>
+        <location filename="../app/Main.qml" line="1049"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1039"/>
+        <location filename="../app/Main.qml" line="1057"/>
         <source>Quit</source>
         <translation type="unfinished">Beenden</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2114"/>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2239"/>
-        <location filename="../app/Main.qml" line="2276"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2241"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2296"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2209"/>
-        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2340"/>
+        <location filename="../app/Main.qml" line="2360"/>
         <source>Move</source>
         <translation type="unfinished">Bewegen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2523"/>
+        <location filename="../app/Main.qml" line="2543"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2871"/>
-        <location filename="../app/Main.qml" line="2893"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="2959"/>
+        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="2907"/>
+        <location filename="../app/Main.qml" line="2929"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2995"/>
         <source>OK</source>
         <translation type="unfinished">In Ordnung</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2917"/>
-        <source>No matching games found.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2926"/>
-        <source>Action failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2927"/>
-        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2929"/>
-        <source>Launch failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start %1. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start this item. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2932"/>
-        <source>Favorite update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2933"/>
-        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2935"/>
-        <source>Media update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2936"/>
-        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2938"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2939"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2941"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2942"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2944"/>
-        <source>Cancel failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2945"/>
-        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2948"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2950"/>
-        <source>Alternate versions unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2951"/>
-        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2953"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2962"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2963"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2965"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2968"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2969"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2971"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2972"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2974"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2975"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2977"/>
+        <source>Scraper list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2978"/>
+        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2980"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2981"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2984"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2986"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2987"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2989"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2954"/>
+        <location filename="../app/Main.qml" line="2990"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2956"/>
+        <location filename="../app/Main.qml" line="2992"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2957"/>
+        <location filename="../app/Main.qml" line="2993"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3096"/>
+        <location filename="../app/Main.qml" line="3133"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3218"/>
+        <location filename="../app/Main.qml" line="3256"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3258"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3296"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoriten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3241"/>
-        <location filename="../app/Main.qml" line="3287"/>
+        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3325"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3275"/>
-        <location filename="../app/Main.qml" line="3297"/>
+        <location filename="../app/Main.qml" line="3313"/>
+        <location filename="../app/Main.qml" line="3335"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3315"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3353"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3311"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3349"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3518"/>
-        <location filename="../app/Main.qml" line="3536"/>
+        <location filename="../app/Main.qml" line="3556"/>
+        <location filename="../app/Main.qml" line="3574"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3522"/>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3560"/>
+        <location filename="../app/Main.qml" line="3577"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2947"/>
-        <location filename="../app/Main.qml" line="3552"/>
+        <location filename="../app/Main.qml" line="2983"/>
+        <location filename="../app/Main.qml" line="3590"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
-        <location filename="../app/Main.qml" line="3144"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Retry</source>
         <translation type="unfinished">Wiederholen</translation>
     </message>
@@ -1133,22 +1144,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4569"/>
+        <location filename="../app/Main.qml" line="4607"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4574"/>
+        <location filename="../app/Main.qml" line="4612"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4576"/>
+        <location filename="../app/Main.qml" line="4614"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4578"/>
+        <location filename="../app/Main.qml" line="4616"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>
@@ -2358,68 +2369,73 @@ Français - Wilfried</source>
 <context>
     <name>StatusLine</name>
     <message>
-        <location filename="../components/StatusLine.qml" line="66"/>
-        <location filename="../components/StatusLine.qml" line="70"/>
+        <location filename="../components/StatusLine.qml" line="71"/>
+        <location filename="../components/StatusLine.qml" line="75"/>
         <source>Disconnected</source>
         <translation type="unfinished">Getrennt</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="68"/>
+        <location filename="../components/StatusLine.qml" line="73"/>
         <source>Reconnecting…</source>
         <translation type="unfinished">Verbindung wird wiederhergestellt…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="72"/>
+        <location filename="../components/StatusLine.qml" line="77"/>
         <source>Connecting…</source>
         <translation type="unfinished">Verbindung wird aufgebaut…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error</source>
         <translation type="unfinished">Core-Fehler</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing…</source>
         <translation type="unfinished">Indizierung…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping…</source>
         <translation type="unfinished">Metadaten werden abgerufen…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="248"/>
+        <source>%1%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="88"/>
+        <location filename="../components/StatusLine.qml" line="93"/>
         <source>Indexing paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="100"/>
+        <location filename="../components/StatusLine.qml" line="105"/>
         <source>Scraping paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2432,27 +2448,27 @@ Français - Wilfried</source>
         <translation type="obsolete">%1 erfasst</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexed %1 files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scraped %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="187"/>
+        <location filename="../components/StatusLine.qml" line="192"/>
         <source>Playtime limit in %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -2406,6 +2406,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
+        <location filename="../components/StatusLine.qml" line="271"/>
         <source>%1%</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -462,8 +462,8 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
-        <location filename="../screens/GamesScreen.qml" line="217"/>
+        <location filename="../screens/GamesScreen.qml" line="176"/>
+        <location filename="../screens/GamesScreen.qml" line="238"/>
         <source>%1 games</source>
         <translation type="unfinished"></translation>
     </message>
@@ -473,7 +473,7 @@ Français - Wilfried</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="184"/>
         <source>Loading more…</source>
         <translation>Φόρτωση περισσότερων…</translation>
     </message>
@@ -569,7 +569,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1583"/>
+        <location filename="../screens/HubScreen.qml" line="1591"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Δεν υπάρχουν διαθέσιμα συστήματα. Εκτελέστε Ενημέρωση βάσης δεδομένων από τις Ρυθμίσεις.</translation>
     </message>
@@ -675,24 +675,24 @@ Français - Wilfried</source>
         <translation type="vanished">Εκκίνηση Core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2109"/>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2127"/>
+        <location filename="../app/Main.qml" line="2563"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Remove from favorites</source>
         <translation>Αφαίρεση από αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Add to favorites</source>
         <translation>Προσθήκη στα αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2205"/>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Write to NFC token</source>
         <translation>Εγγραφή σε NFC token</translation>
     </message>
@@ -701,430 +701,441 @@ Français - Wilfried</source>
         <translation type="vanished">Κωδικός QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2195"/>
-        <location filename="../app/Main.qml" line="2246"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Launch game</source>
         <translation>Εκκίνηση παιχνιδιού</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1042"/>
-        <location filename="../app/Main.qml" line="3243"/>
-        <location filename="../app/Main.qml" line="3290"/>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="3281"/>
+        <location filename="../app/Main.qml" line="3328"/>
+        <location filename="../app/Main.qml" line="3338"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3317"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4565"/>
+        <location filename="../app/Main.qml" line="4603"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4572"/>
+        <location filename="../app/Main.qml" line="4610"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4567"/>
+        <location filename="../app/Main.qml" line="4605"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2124"/>
-        <location filename="../app/Main.qml" line="2159"/>
+        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Update media database</source>
         <translation type="unfinished">Ενημέρωση βάσης δεδομένων</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2145"/>
+        <location filename="../app/Main.qml" line="2180"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Ανάκτηση μεταδεδομένων</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
+        <location filename="../app/Main.qml" line="2136"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1035"/>
+        <location filename="../app/Main.qml" line="1053"/>
         <source>Settings</source>
         <translation type="unfinished">Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2076"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2095"/>
+        <location filename="../app/Main.qml" line="2113"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2199"/>
-        <location filename="../app/Main.qml" line="2250"/>
+        <location filename="../app/Main.qml" line="2217"/>
+        <location filename="../app/Main.qml" line="2271"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2313"/>
+        <location filename="../app/Main.qml" line="2237"/>
+        <location filename="../app/Main.qml" line="2292"/>
+        <location filename="../app/Main.qml" line="2333"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3333"/>
+        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3371"/>
         <source>Default</source>
         <translation type="unfinished">Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
+        <location filename="../app/Main.qml" line="2559"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2104"/>
-        <location filename="../app/Main.qml" line="2154"/>
-        <location filename="../app/Main.qml" line="2171"/>
-        <location filename="../app/Main.qml" line="2179"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="3226"/>
+        <location filename="../app/Main.qml" line="2122"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2189"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="3264"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3309"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
+        <location filename="../app/Main.qml" line="3270"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3337"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3375"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3254"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3292"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3341"/>
+        <location filename="../app/Main.qml" line="3379"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3262"/>
+        <location filename="../app/Main.qml" line="3300"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1007"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1027"/>
+        <location filename="../app/Main.qml" line="1045"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1031"/>
+        <location filename="../app/Main.qml" line="1049"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1039"/>
+        <location filename="../app/Main.qml" line="1057"/>
         <source>Quit</source>
         <translation type="unfinished">Έξοδος</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2114"/>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2239"/>
-        <location filename="../app/Main.qml" line="2276"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2241"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2296"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2209"/>
-        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2340"/>
+        <location filename="../app/Main.qml" line="2360"/>
         <source>Move</source>
         <translation type="unfinished">Μετακίνηση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2523"/>
+        <location filename="../app/Main.qml" line="2543"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2871"/>
-        <location filename="../app/Main.qml" line="2893"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="2959"/>
+        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="2907"/>
+        <location filename="../app/Main.qml" line="2929"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2995"/>
         <source>OK</source>
         <translation type="unfinished">Εντάξει</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2917"/>
-        <source>No matching games found.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2926"/>
-        <source>Action failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2927"/>
-        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2929"/>
-        <source>Launch failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start %1. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start this item. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2932"/>
-        <source>Favorite update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2933"/>
-        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2935"/>
-        <source>Media update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2936"/>
-        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2938"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2939"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2941"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2942"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2944"/>
-        <source>Cancel failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2945"/>
-        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2948"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2950"/>
-        <source>Alternate versions unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2951"/>
-        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2953"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2962"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2963"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2965"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2968"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2969"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2971"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2972"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2974"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2975"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2977"/>
+        <source>Scraper list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2978"/>
+        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2980"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2981"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2984"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2986"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2987"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2989"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2954"/>
+        <location filename="../app/Main.qml" line="2990"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2956"/>
+        <location filename="../app/Main.qml" line="2992"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2957"/>
+        <location filename="../app/Main.qml" line="2993"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3096"/>
+        <location filename="../app/Main.qml" line="3133"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3218"/>
+        <location filename="../app/Main.qml" line="3256"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3258"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3296"/>
         <source>Favorites</source>
         <translation type="unfinished">Αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3241"/>
-        <location filename="../app/Main.qml" line="3287"/>
+        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3325"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3275"/>
-        <location filename="../app/Main.qml" line="3297"/>
+        <location filename="../app/Main.qml" line="3313"/>
+        <location filename="../app/Main.qml" line="3335"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3315"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3353"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3311"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3349"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3518"/>
-        <location filename="../app/Main.qml" line="3536"/>
+        <location filename="../app/Main.qml" line="3556"/>
+        <location filename="../app/Main.qml" line="3574"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3522"/>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3560"/>
+        <location filename="../app/Main.qml" line="3577"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2947"/>
-        <location filename="../app/Main.qml" line="3552"/>
+        <location filename="../app/Main.qml" line="2983"/>
+        <location filename="../app/Main.qml" line="3590"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
-        <location filename="../app/Main.qml" line="3144"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Retry</source>
         <translation type="unfinished">Επανάληψη</translation>
     </message>
@@ -1133,22 +1144,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4569"/>
+        <location filename="../app/Main.qml" line="4607"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4574"/>
+        <location filename="../app/Main.qml" line="4612"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4576"/>
+        <location filename="../app/Main.qml" line="4614"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4578"/>
+        <location filename="../app/Main.qml" line="4616"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>
@@ -2358,68 +2369,73 @@ Français - Wilfried</source>
 <context>
     <name>StatusLine</name>
     <message>
-        <location filename="../components/StatusLine.qml" line="66"/>
-        <location filename="../components/StatusLine.qml" line="70"/>
+        <location filename="../components/StatusLine.qml" line="71"/>
+        <location filename="../components/StatusLine.qml" line="75"/>
         <source>Disconnected</source>
         <translation type="unfinished">Αποσυνδεδεμένο</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="68"/>
+        <location filename="../components/StatusLine.qml" line="73"/>
         <source>Reconnecting…</source>
         <translation type="unfinished">Επανασύνδεση…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="72"/>
+        <location filename="../components/StatusLine.qml" line="77"/>
         <source>Connecting…</source>
         <translation type="unfinished">Σύνδεση…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error</source>
         <translation type="unfinished">Σφάλμα Core</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing…</source>
         <translation type="unfinished">Ευρετηρίαση…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping…</source>
         <translation type="unfinished">Γίνεται συλλογή…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="248"/>
+        <source>%1%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="88"/>
+        <location filename="../components/StatusLine.qml" line="93"/>
         <source>Indexing paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="100"/>
+        <location filename="../components/StatusLine.qml" line="105"/>
         <source>Scraping paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2432,27 +2448,27 @@ Français - Wilfried</source>
         <translation type="obsolete">%1 συλλέχθηκαν</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexed %1 files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scraped %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="187"/>
+        <location filename="../components/StatusLine.qml" line="192"/>
         <source>Playtime limit in %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -2406,6 +2406,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
+        <location filename="../components/StatusLine.qml" line="271"/>
         <source>%1%</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -2292,6 +2292,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
+        <location filename="../components/StatusLine.qml" line="271"/>
         <source>%1%</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -388,8 +388,8 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
-        <location filename="../screens/GamesScreen.qml" line="217"/>
+        <location filename="../screens/GamesScreen.qml" line="176"/>
+        <location filename="../screens/GamesScreen.qml" line="238"/>
         <source>%1 games</source>
         <translation type="unfinished"></translation>
     </message>
@@ -399,7 +399,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="184"/>
         <source>Loading more…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -499,7 +499,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1583"/>
+        <location filename="../screens/HubScreen.qml" line="1591"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -589,452 +589,463 @@ Français - Wilfried</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="2109"/>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2127"/>
+        <location filename="../app/Main.qml" line="2563"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Add to favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2205"/>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Write to NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2195"/>
-        <location filename="../app/Main.qml" line="2246"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Launch game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1042"/>
-        <location filename="../app/Main.qml" line="3243"/>
-        <location filename="../app/Main.qml" line="3290"/>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="3281"/>
+        <location filename="../app/Main.qml" line="3328"/>
+        <location filename="../app/Main.qml" line="3338"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3317"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4565"/>
+        <location filename="../app/Main.qml" line="4603"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4572"/>
+        <location filename="../app/Main.qml" line="4610"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4567"/>
+        <location filename="../app/Main.qml" line="4605"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2124"/>
-        <location filename="../app/Main.qml" line="2159"/>
+        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Update media database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2145"/>
+        <location filename="../app/Main.qml" line="2180"/>
         <source>Scrape metadata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
+        <location filename="../app/Main.qml" line="2136"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1035"/>
+        <location filename="../app/Main.qml" line="1053"/>
         <source>Settings</source>
         <translation type="unfinished">Settings</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2076"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2095"/>
+        <location filename="../app/Main.qml" line="2113"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2199"/>
-        <location filename="../app/Main.qml" line="2250"/>
+        <location filename="../app/Main.qml" line="2217"/>
+        <location filename="../app/Main.qml" line="2271"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2313"/>
+        <location filename="../app/Main.qml" line="2237"/>
+        <location filename="../app/Main.qml" line="2292"/>
+        <location filename="../app/Main.qml" line="2333"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3333"/>
+        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3371"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
+        <location filename="../app/Main.qml" line="2559"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2104"/>
-        <location filename="../app/Main.qml" line="2154"/>
-        <location filename="../app/Main.qml" line="2171"/>
-        <location filename="../app/Main.qml" line="2179"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="3226"/>
+        <location filename="../app/Main.qml" line="2122"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2189"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="3264"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3309"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
+        <location filename="../app/Main.qml" line="3270"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3337"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3375"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3254"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3292"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3341"/>
+        <location filename="../app/Main.qml" line="3379"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3262"/>
+        <location filename="../app/Main.qml" line="3300"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1007"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1027"/>
+        <location filename="../app/Main.qml" line="1045"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1031"/>
+        <location filename="../app/Main.qml" line="1049"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1039"/>
+        <location filename="../app/Main.qml" line="1057"/>
         <source>Quit</source>
         <translation type="unfinished">Quit</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2114"/>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2239"/>
-        <location filename="../app/Main.qml" line="2276"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2241"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2296"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2209"/>
-        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2340"/>
+        <location filename="../app/Main.qml" line="2360"/>
         <source>Move</source>
         <translation type="unfinished">Move</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2523"/>
+        <location filename="../app/Main.qml" line="2543"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2871"/>
-        <location filename="../app/Main.qml" line="2893"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="2959"/>
+        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="2907"/>
+        <location filename="../app/Main.qml" line="2929"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2995"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2917"/>
-        <source>No matching games found.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2926"/>
-        <source>Action failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2927"/>
-        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2929"/>
-        <source>Launch failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start %1. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start this item. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2932"/>
-        <source>Favorite update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2933"/>
-        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2935"/>
-        <source>Media update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2936"/>
-        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2938"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2939"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2941"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2942"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2944"/>
-        <source>Cancel failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2945"/>
-        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2948"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2950"/>
-        <source>Alternate versions unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2951"/>
-        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2953"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2962"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2963"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2965"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2968"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2969"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2971"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2972"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2974"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2975"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2977"/>
+        <source>Scraper list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2978"/>
+        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2980"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2981"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2984"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2986"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2987"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2989"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2954"/>
+        <location filename="../app/Main.qml" line="2990"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2956"/>
+        <location filename="../app/Main.qml" line="2992"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2957"/>
+        <location filename="../app/Main.qml" line="2993"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3096"/>
+        <location filename="../app/Main.qml" line="3133"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3218"/>
+        <location filename="../app/Main.qml" line="3256"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3258"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3296"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorites</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3241"/>
-        <location filename="../app/Main.qml" line="3287"/>
+        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3325"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3275"/>
-        <location filename="../app/Main.qml" line="3297"/>
+        <location filename="../app/Main.qml" line="3313"/>
+        <location filename="../app/Main.qml" line="3335"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3315"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3353"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3311"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3349"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3518"/>
-        <location filename="../app/Main.qml" line="3536"/>
+        <location filename="../app/Main.qml" line="3556"/>
+        <location filename="../app/Main.qml" line="3574"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3522"/>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3560"/>
+        <location filename="../app/Main.qml" line="3577"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2947"/>
-        <location filename="../app/Main.qml" line="3552"/>
+        <location filename="../app/Main.qml" line="2983"/>
+        <location filename="../app/Main.qml" line="3590"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
-        <location filename="../app/Main.qml" line="3144"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Retry</source>
         <translation type="unfinished">Retry</translation>
     </message>
@@ -1043,22 +1054,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Cancel</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4569"/>
+        <location filename="../app/Main.qml" line="4607"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4574"/>
+        <location filename="../app/Main.qml" line="4612"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4576"/>
+        <location filename="../app/Main.qml" line="4614"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4578"/>
+        <location filename="../app/Main.qml" line="4616"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>
@@ -2244,68 +2255,73 @@ Français - Wilfried</source>
 <context>
     <name>StatusLine</name>
     <message>
-        <location filename="../components/StatusLine.qml" line="66"/>
-        <location filename="../components/StatusLine.qml" line="70"/>
+        <location filename="../components/StatusLine.qml" line="71"/>
+        <location filename="../components/StatusLine.qml" line="75"/>
         <source>Disconnected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="68"/>
+        <location filename="../components/StatusLine.qml" line="73"/>
         <source>Reconnecting…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="72"/>
+        <location filename="../components/StatusLine.qml" line="77"/>
         <source>Connecting…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error</source>
         <translation type="unfinished">Core error</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="248"/>
+        <source>%1%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="88"/>
+        <location filename="../components/StatusLine.qml" line="93"/>
         <source>Indexing paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="100"/>
+        <location filename="../components/StatusLine.qml" line="105"/>
         <source>Scraping paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2314,27 +2330,27 @@ Français - Wilfried</source>
         <translation type="obsolete">%1 files</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexed %1 files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scraped %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="187"/>
+        <location filename="../components/StatusLine.qml" line="192"/>
         <source>Playtime limit in %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -2402,6 +2402,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
+        <location filename="../components/StatusLine.qml" line="271"/>
         <source>%1%</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -462,8 +462,8 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
-        <location filename="../screens/GamesScreen.qml" line="217"/>
+        <location filename="../screens/GamesScreen.qml" line="176"/>
+        <location filename="../screens/GamesScreen.qml" line="238"/>
         <source>%1 games</source>
         <translation type="unfinished"></translation>
     </message>
@@ -473,7 +473,7 @@ Français - Wilfried</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="184"/>
         <source>Loading more…</source>
         <translation>Cargando más…</translation>
     </message>
@@ -569,7 +569,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1583"/>
+        <location filename="../screens/HubScreen.qml" line="1591"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>No hay sistemas disponibles. Ejecuta Actualizar la base de datos de medios desde Ajustes.</translation>
     </message>
@@ -675,24 +675,24 @@ Français - Wilfried</source>
         <translation type="vanished">Lanzar core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2109"/>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2127"/>
+        <location filename="../app/Main.qml" line="2563"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Remove from favorites</source>
         <translation>Eliminar de favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Add to favorites</source>
         <translation>Agregar a favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2205"/>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Write to NFC token</source>
         <translation>Escribir en token NFC</translation>
     </message>
@@ -701,430 +701,441 @@ Français - Wilfried</source>
         <translation type="vanished">Código QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2195"/>
-        <location filename="../app/Main.qml" line="2246"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Launch game</source>
         <translation>Iniciar juego</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1042"/>
-        <location filename="../app/Main.qml" line="3243"/>
-        <location filename="../app/Main.qml" line="3290"/>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="3281"/>
+        <location filename="../app/Main.qml" line="3328"/>
+        <location filename="../app/Main.qml" line="3338"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3317"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4565"/>
+        <location filename="../app/Main.qml" line="4603"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4572"/>
+        <location filename="../app/Main.qml" line="4610"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4567"/>
+        <location filename="../app/Main.qml" line="4605"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2124"/>
-        <location filename="../app/Main.qml" line="2159"/>
+        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizar base de datos de medios</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2145"/>
+        <location filename="../app/Main.qml" line="2180"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extraer metadatos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
+        <location filename="../app/Main.qml" line="2136"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1035"/>
+        <location filename="../app/Main.qml" line="1053"/>
         <source>Settings</source>
         <translation type="unfinished">Ajustes</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2076"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2095"/>
+        <location filename="../app/Main.qml" line="2113"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2199"/>
-        <location filename="../app/Main.qml" line="2250"/>
+        <location filename="../app/Main.qml" line="2217"/>
+        <location filename="../app/Main.qml" line="2271"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2313"/>
+        <location filename="../app/Main.qml" line="2237"/>
+        <location filename="../app/Main.qml" line="2292"/>
+        <location filename="../app/Main.qml" line="2333"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3333"/>
+        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3371"/>
         <source>Default</source>
         <translation type="unfinished">Por defecto</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
+        <location filename="../app/Main.qml" line="2559"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2104"/>
-        <location filename="../app/Main.qml" line="2154"/>
-        <location filename="../app/Main.qml" line="2171"/>
-        <location filename="../app/Main.qml" line="2179"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="3226"/>
+        <location filename="../app/Main.qml" line="2122"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2189"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="3264"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3309"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
+        <location filename="../app/Main.qml" line="3270"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3337"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3375"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3254"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3292"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3341"/>
+        <location filename="../app/Main.qml" line="3379"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3262"/>
+        <location filename="../app/Main.qml" line="3300"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1007"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1027"/>
+        <location filename="../app/Main.qml" line="1045"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1031"/>
+        <location filename="../app/Main.qml" line="1049"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1039"/>
+        <location filename="../app/Main.qml" line="1057"/>
         <source>Quit</source>
         <translation type="unfinished">Salir</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2114"/>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2239"/>
-        <location filename="../app/Main.qml" line="2276"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2241"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2296"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2209"/>
-        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2340"/>
+        <location filename="../app/Main.qml" line="2360"/>
         <source>Move</source>
         <translation type="unfinished">Mover</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2523"/>
+        <location filename="../app/Main.qml" line="2543"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2871"/>
-        <location filename="../app/Main.qml" line="2893"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="2959"/>
+        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="2907"/>
+        <location filename="../app/Main.qml" line="2929"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2995"/>
         <source>OK</source>
         <translation type="unfinished">Aceptar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2917"/>
-        <source>No matching games found.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2926"/>
-        <source>Action failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2927"/>
-        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2929"/>
-        <source>Launch failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start %1. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start this item. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2932"/>
-        <source>Favorite update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2933"/>
-        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2935"/>
-        <source>Media update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2936"/>
-        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2938"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2939"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2941"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2942"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2944"/>
-        <source>Cancel failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2945"/>
-        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2948"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2950"/>
-        <source>Alternate versions unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2951"/>
-        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2953"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2962"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2963"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2965"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2968"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2969"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2971"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2972"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2974"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2975"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2977"/>
+        <source>Scraper list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2978"/>
+        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2980"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2981"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2984"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2986"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2987"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2989"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2954"/>
+        <location filename="../app/Main.qml" line="2990"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2956"/>
+        <location filename="../app/Main.qml" line="2992"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2957"/>
+        <location filename="../app/Main.qml" line="2993"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3096"/>
+        <location filename="../app/Main.qml" line="3133"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3218"/>
+        <location filename="../app/Main.qml" line="3256"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3258"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3296"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3241"/>
-        <location filename="../app/Main.qml" line="3287"/>
+        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3325"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3275"/>
-        <location filename="../app/Main.qml" line="3297"/>
+        <location filename="../app/Main.qml" line="3313"/>
+        <location filename="../app/Main.qml" line="3335"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3315"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3353"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3311"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3349"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3518"/>
-        <location filename="../app/Main.qml" line="3536"/>
+        <location filename="../app/Main.qml" line="3556"/>
+        <location filename="../app/Main.qml" line="3574"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3522"/>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3560"/>
+        <location filename="../app/Main.qml" line="3577"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2947"/>
-        <location filename="../app/Main.qml" line="3552"/>
+        <location filename="../app/Main.qml" line="2983"/>
+        <location filename="../app/Main.qml" line="3590"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
-        <location filename="../app/Main.qml" line="3144"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Retry</source>
         <translation type="unfinished">Reintentar</translation>
     </message>
@@ -1133,22 +1144,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4569"/>
+        <location filename="../app/Main.qml" line="4607"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4574"/>
+        <location filename="../app/Main.qml" line="4612"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4576"/>
+        <location filename="../app/Main.qml" line="4614"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4578"/>
+        <location filename="../app/Main.qml" line="4616"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>
@@ -2354,68 +2365,73 @@ Français - Wilfried</source>
 <context>
     <name>StatusLine</name>
     <message>
-        <location filename="../components/StatusLine.qml" line="66"/>
-        <location filename="../components/StatusLine.qml" line="70"/>
+        <location filename="../components/StatusLine.qml" line="71"/>
+        <location filename="../components/StatusLine.qml" line="75"/>
         <source>Disconnected</source>
         <translation type="unfinished">Desconectado</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="68"/>
+        <location filename="../components/StatusLine.qml" line="73"/>
         <source>Reconnecting…</source>
         <translation type="unfinished">Reconectando…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="72"/>
+        <location filename="../components/StatusLine.qml" line="77"/>
         <source>Connecting…</source>
         <translation type="unfinished">Conectando…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error</source>
         <translation type="unfinished">Error del Core</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing…</source>
         <translation type="unfinished">Indexando…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping…</source>
         <translation type="unfinished">Extrayendo…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="248"/>
+        <source>%1%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="88"/>
+        <location filename="../components/StatusLine.qml" line="93"/>
         <source>Indexing paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="100"/>
+        <location filename="../components/StatusLine.qml" line="105"/>
         <source>Scraping paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2428,27 +2444,27 @@ Français - Wilfried</source>
         <translation type="obsolete">%1 extraídos</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexed %1 files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scraped %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="187"/>
+        <location filename="../components/StatusLine.qml" line="192"/>
         <source>Playtime limit in %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -2428,6 +2428,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
+        <location filename="../components/StatusLine.qml" line="271"/>
         <source>%1%</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -470,8 +470,8 @@ Français - Wilfried</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
-        <location filename="../screens/GamesScreen.qml" line="217"/>
+        <location filename="../screens/GamesScreen.qml" line="176"/>
+        <location filename="../screens/GamesScreen.qml" line="238"/>
         <source>%1 games</source>
         <translation type="unfinished"></translation>
     </message>
@@ -485,7 +485,7 @@ Français - Wilfried</source>
         <translation type="unfinished">Jokuak kargatzen</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="184"/>
         <source>Loading more…</source>
         <translation type="unfinished">Gehiago kargatzen...</translation>
     </message>
@@ -585,7 +585,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1583"/>
+        <location filename="../screens/HubScreen.qml" line="1591"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation type="unfinished">Ez dago sistemarik eskuragarri. Exekutatu Eguneratu baliabide datubasea Aukeretatik</translation>
     </message>
@@ -691,24 +691,24 @@ Français - Wilfried</source>
         <translation type="obsolete">Exekutatu nukleoa</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2109"/>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2127"/>
+        <location filename="../app/Main.qml" line="2563"/>
         <source>Change launcher</source>
         <translation type="unfinished">Aldatu abiarazlea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Remove from favorites</source>
         <translation type="unfinished">Kendu gogokoetatik</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Add to favorites</source>
         <translation type="unfinished">Gehitu gogokoetan</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2205"/>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Idatzi NFC token-a</translation>
     </message>
@@ -717,422 +717,433 @@ Français - Wilfried</source>
         <translation type="obsolete">QR kodea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2195"/>
-        <location filename="../app/Main.qml" line="2246"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Launch game</source>
         <translation type="unfinished">Abiarazi jokua</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1042"/>
-        <location filename="../app/Main.qml" line="3243"/>
-        <location filename="../app/Main.qml" line="3290"/>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="3281"/>
+        <location filename="../app/Main.qml" line="3328"/>
+        <location filename="../app/Main.qml" line="3338"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3317"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4565"/>
+        <location filename="../app/Main.qml" line="4603"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4572"/>
+        <location filename="../app/Main.qml" line="4610"/>
         <source>Loading favorites…</source>
         <translation type="unfinished">Gogokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4567"/>
+        <location filename="../app/Main.qml" line="4605"/>
         <source>Loading games…</source>
         <translation type="unfinished">Jokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2124"/>
-        <location filename="../app/Main.qml" line="2159"/>
+        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Update media database</source>
         <translation type="unfinished">Eguneratu multimedia datu-basea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2145"/>
+        <location filename="../app/Main.qml" line="2180"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadatuak scrapeatu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
+        <location filename="../app/Main.qml" line="2136"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1035"/>
+        <location filename="../app/Main.qml" line="1053"/>
         <source>Settings</source>
         <translation type="unfinished">Ezarpenak</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2076"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2095"/>
+        <location filename="../app/Main.qml" line="2113"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2199"/>
-        <location filename="../app/Main.qml" line="2250"/>
+        <location filename="../app/Main.qml" line="2217"/>
+        <location filename="../app/Main.qml" line="2271"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2313"/>
+        <location filename="../app/Main.qml" line="2237"/>
+        <location filename="../app/Main.qml" line="2292"/>
+        <location filename="../app/Main.qml" line="2333"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3333"/>
+        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3371"/>
         <source>Default</source>
         <translation type="unfinished">Lehenetsia</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
+        <location filename="../app/Main.qml" line="2559"/>
         <source>Current: %1</source>
         <translation type="unfinished">Unekoa: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2104"/>
-        <location filename="../app/Main.qml" line="2154"/>
-        <location filename="../app/Main.qml" line="2171"/>
-        <location filename="../app/Main.qml" line="2179"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="3226"/>
+        <location filename="../app/Main.qml" line="2122"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2189"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="3264"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3309"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
+        <location filename="../app/Main.qml" line="3270"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3337"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3375"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3254"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3292"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3341"/>
+        <location filename="../app/Main.qml" line="3379"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3262"/>
+        <location filename="../app/Main.qml" line="3300"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1007"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1027"/>
+        <location filename="../app/Main.qml" line="1045"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1031"/>
+        <location filename="../app/Main.qml" line="1049"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1039"/>
+        <location filename="../app/Main.qml" line="1057"/>
         <source>Quit</source>
         <translation type="unfinished">Irten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2114"/>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2239"/>
-        <location filename="../app/Main.qml" line="2276"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2241"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2296"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2209"/>
-        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2340"/>
+        <location filename="../app/Main.qml" line="2360"/>
         <source>Move</source>
         <translation type="unfinished">Mugitu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2523"/>
+        <location filename="../app/Main.qml" line="2543"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2871"/>
-        <location filename="../app/Main.qml" line="2893"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="2959"/>
+        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="2907"/>
+        <location filename="../app/Main.qml" line="2929"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2995"/>
         <source>OK</source>
         <translation type="unfinished">Ados</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2917"/>
-        <source>No matching games found.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2926"/>
-        <source>Action failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2927"/>
-        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2929"/>
-        <source>Launch failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start %1. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start this item. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2932"/>
-        <source>Favorite update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2933"/>
-        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2935"/>
-        <source>Media update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2936"/>
-        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2938"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2939"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2941"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2942"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2944"/>
-        <source>Cancel failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2945"/>
-        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2948"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2950"/>
-        <source>Alternate versions unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2951"/>
-        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2953"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2962"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2963"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2965"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2968"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2969"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2971"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2972"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2974"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2975"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2977"/>
+        <source>Scraper list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2978"/>
+        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2980"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2981"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2984"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2986"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2987"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2989"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2954"/>
+        <location filename="../app/Main.qml" line="2990"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2956"/>
+        <location filename="../app/Main.qml" line="2992"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2957"/>
+        <location filename="../app/Main.qml" line="2993"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3096"/>
+        <location filename="../app/Main.qml" line="3133"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3218"/>
+        <location filename="../app/Main.qml" line="3256"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3258"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3296"/>
         <source>Favorites</source>
         <translation type="unfinished">Gogokoak</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3241"/>
-        <location filename="../app/Main.qml" line="3287"/>
+        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3325"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3275"/>
-        <location filename="../app/Main.qml" line="3297"/>
+        <location filename="../app/Main.qml" line="3313"/>
+        <location filename="../app/Main.qml" line="3335"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3315"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3353"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3311"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3349"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3518"/>
-        <location filename="../app/Main.qml" line="3536"/>
+        <location filename="../app/Main.qml" line="3556"/>
+        <location filename="../app/Main.qml" line="3574"/>
         <source>Saving launcher</source>
         <translation type="unfinished">Abiarazlea gordetzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3522"/>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3560"/>
+        <location filename="../app/Main.qml" line="3577"/>
         <source>Saving…</source>
         <translation type="unfinished">Gordetzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2947"/>
-        <location filename="../app/Main.qml" line="3552"/>
+        <location filename="../app/Main.qml" line="2983"/>
+        <location filename="../app/Main.qml" line="3590"/>
         <source>Launcher update failed</source>
         <translation type="unfinished">Abiarazle egukeraketak huts egin du</translation>
     </message>
@@ -1141,10 +1152,10 @@ Français - Wilfried</source>
         <translation type="obsolete">Errorea: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
-        <location filename="../app/Main.qml" line="3144"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Retry</source>
         <translation type="unfinished">Berriro saiatu</translation>
     </message>
@@ -1153,22 +1164,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Utzi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4569"/>
+        <location filename="../app/Main.qml" line="4607"/>
         <source>Loading game…</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4574"/>
+        <location filename="../app/Main.qml" line="4612"/>
         <source>Loading recently played…</source>
         <translation type="unfinished">Duela gutxi jokatutakoak kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4576"/>
+        <location filename="../app/Main.qml" line="4614"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4578"/>
+        <location filename="../app/Main.qml" line="4616"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
@@ -2390,48 +2401,53 @@ Français - Wilfried</source>
 <context>
     <name>StatusLine</name>
     <message>
-        <location filename="../components/StatusLine.qml" line="66"/>
-        <location filename="../components/StatusLine.qml" line="70"/>
+        <location filename="../components/StatusLine.qml" line="71"/>
+        <location filename="../components/StatusLine.qml" line="75"/>
         <source>Disconnected</source>
         <translation type="unfinished">Deskonektatuta</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="68"/>
+        <location filename="../components/StatusLine.qml" line="73"/>
         <source>Reconnecting…</source>
         <translation type="unfinished">Berkonektatzen...</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="72"/>
+        <location filename="../components/StatusLine.qml" line="77"/>
         <source>Connecting…</source>
         <translation type="unfinished">Konektatzen...</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="88"/>
+        <location filename="../components/StatusLine.qml" line="93"/>
         <source>Indexing paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="248"/>
+        <source>%1%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error</source>
         <translation type="unfinished">Nukleo errorea</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing…</source>
         <translation type="unfinished">Indexatzen...</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping…</source>
         <translation type="unfinished">Scrapeatzen...</translation>
     </message>
@@ -2440,22 +2456,22 @@ Français - Wilfried</source>
         <translation type="obsolete">%1 / %2</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="100"/>
+        <location filename="../components/StatusLine.qml" line="105"/>
         <source>Scraping paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2468,27 +2484,27 @@ Français - Wilfried</source>
         <translation type="obsolete">%1 scrapetatuta</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexed %1 files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scraped %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="187"/>
+        <location filename="../components/StatusLine.qml" line="192"/>
         <source>Playtime limit in %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_fr.ts
+++ b/src/ui/translations/frontend_fr.ts
@@ -2443,6 +2443,7 @@ Français - Wilfried</translation>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
+        <location filename="../components/StatusLine.qml" line="271"/>
         <source>%1%</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_fr.ts
+++ b/src/ui/translations/frontend_fr.ts
@@ -473,8 +473,8 @@ Français - Wilfried</translation>
         <translation>Chargement du jeu…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
-        <location filename="../screens/GamesScreen.qml" line="217"/>
+        <location filename="../screens/GamesScreen.qml" line="176"/>
+        <location filename="../screens/GamesScreen.qml" line="238"/>
         <source>%1 games</source>
         <translation type="unfinished"></translation>
     </message>
@@ -488,7 +488,7 @@ Français - Wilfried</translation>
         <translation>Chargement des jeux…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="184"/>
         <source>Loading more…</source>
         <translation>Chargement…</translation>
     </message>
@@ -592,7 +592,7 @@ Français - Wilfried</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1583"/>
+        <location filename="../screens/HubScreen.qml" line="1591"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Aucun système disponible. Lancez Mettre à jour la base de données média depuis les Réglages.</translation>
     </message>
@@ -702,24 +702,24 @@ Français - Wilfried</translation>
         <translation type="vanished">Lancer le core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2109"/>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2127"/>
+        <location filename="../app/Main.qml" line="2563"/>
         <source>Change launcher</source>
         <translation>Modifier le lanceur</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Remove from favorites</source>
         <translation>Retirer des favoris</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Add to favorites</source>
         <translation>Ajouter aux favoris</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2205"/>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Write to NFC token</source>
         <translation>Écrire sur un badge NFC</translation>
     </message>
@@ -728,8 +728,8 @@ Français - Wilfried</translation>
         <translation type="vanished">QR code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2195"/>
-        <location filename="../app/Main.qml" line="2246"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Launch game</source>
         <translation>Lancer le jeu</translation>
     </message>
@@ -738,118 +738,118 @@ Français - Wilfried</translation>
         <translation type="vanished">Aller à...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1042"/>
-        <location filename="../app/Main.qml" line="3243"/>
-        <location filename="../app/Main.qml" line="3290"/>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="3281"/>
+        <location filename="../app/Main.qml" line="3328"/>
+        <location filename="../app/Main.qml" line="3338"/>
         <source>View</source>
         <translation>Afficher</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4565"/>
+        <location filename="../app/Main.qml" line="4603"/>
         <source>Loading systems…</source>
         <translation>Chargement des systèmes…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4572"/>
+        <location filename="../app/Main.qml" line="4610"/>
         <source>Loading favorites…</source>
         <translation>Chargement des favoris…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4567"/>
+        <location filename="../app/Main.qml" line="4605"/>
         <source>Loading games…</source>
         <translation>Chargement des jeux…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2124"/>
-        <location filename="../app/Main.qml" line="2159"/>
+        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Update media database</source>
         <translation>Mettre à jour la base de données média</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2145"/>
+        <location filename="../app/Main.qml" line="2180"/>
         <source>Scrape metadata</source>
         <translation>Scraper les métadonnées</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
+        <location filename="../app/Main.qml" line="2136"/>
         <source>Unhide</source>
         <translation>Afficher</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1035"/>
+        <location filename="../app/Main.qml" line="1053"/>
         <source>Settings</source>
         <translation type="unfinished">Réglages</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2076"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2095"/>
+        <location filename="../app/Main.qml" line="2113"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Hide</source>
         <translation>Masquer</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2199"/>
-        <location filename="../app/Main.qml" line="2250"/>
+        <location filename="../app/Main.qml" line="2217"/>
+        <location filename="../app/Main.qml" line="2271"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2313"/>
+        <location filename="../app/Main.qml" line="2237"/>
+        <location filename="../app/Main.qml" line="2292"/>
+        <location filename="../app/Main.qml" line="2333"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3333"/>
+        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3371"/>
         <source>Default</source>
         <translation>Par défaut</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
+        <location filename="../app/Main.qml" line="2559"/>
         <source>Current: %1</source>
         <translation>Actuel&#xa0;: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2104"/>
-        <location filename="../app/Main.qml" line="2154"/>
-        <location filename="../app/Main.qml" line="2171"/>
-        <location filename="../app/Main.qml" line="2179"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="3226"/>
+        <location filename="../app/Main.qml" line="2122"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2189"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="3264"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1007"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1027"/>
+        <location filename="../app/Main.qml" line="1045"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1031"/>
+        <location filename="../app/Main.qml" line="1049"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -858,300 +858,311 @@ Français - Wilfried</translation>
         <translation type="obsolete">Réglages et utilitaires</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1039"/>
+        <location filename="../app/Main.qml" line="1057"/>
         <source>Quit</source>
         <translation type="unfinished">Quitter</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2114"/>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2239"/>
-        <location filename="../app/Main.qml" line="2276"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2241"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2296"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2209"/>
-        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2340"/>
+        <location filename="../app/Main.qml" line="2360"/>
         <source>Move</source>
         <translation type="unfinished">Déplacer</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2523"/>
+        <location filename="../app/Main.qml" line="2543"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2871"/>
-        <location filename="../app/Main.qml" line="2893"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="2959"/>
+        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="2907"/>
+        <location filename="../app/Main.qml" line="2929"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2995"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2917"/>
-        <source>No matching games found.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2926"/>
-        <source>Action failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2927"/>
-        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2929"/>
-        <source>Launch failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start %1. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start this item. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2932"/>
-        <source>Favorite update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2933"/>
-        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2935"/>
-        <source>Media update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2936"/>
-        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2938"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2939"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2941"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2942"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2944"/>
-        <source>Cancel failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2945"/>
-        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2948"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2950"/>
-        <source>Alternate versions unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2951"/>
-        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2953"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2962"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2963"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2965"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2968"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2969"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2971"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2972"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2974"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2975"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2977"/>
+        <source>Scraper list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2978"/>
+        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2980"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2981"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2984"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2986"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2987"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2989"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2954"/>
+        <location filename="../app/Main.qml" line="2990"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2956"/>
+        <location filename="../app/Main.qml" line="2992"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2957"/>
+        <location filename="../app/Main.qml" line="2993"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3096"/>
+        <location filename="../app/Main.qml" line="3133"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3218"/>
+        <location filename="../app/Main.qml" line="3256"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
+        <location filename="../app/Main.qml" line="3270"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3258"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3296"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoris</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3254"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3292"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3241"/>
-        <location filename="../app/Main.qml" line="3287"/>
+        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3325"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3262"/>
+        <location filename="../app/Main.qml" line="3300"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3309"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3275"/>
-        <location filename="../app/Main.qml" line="3297"/>
+        <location filename="../app/Main.qml" line="3313"/>
+        <location filename="../app/Main.qml" line="3335"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3317"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3315"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3353"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3311"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3349"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3337"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3375"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3341"/>
+        <location filename="../app/Main.qml" line="3379"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3518"/>
-        <location filename="../app/Main.qml" line="3536"/>
+        <location filename="../app/Main.qml" line="3556"/>
+        <location filename="../app/Main.qml" line="3574"/>
         <source>Saving launcher</source>
         <translation>Enregistrement du lanceur</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3522"/>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3560"/>
+        <location filename="../app/Main.qml" line="3577"/>
         <source>Saving…</source>
         <translation>Enregistrement…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2947"/>
-        <location filename="../app/Main.qml" line="3552"/>
+        <location filename="../app/Main.qml" line="2983"/>
+        <location filename="../app/Main.qml" line="3590"/>
         <source>Launcher update failed</source>
         <translation>Échec de la mise à jour du lanceur</translation>
     </message>
@@ -1160,10 +1171,10 @@ Français - Wilfried</translation>
         <translation type="vanished">Erreur&#xa0;: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
-        <location filename="../app/Main.qml" line="3144"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Retry</source>
         <translation>Réessayer</translation>
     </message>
@@ -1172,22 +1183,22 @@ Français - Wilfried</translation>
         <translation type="vanished">Annuler</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4569"/>
+        <location filename="../app/Main.qml" line="4607"/>
         <source>Loading game…</source>
         <translation>Chargement du jeu…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4574"/>
+        <location filename="../app/Main.qml" line="4612"/>
         <source>Loading recently played…</source>
         <translation>Chargement des jeux récents…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4576"/>
+        <location filename="../app/Main.qml" line="4614"/>
         <source>Loading settings…</source>
         <translation>Chargement des réglages…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4578"/>
+        <location filename="../app/Main.qml" line="4616"/>
         <source>Loading…</source>
         <translation>Chargement…</translation>
     </message>
@@ -2405,48 +2416,53 @@ Français - Wilfried</translation>
 <context>
     <name>StatusLine</name>
     <message>
-        <location filename="../components/StatusLine.qml" line="66"/>
-        <location filename="../components/StatusLine.qml" line="70"/>
+        <location filename="../components/StatusLine.qml" line="71"/>
+        <location filename="../components/StatusLine.qml" line="75"/>
         <source>Disconnected</source>
         <translation type="unfinished">Déconnecté</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="68"/>
+        <location filename="../components/StatusLine.qml" line="73"/>
         <source>Reconnecting…</source>
         <translation type="unfinished">Reconnexion…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="72"/>
+        <location filename="../components/StatusLine.qml" line="77"/>
         <source>Connecting…</source>
         <translation type="unfinished">Connexion…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="88"/>
+        <location filename="../components/StatusLine.qml" line="93"/>
         <source>Indexing paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="248"/>
+        <source>%1%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error</source>
         <translation type="unfinished">Erreur Core</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing…</source>
         <translation type="unfinished">Indexation…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping…</source>
         <translation type="unfinished">Scraping…</translation>
     </message>
@@ -2455,22 +2471,22 @@ Français - Wilfried</translation>
         <translation type="obsolete">%1 / %2</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="100"/>
+        <location filename="../components/StatusLine.qml" line="105"/>
         <source>Scraping paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2483,27 +2499,27 @@ Français - Wilfried</translation>
         <translation type="obsolete">%1 scrapés</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexed %1 files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scraped %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="187"/>
+        <location filename="../components/StatusLine.qml" line="192"/>
         <source>Playtime limit in %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -472,13 +472,13 @@ Français - Wilfried</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
-        <location filename="../screens/GamesScreen.qml" line="217"/>
+        <location filename="../screens/GamesScreen.qml" line="176"/>
+        <location filename="../screens/GamesScreen.qml" line="238"/>
         <source>%1 games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="184"/>
         <source>Loading more…</source>
         <translation>טוען עוד…</translation>
     </message>
@@ -569,7 +569,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1583"/>
+        <location filename="../screens/HubScreen.qml" line="1591"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>אין מערכות זמינות. הפעילו &quot;עדכון מסד נתוני מדיה&quot; מההגדרות.</translation>
     </message>
@@ -675,81 +675,81 @@ Français - Wilfried</source>
         <translation type="vanished">הפעל את הליבה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2109"/>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2127"/>
+        <location filename="../app/Main.qml" line="2563"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2124"/>
-        <location filename="../app/Main.qml" line="2159"/>
+        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Update media database</source>
         <translation type="unfinished">עדכון מסד נתוני המדיה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2145"/>
+        <location filename="../app/Main.qml" line="2180"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">איסוף מטא-נתונים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
+        <location filename="../app/Main.qml" line="2136"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1035"/>
+        <location filename="../app/Main.qml" line="1053"/>
         <source>Settings</source>
         <translation type="unfinished">הגדרות</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2076"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2095"/>
+        <location filename="../app/Main.qml" line="2113"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2195"/>
-        <location filename="../app/Main.qml" line="2246"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Launch game</source>
         <translation>הפעל משחק</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2199"/>
-        <location filename="../app/Main.qml" line="2250"/>
+        <location filename="../app/Main.qml" line="2217"/>
+        <location filename="../app/Main.qml" line="2271"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2313"/>
+        <location filename="../app/Main.qml" line="2237"/>
+        <location filename="../app/Main.qml" line="2292"/>
+        <location filename="../app/Main.qml" line="2333"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Remove from favorites</source>
         <translation>הסר מהמועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Add to favorites</source>
         <translation>הוסף למועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2205"/>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Write to NFC token</source>
         <translation>כתוב לטוקן NFC</translation>
     </message>
@@ -758,358 +758,369 @@ Français - Wilfried</source>
         <translation type="vanished">קוד QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3333"/>
+        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3371"/>
         <source>Default</source>
         <translation type="unfinished">ברירת מחדל</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
+        <location filename="../app/Main.qml" line="2559"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2104"/>
-        <location filename="../app/Main.qml" line="2154"/>
-        <location filename="../app/Main.qml" line="2171"/>
-        <location filename="../app/Main.qml" line="2179"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="3226"/>
+        <location filename="../app/Main.qml" line="2122"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2189"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="3264"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3258"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3296"/>
         <source>Favorites</source>
         <translation type="unfinished">מועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1042"/>
-        <location filename="../app/Main.qml" line="3243"/>
-        <location filename="../app/Main.qml" line="3290"/>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="3281"/>
+        <location filename="../app/Main.qml" line="3328"/>
+        <location filename="../app/Main.qml" line="3338"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3309"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
+        <location filename="../app/Main.qml" line="3270"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3337"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3375"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3254"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3292"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3341"/>
+        <location filename="../app/Main.qml" line="3379"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3262"/>
+        <location filename="../app/Main.qml" line="3300"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1007"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1027"/>
+        <location filename="../app/Main.qml" line="1045"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1031"/>
+        <location filename="../app/Main.qml" line="1049"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1039"/>
+        <location filename="../app/Main.qml" line="1057"/>
         <source>Quit</source>
         <translation type="unfinished">יציאה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2114"/>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2239"/>
-        <location filename="../app/Main.qml" line="2276"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2241"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2296"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2209"/>
-        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2340"/>
+        <location filename="../app/Main.qml" line="2360"/>
         <source>Move</source>
         <translation type="unfinished">הזזה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2523"/>
+        <location filename="../app/Main.qml" line="2543"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2871"/>
-        <location filename="../app/Main.qml" line="2893"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="2959"/>
+        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="2907"/>
+        <location filename="../app/Main.qml" line="2929"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2995"/>
         <source>OK</source>
         <translation type="unfinished">אישור</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2917"/>
-        <source>No matching games found.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2926"/>
-        <source>Action failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2927"/>
-        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2929"/>
-        <source>Launch failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start %1. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start this item. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2932"/>
-        <source>Favorite update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2933"/>
-        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2935"/>
-        <source>Media update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2936"/>
-        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2938"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2939"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2941"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2942"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2944"/>
-        <source>Cancel failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2945"/>
-        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2948"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2950"/>
-        <source>Alternate versions unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2951"/>
-        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2953"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2962"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2963"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2965"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2968"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2969"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2971"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2972"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2974"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2975"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2977"/>
+        <source>Scraper list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2978"/>
+        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2980"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2981"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2984"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2986"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2987"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2989"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2954"/>
+        <location filename="../app/Main.qml" line="2990"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2956"/>
+        <location filename="../app/Main.qml" line="2992"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2957"/>
+        <location filename="../app/Main.qml" line="2993"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3096"/>
+        <location filename="../app/Main.qml" line="3133"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3218"/>
+        <location filename="../app/Main.qml" line="3256"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3241"/>
-        <location filename="../app/Main.qml" line="3287"/>
+        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3325"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3275"/>
-        <location filename="../app/Main.qml" line="3297"/>
+        <location filename="../app/Main.qml" line="3313"/>
+        <location filename="../app/Main.qml" line="3335"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3317"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3315"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3353"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3311"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3349"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3518"/>
-        <location filename="../app/Main.qml" line="3536"/>
+        <location filename="../app/Main.qml" line="3556"/>
+        <location filename="../app/Main.qml" line="3574"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3522"/>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3560"/>
+        <location filename="../app/Main.qml" line="3577"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2947"/>
-        <location filename="../app/Main.qml" line="3552"/>
+        <location filename="../app/Main.qml" line="2983"/>
+        <location filename="../app/Main.qml" line="3590"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
-        <location filename="../app/Main.qml" line="3144"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Retry</source>
         <translation type="unfinished">נסה שוב</translation>
     </message>
@@ -1118,37 +1129,37 @@ Français - Wilfried</source>
         <translation type="obsolete">ביטול</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4565"/>
+        <location filename="../app/Main.qml" line="4603"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4567"/>
+        <location filename="../app/Main.qml" line="4605"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4569"/>
+        <location filename="../app/Main.qml" line="4607"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4572"/>
+        <location filename="../app/Main.qml" line="4610"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4574"/>
+        <location filename="../app/Main.qml" line="4612"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4576"/>
+        <location filename="../app/Main.qml" line="4614"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4578"/>
+        <location filename="../app/Main.qml" line="4616"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>
@@ -2358,68 +2369,73 @@ Français - Wilfried</source>
 <context>
     <name>StatusLine</name>
     <message>
-        <location filename="../components/StatusLine.qml" line="66"/>
-        <location filename="../components/StatusLine.qml" line="70"/>
+        <location filename="../components/StatusLine.qml" line="71"/>
+        <location filename="../components/StatusLine.qml" line="75"/>
         <source>Disconnected</source>
         <translation type="unfinished">מנותק</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="68"/>
+        <location filename="../components/StatusLine.qml" line="73"/>
         <source>Reconnecting…</source>
         <translation type="unfinished">מתחבר מחדש…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="72"/>
+        <location filename="../components/StatusLine.qml" line="77"/>
         <source>Connecting…</source>
         <translation type="unfinished">מתחבר…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error</source>
         <translation type="unfinished">שגיאת Core</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing…</source>
         <translation type="unfinished">מאנדקס…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping…</source>
         <translation type="unfinished">אוסף נתונים…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="248"/>
+        <source>%1%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="88"/>
+        <location filename="../components/StatusLine.qml" line="93"/>
         <source>Indexing paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="100"/>
+        <location filename="../components/StatusLine.qml" line="105"/>
         <source>Scraping paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2432,27 +2448,27 @@ Français - Wilfried</source>
         <translation type="obsolete">%1 נאספו</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexed %1 files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scraped %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="187"/>
+        <location filename="../components/StatusLine.qml" line="192"/>
         <source>Playtime limit in %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -2406,6 +2406,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
+        <location filename="../components/StatusLine.qml" line="271"/>
         <source>%1%</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -472,13 +472,13 @@ Français - Wilfried</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
-        <location filename="../screens/GamesScreen.qml" line="217"/>
+        <location filename="../screens/GamesScreen.qml" line="176"/>
+        <location filename="../screens/GamesScreen.qml" line="238"/>
         <source>%1 games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="184"/>
         <source>Loading more…</source>
         <translation>और लोड हो रहा है…</translation>
     </message>
@@ -569,7 +569,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1583"/>
+        <location filename="../screens/HubScreen.qml" line="1591"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>कोई सिस्टम उपलब्ध नहीं है। सेटिंग्स से मीडिया डेटाबेस अपडेट चलाएँ।</translation>
     </message>
@@ -675,81 +675,81 @@ Français - Wilfried</source>
         <translation type="vanished">कोर चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2109"/>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2127"/>
+        <location filename="../app/Main.qml" line="2563"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2124"/>
-        <location filename="../app/Main.qml" line="2159"/>
+        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Update media database</source>
         <translation type="unfinished">मीडिया डेटाबेस अपडेट करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2145"/>
+        <location filename="../app/Main.qml" line="2180"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">मेटाडेटा स्क्रैप करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
+        <location filename="../app/Main.qml" line="2136"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1035"/>
+        <location filename="../app/Main.qml" line="1053"/>
         <source>Settings</source>
         <translation type="unfinished">सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2076"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2095"/>
+        <location filename="../app/Main.qml" line="2113"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2195"/>
-        <location filename="../app/Main.qml" line="2246"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Launch game</source>
         <translation>गेम चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2199"/>
-        <location filename="../app/Main.qml" line="2250"/>
+        <location filename="../app/Main.qml" line="2217"/>
+        <location filename="../app/Main.qml" line="2271"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2313"/>
+        <location filename="../app/Main.qml" line="2237"/>
+        <location filename="../app/Main.qml" line="2292"/>
+        <location filename="../app/Main.qml" line="2333"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Remove from favorites</source>
         <translation>पसंदीदा से हटाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Add to favorites</source>
         <translation>पसंदीदा में जोड़ें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2205"/>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Write to NFC token</source>
         <translation>NFC टोकन पर लिखें</translation>
     </message>
@@ -758,358 +758,369 @@ Français - Wilfried</source>
         <translation type="vanished">QR कोड</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3333"/>
+        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3371"/>
         <source>Default</source>
         <translation type="unfinished">डिफ़ॉल्ट</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
+        <location filename="../app/Main.qml" line="2559"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2104"/>
-        <location filename="../app/Main.qml" line="2154"/>
-        <location filename="../app/Main.qml" line="2171"/>
-        <location filename="../app/Main.qml" line="2179"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="3226"/>
+        <location filename="../app/Main.qml" line="2122"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2189"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="3264"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3258"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3296"/>
         <source>Favorites</source>
         <translation type="unfinished">पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1042"/>
-        <location filename="../app/Main.qml" line="3243"/>
-        <location filename="../app/Main.qml" line="3290"/>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="3281"/>
+        <location filename="../app/Main.qml" line="3328"/>
+        <location filename="../app/Main.qml" line="3338"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3309"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
+        <location filename="../app/Main.qml" line="3270"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3337"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3375"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3254"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3292"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3341"/>
+        <location filename="../app/Main.qml" line="3379"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3262"/>
+        <location filename="../app/Main.qml" line="3300"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1007"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1027"/>
+        <location filename="../app/Main.qml" line="1045"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1031"/>
+        <location filename="../app/Main.qml" line="1049"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1039"/>
+        <location filename="../app/Main.qml" line="1057"/>
         <source>Quit</source>
         <translation type="unfinished">बंद करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2114"/>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2239"/>
-        <location filename="../app/Main.qml" line="2276"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2241"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2296"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2209"/>
-        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2340"/>
+        <location filename="../app/Main.qml" line="2360"/>
         <source>Move</source>
         <translation type="unfinished">स्थानांतरित करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2523"/>
+        <location filename="../app/Main.qml" line="2543"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2871"/>
-        <location filename="../app/Main.qml" line="2893"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="2959"/>
+        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="2907"/>
+        <location filename="../app/Main.qml" line="2929"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2995"/>
         <source>OK</source>
         <translation type="unfinished">ठीक है</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2917"/>
-        <source>No matching games found.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2926"/>
-        <source>Action failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2927"/>
-        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2929"/>
-        <source>Launch failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start %1. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start this item. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2932"/>
-        <source>Favorite update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2933"/>
-        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2935"/>
-        <source>Media update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2936"/>
-        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2938"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2939"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2941"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2942"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2944"/>
-        <source>Cancel failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2945"/>
-        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2948"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2950"/>
-        <source>Alternate versions unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2951"/>
-        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2953"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2962"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2963"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2965"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2968"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2969"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2971"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2972"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2974"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2975"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2977"/>
+        <source>Scraper list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2978"/>
+        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2980"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2981"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2984"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2986"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2987"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2989"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2954"/>
+        <location filename="../app/Main.qml" line="2990"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2956"/>
+        <location filename="../app/Main.qml" line="2992"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2957"/>
+        <location filename="../app/Main.qml" line="2993"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3096"/>
+        <location filename="../app/Main.qml" line="3133"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3218"/>
+        <location filename="../app/Main.qml" line="3256"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3241"/>
-        <location filename="../app/Main.qml" line="3287"/>
+        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3325"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3275"/>
-        <location filename="../app/Main.qml" line="3297"/>
+        <location filename="../app/Main.qml" line="3313"/>
+        <location filename="../app/Main.qml" line="3335"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3317"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3315"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3353"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3311"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3349"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3518"/>
-        <location filename="../app/Main.qml" line="3536"/>
+        <location filename="../app/Main.qml" line="3556"/>
+        <location filename="../app/Main.qml" line="3574"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3522"/>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3560"/>
+        <location filename="../app/Main.qml" line="3577"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2947"/>
-        <location filename="../app/Main.qml" line="3552"/>
+        <location filename="../app/Main.qml" line="2983"/>
+        <location filename="../app/Main.qml" line="3590"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
-        <location filename="../app/Main.qml" line="3144"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Retry</source>
         <translation type="unfinished">फिर से प्रयास करें</translation>
     </message>
@@ -1118,37 +1129,37 @@ Français - Wilfried</source>
         <translation type="obsolete">रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4565"/>
+        <location filename="../app/Main.qml" line="4603"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4567"/>
+        <location filename="../app/Main.qml" line="4605"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4569"/>
+        <location filename="../app/Main.qml" line="4607"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4572"/>
+        <location filename="../app/Main.qml" line="4610"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4574"/>
+        <location filename="../app/Main.qml" line="4612"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4576"/>
+        <location filename="../app/Main.qml" line="4614"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4578"/>
+        <location filename="../app/Main.qml" line="4616"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>
@@ -2358,68 +2369,73 @@ Français - Wilfried</source>
 <context>
     <name>StatusLine</name>
     <message>
-        <location filename="../components/StatusLine.qml" line="66"/>
-        <location filename="../components/StatusLine.qml" line="70"/>
+        <location filename="../components/StatusLine.qml" line="71"/>
+        <location filename="../components/StatusLine.qml" line="75"/>
         <source>Disconnected</source>
         <translation type="unfinished">डिस्कनेक्टेड</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="68"/>
+        <location filename="../components/StatusLine.qml" line="73"/>
         <source>Reconnecting…</source>
         <translation type="unfinished">फिर से कनेक्ट किया जा रहा है…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="72"/>
+        <location filename="../components/StatusLine.qml" line="77"/>
         <source>Connecting…</source>
         <translation type="unfinished">कनेक्ट किया जा रहा है…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error</source>
         <translation type="unfinished">कोर त्रुटि</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing…</source>
         <translation type="unfinished">इंडेक्सिंग…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping…</source>
         <translation type="unfinished">स्क्रैपिंग…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="248"/>
+        <source>%1%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="88"/>
+        <location filename="../components/StatusLine.qml" line="93"/>
         <source>Indexing paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="100"/>
+        <location filename="../components/StatusLine.qml" line="105"/>
         <source>Scraping paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2432,27 +2448,27 @@ Français - Wilfried</source>
         <translation type="obsolete">%1 स्क्रैप किए गए</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexed %1 files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scraped %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="187"/>
+        <location filename="../components/StatusLine.qml" line="192"/>
         <source>Playtime limit in %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -2406,6 +2406,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
+        <location filename="../components/StatusLine.qml" line="271"/>
         <source>%1%</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -462,8 +462,8 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
-        <location filename="../screens/GamesScreen.qml" line="217"/>
+        <location filename="../screens/GamesScreen.qml" line="176"/>
+        <location filename="../screens/GamesScreen.qml" line="238"/>
         <source>%1 games</source>
         <translation type="unfinished"></translation>
     </message>
@@ -473,7 +473,7 @@ Français - Wilfried</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="184"/>
         <source>Loading more…</source>
         <translation>Caricamento altro…</translation>
     </message>
@@ -569,7 +569,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1583"/>
+        <location filename="../screens/HubScreen.qml" line="1591"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Nessun sistema disponibile. Esegui Aggiorna database multimediale dalle Impostazioni.</translation>
     </message>
@@ -675,24 +675,24 @@ Français - Wilfried</source>
         <translation type="vanished">Avvia core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2109"/>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2127"/>
+        <location filename="../app/Main.qml" line="2563"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Remove from favorites</source>
         <translation>Rimuovi dai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Add to favorites</source>
         <translation>Aggiungi ai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2205"/>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Write to NFC token</source>
         <translation>Scrivi sul token NFC</translation>
     </message>
@@ -701,430 +701,441 @@ Français - Wilfried</source>
         <translation type="vanished">Codice QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2195"/>
-        <location filename="../app/Main.qml" line="2246"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Launch game</source>
         <translation>Avvia gioco</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1042"/>
-        <location filename="../app/Main.qml" line="3243"/>
-        <location filename="../app/Main.qml" line="3290"/>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="3281"/>
+        <location filename="../app/Main.qml" line="3328"/>
+        <location filename="../app/Main.qml" line="3338"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3317"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4565"/>
+        <location filename="../app/Main.qml" line="4603"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4572"/>
+        <location filename="../app/Main.qml" line="4610"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4567"/>
+        <location filename="../app/Main.qml" line="4605"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2124"/>
-        <location filename="../app/Main.qml" line="2159"/>
+        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Update media database</source>
         <translation type="unfinished">Aggiorna database multimediale</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2145"/>
+        <location filename="../app/Main.qml" line="2180"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Recupera metadati</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
+        <location filename="../app/Main.qml" line="2136"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1035"/>
+        <location filename="../app/Main.qml" line="1053"/>
         <source>Settings</source>
         <translation type="unfinished">Impostazioni</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2076"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2095"/>
+        <location filename="../app/Main.qml" line="2113"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2199"/>
-        <location filename="../app/Main.qml" line="2250"/>
+        <location filename="../app/Main.qml" line="2217"/>
+        <location filename="../app/Main.qml" line="2271"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2313"/>
+        <location filename="../app/Main.qml" line="2237"/>
+        <location filename="../app/Main.qml" line="2292"/>
+        <location filename="../app/Main.qml" line="2333"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3333"/>
+        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3371"/>
         <source>Default</source>
         <translation type="unfinished">Predefinito</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
+        <location filename="../app/Main.qml" line="2559"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2104"/>
-        <location filename="../app/Main.qml" line="2154"/>
-        <location filename="../app/Main.qml" line="2171"/>
-        <location filename="../app/Main.qml" line="2179"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="3226"/>
+        <location filename="../app/Main.qml" line="2122"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2189"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="3264"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3309"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
+        <location filename="../app/Main.qml" line="3270"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3337"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3375"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3254"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3292"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3341"/>
+        <location filename="../app/Main.qml" line="3379"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3262"/>
+        <location filename="../app/Main.qml" line="3300"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1007"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1027"/>
+        <location filename="../app/Main.qml" line="1045"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1031"/>
+        <location filename="../app/Main.qml" line="1049"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1039"/>
+        <location filename="../app/Main.qml" line="1057"/>
         <source>Quit</source>
         <translation type="unfinished">Esci</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2114"/>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2239"/>
-        <location filename="../app/Main.qml" line="2276"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2241"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2296"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2209"/>
-        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2340"/>
+        <location filename="../app/Main.qml" line="2360"/>
         <source>Move</source>
         <translation type="unfinished">Muovi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2523"/>
+        <location filename="../app/Main.qml" line="2543"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2871"/>
-        <location filename="../app/Main.qml" line="2893"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="2959"/>
+        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="2907"/>
+        <location filename="../app/Main.qml" line="2929"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2995"/>
         <source>OK</source>
         <translation type="unfinished">Va bene</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2917"/>
-        <source>No matching games found.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2926"/>
-        <source>Action failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2927"/>
-        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2929"/>
-        <source>Launch failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start %1. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start this item. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2932"/>
-        <source>Favorite update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2933"/>
-        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2935"/>
-        <source>Media update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2936"/>
-        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2938"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2939"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2941"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2942"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2944"/>
-        <source>Cancel failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2945"/>
-        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2948"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2950"/>
-        <source>Alternate versions unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2951"/>
-        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2953"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2962"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2963"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2965"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2968"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2969"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2971"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2972"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2974"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2975"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2977"/>
+        <source>Scraper list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2978"/>
+        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2980"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2981"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2984"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2986"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2987"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2989"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2954"/>
+        <location filename="../app/Main.qml" line="2990"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2956"/>
+        <location filename="../app/Main.qml" line="2992"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2957"/>
+        <location filename="../app/Main.qml" line="2993"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3096"/>
+        <location filename="../app/Main.qml" line="3133"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3218"/>
+        <location filename="../app/Main.qml" line="3256"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3258"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3296"/>
         <source>Favorites</source>
         <translation type="unfinished">Preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3241"/>
-        <location filename="../app/Main.qml" line="3287"/>
+        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3325"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3275"/>
-        <location filename="../app/Main.qml" line="3297"/>
+        <location filename="../app/Main.qml" line="3313"/>
+        <location filename="../app/Main.qml" line="3335"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3315"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3353"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3311"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3349"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3518"/>
-        <location filename="../app/Main.qml" line="3536"/>
+        <location filename="../app/Main.qml" line="3556"/>
+        <location filename="../app/Main.qml" line="3574"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3522"/>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3560"/>
+        <location filename="../app/Main.qml" line="3577"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2947"/>
-        <location filename="../app/Main.qml" line="3552"/>
+        <location filename="../app/Main.qml" line="2983"/>
+        <location filename="../app/Main.qml" line="3590"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
-        <location filename="../app/Main.qml" line="3144"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Retry</source>
         <translation type="unfinished">Riprova</translation>
     </message>
@@ -1133,22 +1144,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Annulla</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4569"/>
+        <location filename="../app/Main.qml" line="4607"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4574"/>
+        <location filename="../app/Main.qml" line="4612"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4576"/>
+        <location filename="../app/Main.qml" line="4614"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4578"/>
+        <location filename="../app/Main.qml" line="4616"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>
@@ -2358,68 +2369,73 @@ Français - Wilfried</source>
 <context>
     <name>StatusLine</name>
     <message>
-        <location filename="../components/StatusLine.qml" line="66"/>
-        <location filename="../components/StatusLine.qml" line="70"/>
+        <location filename="../components/StatusLine.qml" line="71"/>
+        <location filename="../components/StatusLine.qml" line="75"/>
         <source>Disconnected</source>
         <translation type="unfinished">Disconnesso</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="68"/>
+        <location filename="../components/StatusLine.qml" line="73"/>
         <source>Reconnecting…</source>
         <translation type="unfinished">Riconnessione…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="72"/>
+        <location filename="../components/StatusLine.qml" line="77"/>
         <source>Connecting…</source>
         <translation type="unfinished">Connessione…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error</source>
         <translation type="unfinished">Errore del Core</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing…</source>
         <translation type="unfinished">Indicizzazione…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping…</source>
         <translation type="unfinished">Recupero metadati…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="248"/>
+        <source>%1%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="88"/>
+        <location filename="../components/StatusLine.qml" line="93"/>
         <source>Indexing paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="100"/>
+        <location filename="../components/StatusLine.qml" line="105"/>
         <source>Scraping paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2432,27 +2448,27 @@ Français - Wilfried</source>
         <translation type="obsolete">%1 recuperati</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexed %1 files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scraped %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="187"/>
+        <location filename="../components/StatusLine.qml" line="192"/>
         <source>Playtime limit in %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -2406,6 +2406,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
+        <location filename="../components/StatusLine.qml" line="271"/>
         <source>%1%</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -460,8 +460,8 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
-        <location filename="../screens/GamesScreen.qml" line="217"/>
+        <location filename="../screens/GamesScreen.qml" line="176"/>
+        <location filename="../screens/GamesScreen.qml" line="238"/>
         <source>%1 games</source>
         <translation type="unfinished"></translation>
     </message>
@@ -471,7 +471,7 @@ Français - Wilfried</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="184"/>
         <source>Loading more…</source>
         <translation>さらに読み込み中…</translation>
     </message>
@@ -567,7 +567,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1583"/>
+        <location filename="../screens/HubScreen.qml" line="1591"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>利用可能なシステムがありません。設定からメディアデータベースの更新を実行してください。</translation>
     </message>
@@ -673,24 +673,24 @@ Français - Wilfried</source>
         <translation type="vanished">コアを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2109"/>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2127"/>
+        <location filename="../app/Main.qml" line="2563"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Remove from favorites</source>
         <translation>お気に入りから削除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Add to favorites</source>
         <translation>お気に入りに追加</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2205"/>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Write to NFC token</source>
         <translation>NFC トークンに書き込む</translation>
     </message>
@@ -699,430 +699,441 @@ Français - Wilfried</source>
         <translation type="vanished">QR コード</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2195"/>
-        <location filename="../app/Main.qml" line="2246"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Launch game</source>
         <translation>ゲームを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1042"/>
-        <location filename="../app/Main.qml" line="3243"/>
-        <location filename="../app/Main.qml" line="3290"/>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="3281"/>
+        <location filename="../app/Main.qml" line="3328"/>
+        <location filename="../app/Main.qml" line="3338"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3317"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4565"/>
+        <location filename="../app/Main.qml" line="4603"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4572"/>
+        <location filename="../app/Main.qml" line="4610"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4567"/>
+        <location filename="../app/Main.qml" line="4605"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2124"/>
-        <location filename="../app/Main.qml" line="2159"/>
+        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Update media database</source>
         <translation type="unfinished">メディアデータベースを更新</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2145"/>
+        <location filename="../app/Main.qml" line="2180"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">メタデータをスクレイピング</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
+        <location filename="../app/Main.qml" line="2136"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1035"/>
+        <location filename="../app/Main.qml" line="1053"/>
         <source>Settings</source>
         <translation type="unfinished">設定</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2076"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2095"/>
+        <location filename="../app/Main.qml" line="2113"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2199"/>
-        <location filename="../app/Main.qml" line="2250"/>
+        <location filename="../app/Main.qml" line="2217"/>
+        <location filename="../app/Main.qml" line="2271"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2313"/>
+        <location filename="../app/Main.qml" line="2237"/>
+        <location filename="../app/Main.qml" line="2292"/>
+        <location filename="../app/Main.qml" line="2333"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3333"/>
+        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3371"/>
         <source>Default</source>
         <translation type="unfinished">デフォルト</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
+        <location filename="../app/Main.qml" line="2559"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2104"/>
-        <location filename="../app/Main.qml" line="2154"/>
-        <location filename="../app/Main.qml" line="2171"/>
-        <location filename="../app/Main.qml" line="2179"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="3226"/>
+        <location filename="../app/Main.qml" line="2122"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2189"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="3264"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3309"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
+        <location filename="../app/Main.qml" line="3270"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3337"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3375"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3254"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3292"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3341"/>
+        <location filename="../app/Main.qml" line="3379"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3262"/>
+        <location filename="../app/Main.qml" line="3300"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1007"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1027"/>
+        <location filename="../app/Main.qml" line="1045"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1031"/>
+        <location filename="../app/Main.qml" line="1049"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1039"/>
+        <location filename="../app/Main.qml" line="1057"/>
         <source>Quit</source>
         <translation type="unfinished">終了</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2114"/>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2239"/>
-        <location filename="../app/Main.qml" line="2276"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2241"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2296"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2209"/>
-        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2340"/>
+        <location filename="../app/Main.qml" line="2360"/>
         <source>Move</source>
         <translation type="unfinished">移動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2523"/>
+        <location filename="../app/Main.qml" line="2543"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2871"/>
-        <location filename="../app/Main.qml" line="2893"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="2959"/>
+        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="2907"/>
+        <location filename="../app/Main.qml" line="2929"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2995"/>
         <source>OK</source>
         <translation type="unfinished">決定</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2917"/>
-        <source>No matching games found.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2926"/>
-        <source>Action failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2927"/>
-        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2929"/>
-        <source>Launch failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start %1. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start this item. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2932"/>
-        <source>Favorite update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2933"/>
-        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2935"/>
-        <source>Media update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2936"/>
-        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2938"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2939"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2941"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2942"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2944"/>
-        <source>Cancel failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2945"/>
-        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2948"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2950"/>
-        <source>Alternate versions unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2951"/>
-        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2953"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2962"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2963"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2965"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2968"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2969"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2971"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2972"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2974"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2975"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2977"/>
+        <source>Scraper list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2978"/>
+        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2980"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2981"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2984"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2986"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2987"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2989"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2954"/>
+        <location filename="../app/Main.qml" line="2990"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2956"/>
+        <location filename="../app/Main.qml" line="2992"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2957"/>
+        <location filename="../app/Main.qml" line="2993"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3096"/>
+        <location filename="../app/Main.qml" line="3133"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3218"/>
+        <location filename="../app/Main.qml" line="3256"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3258"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3296"/>
         <source>Favorites</source>
         <translation type="unfinished">お気に入り</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3241"/>
-        <location filename="../app/Main.qml" line="3287"/>
+        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3325"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3275"/>
-        <location filename="../app/Main.qml" line="3297"/>
+        <location filename="../app/Main.qml" line="3313"/>
+        <location filename="../app/Main.qml" line="3335"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3315"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3353"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3311"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3349"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3518"/>
-        <location filename="../app/Main.qml" line="3536"/>
+        <location filename="../app/Main.qml" line="3556"/>
+        <location filename="../app/Main.qml" line="3574"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3522"/>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3560"/>
+        <location filename="../app/Main.qml" line="3577"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2947"/>
-        <location filename="../app/Main.qml" line="3552"/>
+        <location filename="../app/Main.qml" line="2983"/>
+        <location filename="../app/Main.qml" line="3590"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
-        <location filename="../app/Main.qml" line="3144"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Retry</source>
         <translation type="unfinished">再試行</translation>
     </message>
@@ -1131,22 +1142,22 @@ Français - Wilfried</source>
         <translation type="obsolete">キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4569"/>
+        <location filename="../app/Main.qml" line="4607"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4574"/>
+        <location filename="../app/Main.qml" line="4612"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4576"/>
+        <location filename="../app/Main.qml" line="4614"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4578"/>
+        <location filename="../app/Main.qml" line="4616"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>
@@ -2356,68 +2367,73 @@ Français - Wilfried</source>
 <context>
     <name>StatusLine</name>
     <message>
-        <location filename="../components/StatusLine.qml" line="66"/>
-        <location filename="../components/StatusLine.qml" line="70"/>
+        <location filename="../components/StatusLine.qml" line="71"/>
+        <location filename="../components/StatusLine.qml" line="75"/>
         <source>Disconnected</source>
         <translation type="unfinished">切断済み</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="68"/>
+        <location filename="../components/StatusLine.qml" line="73"/>
         <source>Reconnecting…</source>
         <translation type="unfinished">再接続中…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="72"/>
+        <location filename="../components/StatusLine.qml" line="77"/>
         <source>Connecting…</source>
         <translation type="unfinished">接続中…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error</source>
         <translation type="unfinished">Core エラー</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing…</source>
         <translation type="unfinished">インデックス作成中…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping…</source>
         <translation type="unfinished">スクレイピング中…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="248"/>
+        <source>%1%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="88"/>
+        <location filename="../components/StatusLine.qml" line="93"/>
         <source>Indexing paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="100"/>
+        <location filename="../components/StatusLine.qml" line="105"/>
         <source>Scraping paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2430,27 +2446,27 @@ Français - Wilfried</source>
         <translation type="obsolete">%1 件取得済み</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexed %1 files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scraped %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="187"/>
+        <location filename="../components/StatusLine.qml" line="192"/>
         <source>Playtime limit in %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -2404,6 +2404,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
+        <location filename="../components/StatusLine.qml" line="271"/>
         <source>%1%</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -470,13 +470,13 @@ Français - Wilfried</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
-        <location filename="../screens/GamesScreen.qml" line="217"/>
+        <location filename="../screens/GamesScreen.qml" line="176"/>
+        <location filename="../screens/GamesScreen.qml" line="238"/>
         <source>%1 games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="184"/>
         <source>Loading more…</source>
         <translation>더 불러오는 중…</translation>
     </message>
@@ -567,7 +567,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1583"/>
+        <location filename="../screens/HubScreen.qml" line="1591"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>사용 가능한 시스템이 없습니다. 설정에서 미디어 데이터베이스 업데이트를 실행하세요.</translation>
     </message>
@@ -673,81 +673,81 @@ Français - Wilfried</source>
         <translation type="vanished">코어 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2109"/>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2127"/>
+        <location filename="../app/Main.qml" line="2563"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2124"/>
-        <location filename="../app/Main.qml" line="2159"/>
+        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Update media database</source>
         <translation type="unfinished">미디어 데이터베이스 업데이트</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2145"/>
+        <location filename="../app/Main.qml" line="2180"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">메타데이터 수집</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
+        <location filename="../app/Main.qml" line="2136"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1035"/>
+        <location filename="../app/Main.qml" line="1053"/>
         <source>Settings</source>
         <translation type="unfinished">설정</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2076"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2095"/>
+        <location filename="../app/Main.qml" line="2113"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2195"/>
-        <location filename="../app/Main.qml" line="2246"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Launch game</source>
         <translation>게임 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2199"/>
-        <location filename="../app/Main.qml" line="2250"/>
+        <location filename="../app/Main.qml" line="2217"/>
+        <location filename="../app/Main.qml" line="2271"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2313"/>
+        <location filename="../app/Main.qml" line="2237"/>
+        <location filename="../app/Main.qml" line="2292"/>
+        <location filename="../app/Main.qml" line="2333"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Remove from favorites</source>
         <translation>즐겨찾기에서 제거</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Add to favorites</source>
         <translation>즐겨찾기에 추가</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2205"/>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Write to NFC token</source>
         <translation>NFC 토큰에 쓰기</translation>
     </message>
@@ -756,358 +756,369 @@ Français - Wilfried</source>
         <translation type="vanished">QR 코드</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3333"/>
+        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3371"/>
         <source>Default</source>
         <translation type="unfinished">기본값</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
+        <location filename="../app/Main.qml" line="2559"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2104"/>
-        <location filename="../app/Main.qml" line="2154"/>
-        <location filename="../app/Main.qml" line="2171"/>
-        <location filename="../app/Main.qml" line="2179"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="3226"/>
+        <location filename="../app/Main.qml" line="2122"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2189"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="3264"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3258"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3296"/>
         <source>Favorites</source>
         <translation type="unfinished">즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1042"/>
-        <location filename="../app/Main.qml" line="3243"/>
-        <location filename="../app/Main.qml" line="3290"/>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="3281"/>
+        <location filename="../app/Main.qml" line="3328"/>
+        <location filename="../app/Main.qml" line="3338"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3309"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
+        <location filename="../app/Main.qml" line="3270"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3337"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3375"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3254"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3292"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3341"/>
+        <location filename="../app/Main.qml" line="3379"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3262"/>
+        <location filename="../app/Main.qml" line="3300"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1007"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1027"/>
+        <location filename="../app/Main.qml" line="1045"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1031"/>
+        <location filename="../app/Main.qml" line="1049"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1039"/>
+        <location filename="../app/Main.qml" line="1057"/>
         <source>Quit</source>
         <translation type="unfinished">종료</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2114"/>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2239"/>
-        <location filename="../app/Main.qml" line="2276"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2241"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2296"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2209"/>
-        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2340"/>
+        <location filename="../app/Main.qml" line="2360"/>
         <source>Move</source>
         <translation type="unfinished">이동</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2523"/>
+        <location filename="../app/Main.qml" line="2543"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2871"/>
-        <location filename="../app/Main.qml" line="2893"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="2959"/>
+        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="2907"/>
+        <location filename="../app/Main.qml" line="2929"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2995"/>
         <source>OK</source>
         <translation type="unfinished">확인</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2917"/>
-        <source>No matching games found.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2926"/>
-        <source>Action failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2927"/>
-        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2929"/>
-        <source>Launch failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start %1. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start this item. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2932"/>
-        <source>Favorite update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2933"/>
-        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2935"/>
-        <source>Media update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2936"/>
-        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2938"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2939"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2941"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2942"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2944"/>
-        <source>Cancel failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2945"/>
-        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2948"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2950"/>
-        <source>Alternate versions unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2951"/>
-        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2953"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2962"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2963"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2965"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2968"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2969"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2971"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2972"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2974"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2975"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2977"/>
+        <source>Scraper list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2978"/>
+        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2980"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2981"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2984"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2986"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2987"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2989"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2954"/>
+        <location filename="../app/Main.qml" line="2990"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2956"/>
+        <location filename="../app/Main.qml" line="2992"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2957"/>
+        <location filename="../app/Main.qml" line="2993"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3096"/>
+        <location filename="../app/Main.qml" line="3133"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3218"/>
+        <location filename="../app/Main.qml" line="3256"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3241"/>
-        <location filename="../app/Main.qml" line="3287"/>
+        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3325"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3275"/>
-        <location filename="../app/Main.qml" line="3297"/>
+        <location filename="../app/Main.qml" line="3313"/>
+        <location filename="../app/Main.qml" line="3335"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3317"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3315"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3353"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3311"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3349"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3518"/>
-        <location filename="../app/Main.qml" line="3536"/>
+        <location filename="../app/Main.qml" line="3556"/>
+        <location filename="../app/Main.qml" line="3574"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3522"/>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3560"/>
+        <location filename="../app/Main.qml" line="3577"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2947"/>
-        <location filename="../app/Main.qml" line="3552"/>
+        <location filename="../app/Main.qml" line="2983"/>
+        <location filename="../app/Main.qml" line="3590"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
-        <location filename="../app/Main.qml" line="3144"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Retry</source>
         <translation type="unfinished">다시 시도</translation>
     </message>
@@ -1116,37 +1127,37 @@ Français - Wilfried</source>
         <translation type="obsolete">취소</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4565"/>
+        <location filename="../app/Main.qml" line="4603"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4567"/>
+        <location filename="../app/Main.qml" line="4605"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4569"/>
+        <location filename="../app/Main.qml" line="4607"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4572"/>
+        <location filename="../app/Main.qml" line="4610"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4574"/>
+        <location filename="../app/Main.qml" line="4612"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4576"/>
+        <location filename="../app/Main.qml" line="4614"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4578"/>
+        <location filename="../app/Main.qml" line="4616"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>
@@ -2356,68 +2367,73 @@ Français - Wilfried</source>
 <context>
     <name>StatusLine</name>
     <message>
-        <location filename="../components/StatusLine.qml" line="66"/>
-        <location filename="../components/StatusLine.qml" line="70"/>
+        <location filename="../components/StatusLine.qml" line="71"/>
+        <location filename="../components/StatusLine.qml" line="75"/>
         <source>Disconnected</source>
         <translation type="unfinished">연결 끊김</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="68"/>
+        <location filename="../components/StatusLine.qml" line="73"/>
         <source>Reconnecting…</source>
         <translation type="unfinished">재연결 중…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="72"/>
+        <location filename="../components/StatusLine.qml" line="77"/>
         <source>Connecting…</source>
         <translation type="unfinished">연결 중…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error</source>
         <translation type="unfinished">코어 오류</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing…</source>
         <translation type="unfinished">인덱싱 중…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping…</source>
         <translation type="unfinished">메타데이터 수집 중…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="248"/>
+        <source>%1%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="88"/>
+        <location filename="../components/StatusLine.qml" line="93"/>
         <source>Indexing paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="100"/>
+        <location filename="../components/StatusLine.qml" line="105"/>
         <source>Scraping paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2430,27 +2446,27 @@ Français - Wilfried</source>
         <translation type="obsolete">%1개 수집됨</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexed %1 files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scraped %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="187"/>
+        <location filename="../components/StatusLine.qml" line="192"/>
         <source>Playtime limit in %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -2404,6 +2404,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
+        <location filename="../components/StatusLine.qml" line="271"/>
         <source>%1%</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -462,8 +462,8 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
-        <location filename="../screens/GamesScreen.qml" line="217"/>
+        <location filename="../screens/GamesScreen.qml" line="176"/>
+        <location filename="../screens/GamesScreen.qml" line="238"/>
         <source>%1 games</source>
         <translation type="unfinished"></translation>
     </message>
@@ -473,7 +473,7 @@ Français - Wilfried</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="184"/>
         <source>Loading more…</source>
         <translation>Meer laden…</translation>
     </message>
@@ -569,7 +569,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1583"/>
+        <location filename="../screens/HubScreen.qml" line="1591"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Geen systemen beschikbaar. Voer Database bijwerken uit via Instellingen.</translation>
     </message>
@@ -675,24 +675,24 @@ Français - Wilfried</source>
         <translation type="vanished">Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2109"/>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2127"/>
+        <location filename="../app/Main.qml" line="2563"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Remove from favorites</source>
         <translation>Uit favorieten verwijderen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Add to favorites</source>
         <translation>Aan favorieten toevoegen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2205"/>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Write to NFC token</source>
         <translation>Naar NFC-token schrijven</translation>
     </message>
@@ -701,430 +701,441 @@ Français - Wilfried</source>
         <translation type="vanished">QR-code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2195"/>
-        <location filename="../app/Main.qml" line="2246"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Launch game</source>
         <translation>Game starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1042"/>
-        <location filename="../app/Main.qml" line="3243"/>
-        <location filename="../app/Main.qml" line="3290"/>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="3281"/>
+        <location filename="../app/Main.qml" line="3328"/>
+        <location filename="../app/Main.qml" line="3338"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3317"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4565"/>
+        <location filename="../app/Main.qml" line="4603"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4572"/>
+        <location filename="../app/Main.qml" line="4610"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4567"/>
+        <location filename="../app/Main.qml" line="4605"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2124"/>
-        <location filename="../app/Main.qml" line="2159"/>
+        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediadatabase bijwerken</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2145"/>
+        <location filename="../app/Main.qml" line="2180"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadata ophalen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
+        <location filename="../app/Main.qml" line="2136"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1035"/>
+        <location filename="../app/Main.qml" line="1053"/>
         <source>Settings</source>
         <translation type="unfinished">Instellingen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2076"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2095"/>
+        <location filename="../app/Main.qml" line="2113"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2199"/>
-        <location filename="../app/Main.qml" line="2250"/>
+        <location filename="../app/Main.qml" line="2217"/>
+        <location filename="../app/Main.qml" line="2271"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2313"/>
+        <location filename="../app/Main.qml" line="2237"/>
+        <location filename="../app/Main.qml" line="2292"/>
+        <location filename="../app/Main.qml" line="2333"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3333"/>
+        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3371"/>
         <source>Default</source>
         <translation type="unfinished">Standaard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
+        <location filename="../app/Main.qml" line="2559"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2104"/>
-        <location filename="../app/Main.qml" line="2154"/>
-        <location filename="../app/Main.qml" line="2171"/>
-        <location filename="../app/Main.qml" line="2179"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="3226"/>
+        <location filename="../app/Main.qml" line="2122"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2189"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="3264"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3309"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
+        <location filename="../app/Main.qml" line="3270"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3337"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3375"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3254"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3292"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3341"/>
+        <location filename="../app/Main.qml" line="3379"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3262"/>
+        <location filename="../app/Main.qml" line="3300"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1007"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1027"/>
+        <location filename="../app/Main.qml" line="1045"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1031"/>
+        <location filename="../app/Main.qml" line="1049"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1039"/>
+        <location filename="../app/Main.qml" line="1057"/>
         <source>Quit</source>
         <translation type="unfinished">Afsluiten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2114"/>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2239"/>
-        <location filename="../app/Main.qml" line="2276"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2241"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2296"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2209"/>
-        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2340"/>
+        <location filename="../app/Main.qml" line="2360"/>
         <source>Move</source>
         <translation type="unfinished">Bewegen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2523"/>
+        <location filename="../app/Main.qml" line="2543"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2871"/>
-        <location filename="../app/Main.qml" line="2893"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="2959"/>
+        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="2907"/>
+        <location filename="../app/Main.qml" line="2929"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2995"/>
         <source>OK</source>
         <translation type="unfinished">Akkoord</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2917"/>
-        <source>No matching games found.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2926"/>
-        <source>Action failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2927"/>
-        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2929"/>
-        <source>Launch failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start %1. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start this item. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2932"/>
-        <source>Favorite update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2933"/>
-        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2935"/>
-        <source>Media update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2936"/>
-        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2938"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2939"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2941"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2942"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2944"/>
-        <source>Cancel failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2945"/>
-        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2948"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2950"/>
-        <source>Alternate versions unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2951"/>
-        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2953"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2962"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2963"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2965"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2968"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2969"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2971"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2972"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2974"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2975"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2977"/>
+        <source>Scraper list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2978"/>
+        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2980"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2981"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2984"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2986"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2987"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2989"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2954"/>
+        <location filename="../app/Main.qml" line="2990"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2956"/>
+        <location filename="../app/Main.qml" line="2992"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2957"/>
+        <location filename="../app/Main.qml" line="2993"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3096"/>
+        <location filename="../app/Main.qml" line="3133"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3218"/>
+        <location filename="../app/Main.qml" line="3256"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3258"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3296"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorieten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3241"/>
-        <location filename="../app/Main.qml" line="3287"/>
+        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3325"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3275"/>
-        <location filename="../app/Main.qml" line="3297"/>
+        <location filename="../app/Main.qml" line="3313"/>
+        <location filename="../app/Main.qml" line="3335"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3315"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3353"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3311"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3349"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3518"/>
-        <location filename="../app/Main.qml" line="3536"/>
+        <location filename="../app/Main.qml" line="3556"/>
+        <location filename="../app/Main.qml" line="3574"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3522"/>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3560"/>
+        <location filename="../app/Main.qml" line="3577"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2947"/>
-        <location filename="../app/Main.qml" line="3552"/>
+        <location filename="../app/Main.qml" line="2983"/>
+        <location filename="../app/Main.qml" line="3590"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
-        <location filename="../app/Main.qml" line="3144"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Retry</source>
         <translation type="unfinished">Opnieuw proberen</translation>
     </message>
@@ -1133,22 +1144,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4569"/>
+        <location filename="../app/Main.qml" line="4607"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4574"/>
+        <location filename="../app/Main.qml" line="4612"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4576"/>
+        <location filename="../app/Main.qml" line="4614"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4578"/>
+        <location filename="../app/Main.qml" line="4616"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>
@@ -2358,68 +2369,73 @@ Français - Wilfried</source>
 <context>
     <name>StatusLine</name>
     <message>
-        <location filename="../components/StatusLine.qml" line="66"/>
-        <location filename="../components/StatusLine.qml" line="70"/>
+        <location filename="../components/StatusLine.qml" line="71"/>
+        <location filename="../components/StatusLine.qml" line="75"/>
         <source>Disconnected</source>
         <translation type="unfinished">Verbroken</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="68"/>
+        <location filename="../components/StatusLine.qml" line="73"/>
         <source>Reconnecting…</source>
         <translation type="unfinished">Opnieuw verbinden…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="72"/>
+        <location filename="../components/StatusLine.qml" line="77"/>
         <source>Connecting…</source>
         <translation type="unfinished">Verbinden…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error</source>
         <translation type="unfinished">Core-fout</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing…</source>
         <translation type="unfinished">Indexering…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping…</source>
         <translation type="unfinished">Bezig met scrapen…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="248"/>
+        <source>%1%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="88"/>
+        <location filename="../components/StatusLine.qml" line="93"/>
         <source>Indexing paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="100"/>
+        <location filename="../components/StatusLine.qml" line="105"/>
         <source>Scraping paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2432,27 +2448,27 @@ Français - Wilfried</source>
         <translation type="obsolete">%1 opgehaald</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexed %1 files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scraped %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="187"/>
+        <location filename="../components/StatusLine.qml" line="192"/>
         <source>Playtime limit in %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -2406,6 +2406,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
+        <location filename="../components/StatusLine.qml" line="271"/>
         <source>%1%</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -2408,6 +2408,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
+        <location filename="../components/StatusLine.qml" line="271"/>
         <source>%1%</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -464,8 +464,8 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
-        <location filename="../screens/GamesScreen.qml" line="217"/>
+        <location filename="../screens/GamesScreen.qml" line="176"/>
+        <location filename="../screens/GamesScreen.qml" line="238"/>
         <source>%1 games</source>
         <translation type="unfinished"></translation>
     </message>
@@ -475,7 +475,7 @@ Français - Wilfried</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="184"/>
         <source>Loading more…</source>
         <translation>Se încarcă mai multe…</translation>
     </message>
@@ -571,7 +571,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1583"/>
+        <location filename="../screens/HubScreen.qml" line="1591"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Niciun sistem disponibil. Rulați Actualizare bază de date din Setări.</translation>
     </message>
@@ -677,24 +677,24 @@ Français - Wilfried</source>
         <translation type="vanished">Lansare core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2109"/>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2127"/>
+        <location filename="../app/Main.qml" line="2563"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Remove from favorites</source>
         <translation>Elimină din favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Add to favorites</source>
         <translation>Adaugă la favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2205"/>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Write to NFC token</source>
         <translation>Scriere pe token NFC</translation>
     </message>
@@ -703,430 +703,441 @@ Français - Wilfried</source>
         <translation type="vanished">Cod QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2195"/>
-        <location filename="../app/Main.qml" line="2246"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Launch game</source>
         <translation>Lansare joc</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1042"/>
-        <location filename="../app/Main.qml" line="3243"/>
-        <location filename="../app/Main.qml" line="3290"/>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="3281"/>
+        <location filename="../app/Main.qml" line="3328"/>
+        <location filename="../app/Main.qml" line="3338"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3317"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4565"/>
+        <location filename="../app/Main.qml" line="4603"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4572"/>
+        <location filename="../app/Main.qml" line="4610"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4567"/>
+        <location filename="../app/Main.qml" line="4605"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2124"/>
-        <location filename="../app/Main.qml" line="2159"/>
+        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizare bază de date media</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2145"/>
+        <location filename="../app/Main.qml" line="2180"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extragere metadate</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
+        <location filename="../app/Main.qml" line="2136"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1035"/>
+        <location filename="../app/Main.qml" line="1053"/>
         <source>Settings</source>
         <translation type="unfinished">Setări</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2076"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2095"/>
+        <location filename="../app/Main.qml" line="2113"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2199"/>
-        <location filename="../app/Main.qml" line="2250"/>
+        <location filename="../app/Main.qml" line="2217"/>
+        <location filename="../app/Main.qml" line="2271"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2313"/>
+        <location filename="../app/Main.qml" line="2237"/>
+        <location filename="../app/Main.qml" line="2292"/>
+        <location filename="../app/Main.qml" line="2333"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3333"/>
+        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3371"/>
         <source>Default</source>
         <translation type="unfinished">Implicit</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
+        <location filename="../app/Main.qml" line="2559"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2104"/>
-        <location filename="../app/Main.qml" line="2154"/>
-        <location filename="../app/Main.qml" line="2171"/>
-        <location filename="../app/Main.qml" line="2179"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="3226"/>
+        <location filename="../app/Main.qml" line="2122"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2189"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="3264"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3309"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
+        <location filename="../app/Main.qml" line="3270"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3337"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3375"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3254"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3292"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3341"/>
+        <location filename="../app/Main.qml" line="3379"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3262"/>
+        <location filename="../app/Main.qml" line="3300"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1007"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1027"/>
+        <location filename="../app/Main.qml" line="1045"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1031"/>
+        <location filename="../app/Main.qml" line="1049"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1039"/>
+        <location filename="../app/Main.qml" line="1057"/>
         <source>Quit</source>
         <translation type="unfinished">Ieșire</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2114"/>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2239"/>
-        <location filename="../app/Main.qml" line="2276"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2241"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2296"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2209"/>
-        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2340"/>
+        <location filename="../app/Main.qml" line="2360"/>
         <source>Move</source>
         <translation type="unfinished">Mutare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2523"/>
+        <location filename="../app/Main.qml" line="2543"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2871"/>
-        <location filename="../app/Main.qml" line="2893"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="2959"/>
+        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="2907"/>
+        <location filename="../app/Main.qml" line="2929"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2995"/>
         <source>OK</source>
         <translation type="unfinished">În regulă</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2917"/>
-        <source>No matching games found.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2926"/>
-        <source>Action failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2927"/>
-        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2929"/>
-        <source>Launch failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start %1. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start this item. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2932"/>
-        <source>Favorite update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2933"/>
-        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2935"/>
-        <source>Media update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2936"/>
-        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2938"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2939"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2941"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2942"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2944"/>
-        <source>Cancel failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2945"/>
-        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2948"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2950"/>
-        <source>Alternate versions unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2951"/>
-        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2953"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2962"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2963"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2965"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2968"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2969"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2971"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2972"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2974"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2975"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2977"/>
+        <source>Scraper list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2978"/>
+        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2980"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2981"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2984"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2986"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2987"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2989"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2954"/>
+        <location filename="../app/Main.qml" line="2990"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2956"/>
+        <location filename="../app/Main.qml" line="2992"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2957"/>
+        <location filename="../app/Main.qml" line="2993"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3096"/>
+        <location filename="../app/Main.qml" line="3133"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3218"/>
+        <location filename="../app/Main.qml" line="3256"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3258"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3296"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3241"/>
-        <location filename="../app/Main.qml" line="3287"/>
+        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3325"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3275"/>
-        <location filename="../app/Main.qml" line="3297"/>
+        <location filename="../app/Main.qml" line="3313"/>
+        <location filename="../app/Main.qml" line="3335"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3315"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3353"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3311"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3349"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3518"/>
-        <location filename="../app/Main.qml" line="3536"/>
+        <location filename="../app/Main.qml" line="3556"/>
+        <location filename="../app/Main.qml" line="3574"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3522"/>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3560"/>
+        <location filename="../app/Main.qml" line="3577"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2947"/>
-        <location filename="../app/Main.qml" line="3552"/>
+        <location filename="../app/Main.qml" line="2983"/>
+        <location filename="../app/Main.qml" line="3590"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
-        <location filename="../app/Main.qml" line="3144"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Retry</source>
         <translation type="unfinished">Reîncercare</translation>
     </message>
@@ -1135,22 +1146,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Anulare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4569"/>
+        <location filename="../app/Main.qml" line="4607"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4574"/>
+        <location filename="../app/Main.qml" line="4612"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4576"/>
+        <location filename="../app/Main.qml" line="4614"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4578"/>
+        <location filename="../app/Main.qml" line="4616"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>
@@ -2360,68 +2371,73 @@ Français - Wilfried</source>
 <context>
     <name>StatusLine</name>
     <message>
-        <location filename="../components/StatusLine.qml" line="66"/>
-        <location filename="../components/StatusLine.qml" line="70"/>
+        <location filename="../components/StatusLine.qml" line="71"/>
+        <location filename="../components/StatusLine.qml" line="75"/>
         <source>Disconnected</source>
         <translation type="unfinished">Deconectat</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="68"/>
+        <location filename="../components/StatusLine.qml" line="73"/>
         <source>Reconnecting…</source>
         <translation type="unfinished">Reconectare…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="72"/>
+        <location filename="../components/StatusLine.qml" line="77"/>
         <source>Connecting…</source>
         <translation type="unfinished">Conectare…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error</source>
         <translation type="unfinished">Eroare Core</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing…</source>
         <translation type="unfinished">Indexare…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping…</source>
         <translation type="unfinished">Se preiau datele…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="248"/>
+        <source>%1%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="88"/>
+        <location filename="../components/StatusLine.qml" line="93"/>
         <source>Indexing paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="100"/>
+        <location filename="../components/StatusLine.qml" line="105"/>
         <source>Scraping paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2434,27 +2450,27 @@ Français - Wilfried</source>
         <translation type="obsolete">%1 extrase</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexed %1 files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scraped %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="187"/>
+        <location filename="../components/StatusLine.qml" line="192"/>
         <source>Playtime limit in %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -464,8 +464,8 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
-        <location filename="../screens/GamesScreen.qml" line="217"/>
+        <location filename="../screens/GamesScreen.qml" line="176"/>
+        <location filename="../screens/GamesScreen.qml" line="238"/>
         <source>%1 games</source>
         <translation type="unfinished"></translation>
     </message>
@@ -475,7 +475,7 @@ Français - Wilfried</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="184"/>
         <source>Loading more…</source>
         <translation>Načítava sa viac…</translation>
     </message>
@@ -571,7 +571,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1583"/>
+        <location filename="../screens/HubScreen.qml" line="1591"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Žiadne systémy nie sú dostupné. Spustite Aktualizovať databázu médií v Nastaveniach.</translation>
     </message>
@@ -677,24 +677,24 @@ Français - Wilfried</source>
         <translation type="vanished">Spustiť core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2109"/>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2127"/>
+        <location filename="../app/Main.qml" line="2563"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Remove from favorites</source>
         <translation>Odstrániť z obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Add to favorites</source>
         <translation>Pridať do obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2205"/>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Write to NFC token</source>
         <translation>Zapísať na NFC token</translation>
     </message>
@@ -703,430 +703,441 @@ Français - Wilfried</source>
         <translation type="vanished">QR kód</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2195"/>
-        <location filename="../app/Main.qml" line="2246"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Launch game</source>
         <translation>Spustiť hru</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1042"/>
-        <location filename="../app/Main.qml" line="3243"/>
-        <location filename="../app/Main.qml" line="3290"/>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="3281"/>
+        <location filename="../app/Main.qml" line="3328"/>
+        <location filename="../app/Main.qml" line="3338"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3317"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4565"/>
+        <location filename="../app/Main.qml" line="4603"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4572"/>
+        <location filename="../app/Main.qml" line="4610"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4567"/>
+        <location filename="../app/Main.qml" line="4605"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2124"/>
-        <location filename="../app/Main.qml" line="2159"/>
+        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Update media database</source>
         <translation type="unfinished">Aktualizovať databázu médií</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2145"/>
+        <location filename="../app/Main.qml" line="2180"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Získať metadáta</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
+        <location filename="../app/Main.qml" line="2136"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1035"/>
+        <location filename="../app/Main.qml" line="1053"/>
         <source>Settings</source>
         <translation type="unfinished">Nastavenia</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2076"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2095"/>
+        <location filename="../app/Main.qml" line="2113"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2199"/>
-        <location filename="../app/Main.qml" line="2250"/>
+        <location filename="../app/Main.qml" line="2217"/>
+        <location filename="../app/Main.qml" line="2271"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2313"/>
+        <location filename="../app/Main.qml" line="2237"/>
+        <location filename="../app/Main.qml" line="2292"/>
+        <location filename="../app/Main.qml" line="2333"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3333"/>
+        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3371"/>
         <source>Default</source>
         <translation type="unfinished">Predvolené</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
+        <location filename="../app/Main.qml" line="2559"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2104"/>
-        <location filename="../app/Main.qml" line="2154"/>
-        <location filename="../app/Main.qml" line="2171"/>
-        <location filename="../app/Main.qml" line="2179"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="3226"/>
+        <location filename="../app/Main.qml" line="2122"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2189"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="3264"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3309"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
+        <location filename="../app/Main.qml" line="3270"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3337"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3375"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3254"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3292"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3341"/>
+        <location filename="../app/Main.qml" line="3379"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3262"/>
+        <location filename="../app/Main.qml" line="3300"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1007"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1027"/>
+        <location filename="../app/Main.qml" line="1045"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1031"/>
+        <location filename="../app/Main.qml" line="1049"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1039"/>
+        <location filename="../app/Main.qml" line="1057"/>
         <source>Quit</source>
         <translation type="unfinished">Ukončiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2114"/>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2239"/>
-        <location filename="../app/Main.qml" line="2276"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2241"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2296"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2209"/>
-        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2340"/>
+        <location filename="../app/Main.qml" line="2360"/>
         <source>Move</source>
         <translation type="unfinished">Presunúť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2523"/>
+        <location filename="../app/Main.qml" line="2543"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2871"/>
-        <location filename="../app/Main.qml" line="2893"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="2959"/>
+        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="2907"/>
+        <location filename="../app/Main.qml" line="2929"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2995"/>
         <source>OK</source>
         <translation type="unfinished">V poriadku</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2917"/>
-        <source>No matching games found.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2926"/>
-        <source>Action failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2927"/>
-        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2929"/>
-        <source>Launch failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start %1. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start this item. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2932"/>
-        <source>Favorite update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2933"/>
-        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2935"/>
-        <source>Media update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2936"/>
-        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2938"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2939"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2941"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2942"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2944"/>
-        <source>Cancel failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2945"/>
-        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2948"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2950"/>
-        <source>Alternate versions unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2951"/>
-        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2953"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2962"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2963"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2965"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2968"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2969"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2971"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2972"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2974"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2975"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2977"/>
+        <source>Scraper list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2978"/>
+        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2980"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2981"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2984"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2986"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2987"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2989"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2954"/>
+        <location filename="../app/Main.qml" line="2990"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2956"/>
+        <location filename="../app/Main.qml" line="2992"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2957"/>
+        <location filename="../app/Main.qml" line="2993"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3096"/>
+        <location filename="../app/Main.qml" line="3133"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3218"/>
+        <location filename="../app/Main.qml" line="3256"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3258"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3296"/>
         <source>Favorites</source>
         <translation type="unfinished">Obľúbené</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3241"/>
-        <location filename="../app/Main.qml" line="3287"/>
+        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3325"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3275"/>
-        <location filename="../app/Main.qml" line="3297"/>
+        <location filename="../app/Main.qml" line="3313"/>
+        <location filename="../app/Main.qml" line="3335"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3315"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3353"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3311"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3349"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3518"/>
-        <location filename="../app/Main.qml" line="3536"/>
+        <location filename="../app/Main.qml" line="3556"/>
+        <location filename="../app/Main.qml" line="3574"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3522"/>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3560"/>
+        <location filename="../app/Main.qml" line="3577"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2947"/>
-        <location filename="../app/Main.qml" line="3552"/>
+        <location filename="../app/Main.qml" line="2983"/>
+        <location filename="../app/Main.qml" line="3590"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
-        <location filename="../app/Main.qml" line="3144"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Retry</source>
         <translation type="unfinished">Skúsiť znova</translation>
     </message>
@@ -1135,22 +1146,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4569"/>
+        <location filename="../app/Main.qml" line="4607"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4574"/>
+        <location filename="../app/Main.qml" line="4612"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4576"/>
+        <location filename="../app/Main.qml" line="4614"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4578"/>
+        <location filename="../app/Main.qml" line="4616"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>
@@ -2360,68 +2371,73 @@ Français - Wilfried</source>
 <context>
     <name>StatusLine</name>
     <message>
-        <location filename="../components/StatusLine.qml" line="66"/>
-        <location filename="../components/StatusLine.qml" line="70"/>
+        <location filename="../components/StatusLine.qml" line="71"/>
+        <location filename="../components/StatusLine.qml" line="75"/>
         <source>Disconnected</source>
         <translation type="unfinished">Odpojené</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="68"/>
+        <location filename="../components/StatusLine.qml" line="73"/>
         <source>Reconnecting…</source>
         <translation type="unfinished">Opätovné pripojenie…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="72"/>
+        <location filename="../components/StatusLine.qml" line="77"/>
         <source>Connecting…</source>
         <translation type="unfinished">Pripájanie…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error</source>
         <translation type="unfinished">Chyba Core</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing…</source>
         <translation type="unfinished">Indexovanie…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping…</source>
         <translation type="unfinished">Prebieha sťahovanie…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="248"/>
+        <source>%1%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="88"/>
+        <location filename="../components/StatusLine.qml" line="93"/>
         <source>Indexing paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="100"/>
+        <location filename="../components/StatusLine.qml" line="105"/>
         <source>Scraping paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2434,27 +2450,27 @@ Français - Wilfried</source>
         <translation type="obsolete">%1 zozbieraných</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexed %1 files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scraped %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="187"/>
+        <location filename="../components/StatusLine.qml" line="192"/>
         <source>Playtime limit in %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -2408,6 +2408,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
+        <location filename="../components/StatusLine.qml" line="271"/>
         <source>%1%</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -464,8 +464,8 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
-        <location filename="../screens/GamesScreen.qml" line="217"/>
+        <location filename="../screens/GamesScreen.qml" line="176"/>
+        <location filename="../screens/GamesScreen.qml" line="238"/>
         <source>%1 games</source>
         <translation type="unfinished"></translation>
     </message>
@@ -475,7 +475,7 @@ Français - Wilfried</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="184"/>
         <source>Loading more…</source>
         <translation>Завантаження ще…</translation>
     </message>
@@ -571,7 +571,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1583"/>
+        <location filename="../screens/HubScreen.qml" line="1591"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Немає доступних систем. Запустіть Оновлення бази даних з Налаштувань.</translation>
     </message>
@@ -677,24 +677,24 @@ Français - Wilfried</source>
         <translation type="vanished">Запустити core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2109"/>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2127"/>
+        <location filename="../app/Main.qml" line="2563"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Remove from favorites</source>
         <translation>Видалити з вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Add to favorites</source>
         <translation>Додати до вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2205"/>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Write to NFC token</source>
         <translation>Записати на NFC-токен</translation>
     </message>
@@ -703,430 +703,441 @@ Français - Wilfried</source>
         <translation type="vanished">QR-код</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2195"/>
-        <location filename="../app/Main.qml" line="2246"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Launch game</source>
         <translation>Запустити гру</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1042"/>
-        <location filename="../app/Main.qml" line="3243"/>
-        <location filename="../app/Main.qml" line="3290"/>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="3281"/>
+        <location filename="../app/Main.qml" line="3328"/>
+        <location filename="../app/Main.qml" line="3338"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3317"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4565"/>
+        <location filename="../app/Main.qml" line="4603"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4572"/>
+        <location filename="../app/Main.qml" line="4610"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4567"/>
+        <location filename="../app/Main.qml" line="4605"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2124"/>
-        <location filename="../app/Main.qml" line="2159"/>
+        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Update media database</source>
         <translation type="unfinished">Оновити базу медіа</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2145"/>
+        <location filename="../app/Main.qml" line="2180"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Отримати метадані</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
+        <location filename="../app/Main.qml" line="2136"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1035"/>
+        <location filename="../app/Main.qml" line="1053"/>
         <source>Settings</source>
         <translation type="unfinished">Налаштування</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2076"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2095"/>
+        <location filename="../app/Main.qml" line="2113"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2199"/>
-        <location filename="../app/Main.qml" line="2250"/>
+        <location filename="../app/Main.qml" line="2217"/>
+        <location filename="../app/Main.qml" line="2271"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2313"/>
+        <location filename="../app/Main.qml" line="2237"/>
+        <location filename="../app/Main.qml" line="2292"/>
+        <location filename="../app/Main.qml" line="2333"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3333"/>
+        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3371"/>
         <source>Default</source>
         <translation type="unfinished">Типовий</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
+        <location filename="../app/Main.qml" line="2559"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2104"/>
-        <location filename="../app/Main.qml" line="2154"/>
-        <location filename="../app/Main.qml" line="2171"/>
-        <location filename="../app/Main.qml" line="2179"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="3226"/>
+        <location filename="../app/Main.qml" line="2122"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2189"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="3264"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3309"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
+        <location filename="../app/Main.qml" line="3270"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3337"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3375"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3254"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3292"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3341"/>
+        <location filename="../app/Main.qml" line="3379"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3262"/>
+        <location filename="../app/Main.qml" line="3300"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1007"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1027"/>
+        <location filename="../app/Main.qml" line="1045"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1031"/>
+        <location filename="../app/Main.qml" line="1049"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1039"/>
+        <location filename="../app/Main.qml" line="1057"/>
         <source>Quit</source>
         <translation type="unfinished">Вийти</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2114"/>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2239"/>
-        <location filename="../app/Main.qml" line="2276"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2241"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2296"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2209"/>
-        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2340"/>
+        <location filename="../app/Main.qml" line="2360"/>
         <source>Move</source>
         <translation type="unfinished">Переміщення</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2523"/>
+        <location filename="../app/Main.qml" line="2543"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2871"/>
-        <location filename="../app/Main.qml" line="2893"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="2959"/>
+        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="2907"/>
+        <location filename="../app/Main.qml" line="2929"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2995"/>
         <source>OK</source>
         <translation type="unfinished">Гаразд</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2917"/>
-        <source>No matching games found.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2926"/>
-        <source>Action failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2927"/>
-        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2929"/>
-        <source>Launch failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start %1. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start this item. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2932"/>
-        <source>Favorite update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2933"/>
-        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2935"/>
-        <source>Media update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2936"/>
-        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2938"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2939"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2941"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2942"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2944"/>
-        <source>Cancel failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2945"/>
-        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2948"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2950"/>
-        <source>Alternate versions unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2951"/>
-        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2953"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2962"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2963"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2965"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2968"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2969"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2971"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2972"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2974"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2975"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2977"/>
+        <source>Scraper list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2978"/>
+        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2980"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2981"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2984"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2986"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2987"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2989"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2954"/>
+        <location filename="../app/Main.qml" line="2990"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2956"/>
+        <location filename="../app/Main.qml" line="2992"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2957"/>
+        <location filename="../app/Main.qml" line="2993"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3096"/>
+        <location filename="../app/Main.qml" line="3133"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3218"/>
+        <location filename="../app/Main.qml" line="3256"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3258"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3296"/>
         <source>Favorites</source>
         <translation type="unfinished">Вибране</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3241"/>
-        <location filename="../app/Main.qml" line="3287"/>
+        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3325"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3275"/>
-        <location filename="../app/Main.qml" line="3297"/>
+        <location filename="../app/Main.qml" line="3313"/>
+        <location filename="../app/Main.qml" line="3335"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3315"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3353"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3311"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3349"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3518"/>
-        <location filename="../app/Main.qml" line="3536"/>
+        <location filename="../app/Main.qml" line="3556"/>
+        <location filename="../app/Main.qml" line="3574"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3522"/>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3560"/>
+        <location filename="../app/Main.qml" line="3577"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2947"/>
-        <location filename="../app/Main.qml" line="3552"/>
+        <location filename="../app/Main.qml" line="2983"/>
+        <location filename="../app/Main.qml" line="3590"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
-        <location filename="../app/Main.qml" line="3144"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Retry</source>
         <translation type="unfinished">Повторити</translation>
     </message>
@@ -1135,22 +1146,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4569"/>
+        <location filename="../app/Main.qml" line="4607"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4574"/>
+        <location filename="../app/Main.qml" line="4612"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4576"/>
+        <location filename="../app/Main.qml" line="4614"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4578"/>
+        <location filename="../app/Main.qml" line="4616"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>
@@ -2360,68 +2371,73 @@ Français - Wilfried</source>
 <context>
     <name>StatusLine</name>
     <message>
-        <location filename="../components/StatusLine.qml" line="66"/>
-        <location filename="../components/StatusLine.qml" line="70"/>
+        <location filename="../components/StatusLine.qml" line="71"/>
+        <location filename="../components/StatusLine.qml" line="75"/>
         <source>Disconnected</source>
         <translation type="unfinished">Відключено</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="68"/>
+        <location filename="../components/StatusLine.qml" line="73"/>
         <source>Reconnecting…</source>
         <translation type="unfinished">Повторне підключення…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="72"/>
+        <location filename="../components/StatusLine.qml" line="77"/>
         <source>Connecting…</source>
         <translation type="unfinished">Підключення…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error</source>
         <translation type="unfinished">Помилка Core</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing…</source>
         <translation type="unfinished">Індексування…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping…</source>
         <translation type="unfinished">Скрейпінг…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="248"/>
+        <source>%1%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="88"/>
+        <location filename="../components/StatusLine.qml" line="93"/>
         <source>Indexing paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="100"/>
+        <location filename="../components/StatusLine.qml" line="105"/>
         <source>Scraping paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2434,27 +2450,27 @@ Français - Wilfried</source>
         <translation type="obsolete">%1 зібрано</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexed %1 files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scraped %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="187"/>
+        <location filename="../components/StatusLine.qml" line="192"/>
         <source>Playtime limit in %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -2408,6 +2408,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
+        <location filename="../components/StatusLine.qml" line="271"/>
         <source>%1%</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -470,13 +470,13 @@ Français - Wilfried</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="166"/>
-        <location filename="../screens/GamesScreen.qml" line="217"/>
+        <location filename="../screens/GamesScreen.qml" line="176"/>
+        <location filename="../screens/GamesScreen.qml" line="238"/>
         <source>%1 games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/GamesScreen.qml" line="174"/>
+        <location filename="../screens/GamesScreen.qml" line="184"/>
         <source>Loading more…</source>
         <translation>正在加载更多…</translation>
     </message>
@@ -567,7 +567,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1583"/>
+        <location filename="../screens/HubScreen.qml" line="1591"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>没有可用系统。请在“设置”中运行“更新媒体数据库”。</translation>
     </message>
@@ -673,81 +673,81 @@ Français - Wilfried</source>
         <translation type="vanished">启动核心</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2109"/>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2127"/>
+        <location filename="../app/Main.qml" line="2563"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2124"/>
-        <location filename="../app/Main.qml" line="2159"/>
+        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Update media database</source>
         <translation type="unfinished">更新媒体数据库</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2145"/>
+        <location filename="../app/Main.qml" line="2180"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">抓取元数据</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
+        <location filename="../app/Main.qml" line="2136"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1035"/>
+        <location filename="../app/Main.qml" line="1053"/>
         <source>Settings</source>
         <translation type="unfinished">设置</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2058"/>
+        <location filename="../app/Main.qml" line="2076"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2095"/>
+        <location filename="../app/Main.qml" line="2113"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2118"/>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2195"/>
-        <location filename="../app/Main.qml" line="2246"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2267"/>
         <source>Launch game</source>
         <translation>启动游戏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2199"/>
-        <location filename="../app/Main.qml" line="2250"/>
+        <location filename="../app/Main.qml" line="2217"/>
+        <location filename="../app/Main.qml" line="2271"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2313"/>
+        <location filename="../app/Main.qml" line="2237"/>
+        <location filename="../app/Main.qml" line="2292"/>
+        <location filename="../app/Main.qml" line="2333"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Remove from favorites</source>
         <translation>从收藏中移除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2275"/>
         <source>Add to favorites</source>
         <translation>添加到收藏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2205"/>
-        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2281"/>
         <source>Write to NFC token</source>
         <translation>写入 NFC 令牌</translation>
     </message>
@@ -756,358 +756,369 @@ Français - Wilfried</source>
         <translation type="vanished">二维码</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3333"/>
+        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3371"/>
         <source>Default</source>
         <translation type="unfinished">默认</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2539"/>
+        <location filename="../app/Main.qml" line="2559"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2104"/>
-        <location filename="../app/Main.qml" line="2154"/>
-        <location filename="../app/Main.qml" line="2171"/>
-        <location filename="../app/Main.qml" line="2179"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="3226"/>
+        <location filename="../app/Main.qml" line="2122"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2189"/>
+        <location filename="../app/Main.qml" line="2197"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="3264"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3258"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3296"/>
         <source>Favorites</source>
         <translation type="unfinished">收藏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1042"/>
-        <location filename="../app/Main.qml" line="3243"/>
-        <location filename="../app/Main.qml" line="3290"/>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="3281"/>
+        <location filename="../app/Main.qml" line="3328"/>
+        <location filename="../app/Main.qml" line="3338"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3309"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
+        <location filename="../app/Main.qml" line="3270"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3322"/>
-        <location filename="../app/Main.qml" line="3337"/>
+        <location filename="../app/Main.qml" line="3360"/>
+        <location filename="../app/Main.qml" line="3375"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3232"/>
-        <location filename="../app/Main.qml" line="3254"/>
+        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3292"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3341"/>
+        <location filename="../app/Main.qml" line="3379"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3262"/>
+        <location filename="../app/Main.qml" line="3300"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1007"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1027"/>
+        <location filename="../app/Main.qml" line="1045"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1031"/>
+        <location filename="../app/Main.qml" line="1049"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1039"/>
+        <location filename="../app/Main.qml" line="1057"/>
         <source>Quit</source>
         <translation type="unfinished">退出</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2114"/>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2239"/>
-        <location filename="../app/Main.qml" line="2276"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2241"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2296"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2209"/>
-        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="2285"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2336"/>
+        <location filename="../app/Main.qml" line="2356"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2340"/>
+        <location filename="../app/Main.qml" line="2360"/>
         <source>Move</source>
         <translation type="unfinished">移动</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2523"/>
+        <location filename="../app/Main.qml" line="2543"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
+        <location filename="../app/Main.qml" line="2751"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2871"/>
-        <location filename="../app/Main.qml" line="2893"/>
-        <location filename="../app/Main.qml" line="2917"/>
-        <location filename="../app/Main.qml" line="2959"/>
+        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="2907"/>
+        <location filename="../app/Main.qml" line="2929"/>
+        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2995"/>
         <source>OK</source>
         <translation type="unfinished">确定</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2917"/>
-        <source>No matching games found.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2926"/>
-        <source>Action failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2927"/>
-        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2929"/>
-        <source>Launch failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start %1. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2930"/>
-        <source>Could not start this item. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2932"/>
-        <source>Favorite update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2933"/>
-        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2935"/>
-        <source>Media update failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2936"/>
-        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2938"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2939"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2941"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2942"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2944"/>
-        <source>Cancel failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2945"/>
-        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2948"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2950"/>
-        <source>Alternate versions unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2951"/>
-        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <location filename="../app/Main.qml" line="1022"/>
+        <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="2953"/>
+        <source>No matching games found.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2962"/>
+        <source>Action failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2963"/>
+        <source>The action could not be completed. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2965"/>
+        <source>Launch failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start %1. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2966"/>
+        <source>Could not start this item. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2968"/>
+        <source>Favorite update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2969"/>
+        <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2971"/>
+        <source>Media update failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2972"/>
+        <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2974"/>
+        <source>Metadata scrape failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2975"/>
+        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2977"/>
+        <source>Scraper list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2978"/>
+        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2980"/>
+        <source>Cancel failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2981"/>
+        <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2984"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2986"/>
+        <source>Alternate versions unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2987"/>
+        <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2989"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2954"/>
+        <location filename="../app/Main.qml" line="2990"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2956"/>
+        <location filename="../app/Main.qml" line="2992"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2957"/>
+        <location filename="../app/Main.qml" line="2993"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3096"/>
+        <location filename="../app/Main.qml" line="3133"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3144"/>
+        <location filename="../app/Main.qml" line="3182"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3218"/>
+        <location filename="../app/Main.qml" line="3256"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3241"/>
-        <location filename="../app/Main.qml" line="3287"/>
+        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3325"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3275"/>
-        <location filename="../app/Main.qml" line="3297"/>
+        <location filename="../app/Main.qml" line="3313"/>
+        <location filename="../app/Main.qml" line="3335"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
+        <location filename="../app/Main.qml" line="3317"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3315"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3353"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3304"/>
-        <location filename="../app/Main.qml" line="3311"/>
+        <location filename="../app/Main.qml" line="3342"/>
+        <location filename="../app/Main.qml" line="3349"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3518"/>
-        <location filename="../app/Main.qml" line="3536"/>
+        <location filename="../app/Main.qml" line="3556"/>
+        <location filename="../app/Main.qml" line="3574"/>
         <source>Saving launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3522"/>
-        <location filename="../app/Main.qml" line="3539"/>
+        <location filename="../app/Main.qml" line="3560"/>
+        <location filename="../app/Main.qml" line="3577"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2947"/>
-        <location filename="../app/Main.qml" line="3552"/>
+        <location filename="../app/Main.qml" line="2983"/>
+        <location filename="../app/Main.qml" line="3590"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2715"/>
-        <location filename="../app/Main.qml" line="3144"/>
-        <location filename="../app/Main.qml" line="3552"/>
-        <location filename="../app/Main.qml" line="3882"/>
+        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3920"/>
         <source>Retry</source>
         <translation type="unfinished">重试</translation>
     </message>
@@ -1116,37 +1127,37 @@ Français - Wilfried</source>
         <translation type="obsolete">取消</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4565"/>
+        <location filename="../app/Main.qml" line="4603"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4567"/>
+        <location filename="../app/Main.qml" line="4605"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4569"/>
+        <location filename="../app/Main.qml" line="4607"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4572"/>
+        <location filename="../app/Main.qml" line="4610"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4574"/>
+        <location filename="../app/Main.qml" line="4612"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4576"/>
+        <location filename="../app/Main.qml" line="4614"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4578"/>
+        <location filename="../app/Main.qml" line="4616"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>
@@ -2356,68 +2367,73 @@ Français - Wilfried</source>
 <context>
     <name>StatusLine</name>
     <message>
-        <location filename="../components/StatusLine.qml" line="66"/>
-        <location filename="../components/StatusLine.qml" line="70"/>
+        <location filename="../components/StatusLine.qml" line="71"/>
+        <location filename="../components/StatusLine.qml" line="75"/>
         <source>Disconnected</source>
         <translation type="unfinished">已断开</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="68"/>
+        <location filename="../components/StatusLine.qml" line="73"/>
         <source>Reconnecting…</source>
         <translation type="unfinished">正在重新连接…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="72"/>
+        <location filename="../components/StatusLine.qml" line="77"/>
         <source>Connecting…</source>
         <translation type="unfinished">正在连接…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error</source>
         <translation type="unfinished">Core 错误</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing…</source>
         <translation type="unfinished">正在索引…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping…</source>
         <translation type="unfinished">正在抓取…</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="94"/>
+        <location filename="../components/StatusLine.qml" line="248"/>
+        <source>%1%</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="99"/>
         <source>Indexing: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="74"/>
+        <location filename="../components/StatusLine.qml" line="79"/>
         <source>Core error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="88"/>
+        <location filename="../components/StatusLine.qml" line="93"/>
         <source>Indexing paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="97"/>
+        <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="100"/>
+        <location filename="../components/StatusLine.qml" line="105"/>
         <source>Scraping paused: game running</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="101"/>
+        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2430,27 +2446,27 @@ Français - Wilfried</source>
         <translation type="obsolete">已抓取 %1 个</translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexed %1 files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="143"/>
+        <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scraped %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="154"/>
+        <location filename="../components/StatusLine.qml" line="159"/>
         <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="187"/>
+        <location filename="../components/StatusLine.qml" line="192"/>
         <source>Playtime limit in %1</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -2404,6 +2404,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
+        <location filename="../components/StatusLine.qml" line="271"/>
         <source>%1%</source>
         <translation type="unfinished"></translation>
     </message>

--- a/tests/ui/tst_color_schemes.qml
+++ b/tests/ui/tst_color_schemes.qml
@@ -26,10 +26,39 @@ TestCase {
         return (Math.max(firstLuminance, secondLuminance) + 0.05) / (Math.min(firstLuminance, secondLuminance) + 0.05);
     }
 
-    function _saturation(value: color): real {
-        const maximum = Math.max(value.r, value.g, value.b);
-        const minimum = Math.min(value.r, value.g, value.b);
-        return maximum === 0 ? 0 : (maximum - minimum) / maximum;
+    function _cbrt(value: real): real {
+        return value < 0 ? -Math.pow(-value, 1 / 3) : Math.pow(value, 1 / 3);
+    }
+
+    function _srgbToLinearChannel(value: real): real {
+        return value <= 0.04045 ? value / 12.92 : Math.pow((value + 0.055) / 1.055, 2.4);
+    }
+
+    // OKLCh chroma (Bjorn Ottosson's OKLab) -- independently reimplemented
+    // from ColorSchemes.qml's own `_srgbToOklab`/`_toLch` (same numbers,
+    // verified separately here rather than calling into the production
+    // helpers, matching this file's existing `_relativeLuminance`/
+    // `_contrastRatio` pattern) so a regression in that derivation itself
+    // gets caught, not just a regression in how the palette consumes it.
+    // `_saturation` above is HSV, which orders by the color's own r/g/b
+    // spread rather than perceptual colorfulness -- it disagrees with
+    // chroma exactly on presets whose *background* is itself a saturated
+    // colour (`solarized-dark`, `everforest`, `nord`, `green-phosphor`,
+    // `virtual-boy`), which is what this role's own guardrail needs to
+    // measure against.
+    function _chroma(value: color): real {
+        const r = _srgbToLinearChannel(value.r);
+        const g = _srgbToLinearChannel(value.g);
+        const b = _srgbToLinearChannel(value.b);
+        const l = 0.4122214708 * r + 0.5363325363 * g + 0.0514459929 * b;
+        const m = 0.2119034982 * r + 0.6806995451 * g + 0.1073969566 * b;
+        const s = 0.0883024619 * r + 0.2817188376 * g + 0.6299787005 * b;
+        const l_ = _cbrt(l);
+        const m_ = _cbrt(m);
+        const s_ = _cbrt(s);
+        const a = 1.9779984951 * l_ - 2.4285922050 * m_ + 0.4505937099 * s_;
+        const bLab = 0.0259040371 * l_ + 0.7827717662 * m_ - 0.8086757660 * s_;
+        return Math.sqrt(a * a + bLab * bLab);
     }
 
     function cleanup(): void {
@@ -111,6 +140,14 @@ TestCase {
             verify(_contrastRatio(palette.textPrimary, palette.surfaceCard) >= 4.5, id + " primary text/card");
             verify(_contrastRatio(palette.accent, palette.bgDeep) >= 3.0, id + " accent/background");
             verify(_contrastRatio(palette.textLabel, palette.bgDeep) >= 3.0, id + " label/background");
+            // Round N: `textLabel` was only floored against `bgDeep` above,
+            // not `surfaceCard`, where most of it actually renders (menu/
+            // settings rows, tile captions); `textVariant` had no floor at
+            // all, even though it's the dimmest text role in the palette.
+            // Both matter more at 540p, where a TV's own scaling/sharpening
+            // is the first thing to make marginal contrast go mushy.
+            verify(_contrastRatio(palette.textLabel, palette.surfaceCard) >= 3.0, id + " label/card");
+            verify(_contrastRatio(palette.textVariant, palette.surfaceCard) >= 3.0, id + " variant/card");
         }
     }
 
@@ -118,12 +155,26 @@ TestCase {
     // edge is chromatically separated from the face along the accent ramp, not
     // merely a darker version of it. A derivation that flattens the edge into
     // the card loses the gloss cue even though nothing looks obviously broken.
+    //
+    // Separation is measured in OKLCh chroma, not HSV saturation: HSV
+    // saturation orders by a color's own r/g/b spread, which is high on a
+    // preset whose *background* is itself a saturated hue
+    // (`solarized-dark`, `everforest`, `nord`, `green-phosphor`,
+    // `virtual-boy`) even when the edge's perceptual chroma is
+    // deliberately low there -- chroma is what these roles are actually
+    // tuned in (see `ColorSchemes.qml`'s `_edgeFor`), so it's what the
+    // guardrail needs to measure. `controlEdge` gets the same floor as
+    // `tileEdge` (previously untested) since it carries the "this is a
+    // button" cue on every menu/settings row the same way `tileEdge` does
+    // on tiles.
     function test_edge_reads_as_a_lit_bevel(): void {
         for (let i = 0; i < ColorSchemes.ids.length; i++) {
             const id = ColorSchemes.ids[i];
             const palette = ColorSchemes.palette(id);
             verify(_contrastRatio(palette.tileEdge, palette.surfaceCard) >= 1.5, id + " tile edge/card separation");
-            verify(_saturation(palette.tileEdge) > _saturation(palette.surfaceCard), id + " tile edge must be more saturated than the card");
+            verify(_contrastRatio(palette.controlEdge, palette.surfaceCard) >= 1.5, id + " control edge/card separation");
+            verify(_chroma(palette.tileEdge) > _chroma(palette.surfaceCard), id + " tile edge must be more chromatic than the card");
+            verify(_chroma(palette.controlEdge) > _chroma(palette.surfaceCard), id + " control edge must be more chromatic than the card");
         }
     }
 

--- a/tests/ui/tst_color_schemes.qml
+++ b/tests/ui/tst_color_schemes.qml
@@ -43,7 +43,7 @@ TestCase {
     // `_saturation` above is HSV, which orders by the color's own r/g/b
     // spread rather than perceptual colorfulness -- it disagrees with
     // chroma exactly on presets whose *background* is itself a saturated
-    // colour (`solarized-dark`, `everforest`, `nord`, `green-phosphor`,
+    // color (`solarized-dark`, `everforest`, `nord`, `green-phosphor`,
     // `virtual-boy`), which is what this role's own guardrail needs to
     // measure against.
     function _chroma(value: color): real {

--- a/tests/ui/tst_format.qml
+++ b/tests/ui/tst_format.qml
@@ -32,11 +32,16 @@ TestCase {
         compare(Format.folderCountSuffix("", 42), Format.count(42));
     }
 
-    function test_folder_count_suffix_combines_distinguisher_and_count(): void {
-        compare(Format.folderCountSuffix("fat", 18), "fat · " + Format.count(18));
-    }
-
-    function test_folder_count_suffix_shows_the_distinguisher_alone_when_count_is_unknown(): void {
+    // A distinguisher only ever appears on a `root` row (disambiguating
+    // same-named sibling roots, games.rs's `root_distinguishers`); a count
+    // only ever appears on a `directory` row Core hasn't already collapsed
+    // to a single playable item (a media-capable directory reports
+    // fileCount 0 -- see games.rs's `FILE_COUNT_ROLE` data-arm comment).
+    // Those two cases never overlap in practice, so the distinguisher wins
+    // outright with no separator to compose -- folders don't carry tags and
+    // games don't carry counts.
+    function test_folder_count_suffix_prefers_the_distinguisher_over_the_count(): void {
+        compare(Format.folderCountSuffix("fat", 18), "fat");
         compare(Format.folderCountSuffix("usb0", 0), "usb0");
     }
 
@@ -47,10 +52,20 @@ TestCase {
 
     function test_row_suffix_uses_folder_count_for_directory_and_root_rows(): void {
         compare(Format.rowSuffix("directory", "", 5), Format.count(5));
-        compare(Format.rowSuffix("root", "fat", 5), "fat · " + Format.count(5));
+        compare(Format.rowSuffix("root", "fat", 5), "fat");
     }
 
     function test_row_suffix_hidden_for_a_folder_with_no_known_count(): void {
+        compare(Format.rowSuffix("directory", "", 0), "");
+    }
+
+    // A directory Core already collapsed to a single playable item (media_id
+    // or a direct zap_script -- games.rs's `is_media_capable_entry`) reports
+    // fileCount 0 at the source (`FILE_COUNT_ROLE`/`file_count_at`), the
+    // same signal an uncomputed root count uses -- it renders as the game
+    // everywhere else in the tile, so a "1" beside it read as a bug, not a
+    // folder count.
+    function test_row_suffix_suppresses_count_for_a_collapsed_single_item_folder(): void {
         compare(Format.rowSuffix("directory", "", 0), "");
     }
 }

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -1442,12 +1442,12 @@ TestCase {
 
     function test_context_menu_favorites_matches_games_media_entries(): void {
         const entries = main.buildContextMenuEntries("favorites", "", true, true, true, "", false, "");
-        compare(_idsOf(entries), ["launch_game", "more_info", "toggle_favorite", "write_card", "qr_code"]);
+        compare(_idsOf(entries), ["launch_game", "more_info", "toggle_favorite", "write_card", "qr_code", "add_to_hub"]);
     }
 
     function test_context_menu_favorites_no_reader_omits_write_card(): void {
         const entries = main.buildContextMenuEntries("favorites", "", true, false, true, "", false, "");
-        compare(_idsOf(entries), ["launch_game", "more_info", "toggle_favorite", "qr_code"]);
+        compare(_idsOf(entries), ["launch_game", "more_info", "toggle_favorite", "qr_code", "add_to_hub"]);
     }
 
     // Round 10: "Discover alt. versions" only appears when the row's own

--- a/tests/ui/tst_status_line.qml
+++ b/tests/ui/tst_status_line.qml
@@ -229,6 +229,83 @@ TestCase {
         compare(track.totalSteps, 10);
     }
 
+    // The percentage keeps the resolution the 12-cell track quantises
+    // away -- computed from the same current/total the track's own fill
+    // uses, not a separate source that could drift.
+    function test_percentage_matches_current_over_total(): void {
+        Browse.MediaStatus.indexing = true;
+        Browse.MediaStatus.current_step = 3;
+        Browse.MediaStatus.total_steps = 10;
+
+        const line = createTemporaryObject(statusLineComponent, testCase, {
+            "mediaActivityEnabled": true
+        });
+        verify(line !== null);
+        compare(line._percentText, "30%");
+
+        Browse.MediaStatus.current_step = 10;
+        compare(line._percentText, "100%");
+    }
+
+    // Optimize/vacuum has no step count Core reports (mirrors
+    // ProgressTrack's own indeterminate mode) -- the percentage slot
+    // renders blank rather than a misleading number, but stays reserved
+    // at its full width so the track's position doesn't shift the moment
+    // a run passes through this phase.
+    function test_percentage_blank_but_reserved_during_optimize(): void {
+        Browse.MediaStatus.optimizing = true;
+
+        const line = createTemporaryObject(statusLineComponent, testCase, {
+            "mediaActivityEnabled": true
+        });
+        verify(line !== null);
+        compare(line._showTrack, true);
+        compare(line._percentKnown, false);
+        compare(line._percentText, "");
+
+        const percent = findChild(line, "statusLinePercent");
+        verify(percent !== null);
+        compare(percent.text, "");
+        // The reserve must equal the slot's own fixed width (which does
+        // NOT depend on text content, same as `track.width` per
+        // `_trackReserve`'s doc comment) plus one gap -- i.e. the blank
+        // slot claims exactly the room a populated one would, not a
+        // collapsed 0.
+        compare(line._percentReserve, percent.width + line._cellsSpacing, "a blank slot must reserve the same room a populated one would");
+    }
+
+    // Mirrors ProgressTrack's own test_track_width_is_invariant_across_states:
+    // the slot's width must never depend on the current value, or the
+    // track drifts as the run progresses from "1%" to "100%".
+    function test_percentage_slot_width_is_invariant_across_values(): void {
+        Browse.MediaStatus.indexing = true;
+        Browse.MediaStatus.total_steps = 100;
+        Browse.MediaStatus.current_step = 1;
+
+        const line = createTemporaryObject(statusLineComponent, testCase, {
+            "mediaActivityEnabled": true
+        });
+        verify(line !== null);
+        const percent = findChild(line, "statusLinePercent");
+        verify(percent !== null);
+        const narrowWidth = percent.width;
+
+        Browse.MediaStatus.current_step = 100;
+        compare(percent.text, "100%");
+        compare(percent.width, narrowWidth, "the slot must not resize as the digit count grows");
+    }
+
+    // No task, no track, nothing to reserve room for -- mirrors
+    // `_trackReserve`'s own idle collapse.
+    function test_percentage_reserve_collapses_when_idle(): void {
+        const line = createTemporaryObject(statusLineComponent, testCase, {
+            "mediaActivityEnabled": true
+        });
+        verify(line !== null);
+        compare(line._showTrack, false);
+        compare(line._percentReserve, 0);
+    }
+
     function test_indexing_paused_reports_game_running_and_freezes_track(): void {
         Browse.MediaStatus.indexing = true;
         Browse.MediaStatus.paused = true;
@@ -347,11 +424,14 @@ TestCase {
         verify(line !== null);
 
         const label = findChild(line, "statusLineLabel");
+        const percent = findChild(line, "statusLinePercent");
         const track = findChild(line, "statusLineTrack");
         verify(label !== null);
+        verify(percent !== null);
         verify(track !== null);
         compare(label.width, line._labelNaturalWidth);
-        compare(Math.round(label.x + label.width + line._cellsSpacing), Math.round(track.x));
+        compare(Math.round(label.x + label.width + line._cellsSpacing), Math.round(percent.x), "the label must hug the percentage slot");
+        compare(Math.round(percent.x + percent.width + line._cellsSpacing), Math.round(track.x), "the percentage slot must hug the track");
         compare(Math.round(track.x + track.width), Math.round(line.width), "the track must be flush against the row's own right edge");
     }
 


### PR DESCRIPTION
## Summary

Root-causes every item from the 8/24 beta feedback thread against the actual code rather than the bug reports alone. Several items originally assumed to be Core's responsibility turned out to be frontend bugs on closer reading.

> **Note:** an earlier version of this PR also implemented zaparoo-core [PR #1312](https://github.com/ZaparooProject/zaparoo-core/pull/1312)'s merged system-root browse view (`rootView: "contents"`). That duplicated #395 (already open, more complete — it also narrows `decide_initial`'s single-entry auto-navigate and folds the leading virtual-root count into `result_total_dirs`, both real gaps this branch's version had). Dropped here; #395 supersedes it. Once #395 merges, the games-header title fix below will resolve for multi-root systems too — it's already fixed here for single-root systems.

**Correctness fixes**
- Negative image-cache memo is now invalidated per-system when that system's index/scrape completes — fixes box art that never recovers after a NAS mount races boot until a restart.
- A single-game folder no longer shows a stray item-count badge (suppressed at the source in `games.rs`, since the cover-art path already renders it as the game). Also drops the suffix's `" · "` join — a root distinguisher and a count never coexist.
- Games header now resolves the system name at the system root instead of the raw folder basename (e.g. `SMS` → `Master System`, `MegaDrive` → `Genesis`) for single-root systems. Multi-root systems still show the basename until #395 merges.
- Bottom active-label title no longer goes stale across a folder swap that lands on the same index/count.
- Hub's "Add item…" now explains why it has nothing to offer instead of silently no-opping, and "Add to Hub" works from Favorites/Recents rows, not just Games/Systems.
- Cancel on the Hub root is now an explicit no-op instead of an unhandled fall-through.

**Performance**
- Image-cache eviction moved from an O(n) scan to an LRU-indexed O(log n) lookup; the byte clone on a cache hit no longer happens under the write lock.
- Qt's decoded pixmap cache now has an explicit ceiling (`QML_PIXMAP_CACHE_LIMIT`) accounted alongside the encoded-bytes budget instead of growing unbounded on top of it.

**Theme**
- `tileEdge`/`controlEdge` moved onto the OKLCh path every other accent-derived role uses, with capped chroma and contrast-solved lightness — quiets the ambient accent bevel flagged as too strong without touching focus/selection state.
- Added contrast floors for `textVariant`/`textLabel` against `surfaceCard` for 540p legibility.

**Progress display**
- `StatusLine` now shows a fixed-width percentage between the label and the 12-cell track, keeping granularity a coarse 12-state bar loses, without repeating either of the two previously-cut layout attempts.

## Test plan

- [x] `just lint` — clean
- [x] `just test` — full gate clean (8/8 ctest targets incl. QML suite, 762/762 Rust tests)
- [x] Manually verified against a real build: single-game folder badge (grid + list), games header at system root (single-root), active-label staleness, Hub cancel, Add to Hub from Favorites/Recents, theme edge retune
- [ ] Not yet verified: NAS negative-memo fix (needs a real scrape run), both performance fixes (needs a long browsing session on MiSTer), empty "Add item…" copy, progress percentage during a real index/scrape run