### PR TITLE
feat(library): show and change non-default media launcher

### DIFF
--- a/rust/frontend/build.rs
+++ b/rust/frontend/build.rs
@@ -14,6 +14,7 @@ const MODEL_FILES: &[&str] = &[
     "src/models/favorite_systems_state.rs",
     "src/models/systems.rs",
     "src/models/game_info.rs",
+    "src/models/game_launcher_override.rs",
     "src/models/games.rs",
     "src/models/favorites.rs",
     "src/models/browse.rs",

--- a/rust/frontend/src/models/game_launcher_override.rs
+++ b/rust/frontend/src/models/game_launcher_override.rs
@@ -44,6 +44,11 @@ pub struct GameLauncherOverrideRust {
     update_pending: bool,
     update_error: QString,
     launchers: Vec<LauncherInfo>,
+    // System id `prepare_game` last ran for, kept so a `LaunchersEndpoint`
+    // update that lands after it (e.g. still loading at menu-open time)
+    // can rebuild the picker list without a second `prepare_game` call —
+    // see `apply_launchers`.
+    prepared_system_id: String,
     seq: Arc<AtomicU64>,
     update_seq: Arc<AtomicU64>,
 }
@@ -110,13 +115,26 @@ fn apply_launchers(
     mut model: Pin<&mut ffi::GameLauncherOverride>,
     status: &ResourceStatus<zaparoo_core::media_types::LaunchersResult>,
 ) {
-    if let ResourceStatus::Ready(data) = status {
-        model
-            .as_mut()
-            .rust_mut()
-            .launchers
-            .clone_from(&data.launchers);
+    let ResourceStatus::Ready(data) = status else {
+        return;
+    };
+    model
+        .as_mut()
+        .rust_mut()
+        .launchers
+        .clone_from(&data.launchers);
+    let system_id = model.rust().prepared_system_id.clone();
+    if system_id.is_empty() {
+        return;
     }
+    let current = model.current_override.to_string();
+    let launchers = model.rust().launchers.clone();
+    set_picker_entries(
+        model,
+        &launchers,
+        &system_id,
+        (!current.is_empty()).then_some(current.as_str()),
+    );
 }
 
 impl ffi::GameLauncherOverride {
@@ -129,6 +147,10 @@ impl ffi::GameLauncherOverride {
         let path = path.to_string();
         self.as_mut().rust_mut().seq.fetch_add(1, Ordering::SeqCst);
         let ticket = self.rust().seq.load(Ordering::SeqCst);
+        self.as_mut()
+            .rust_mut()
+            .prepared_system_id
+            .clone_from(&system_id);
         self.as_mut().set_current_override(QString::default());
         self.as_mut().set_error_message(QString::default());
         self.as_mut().set_picker_ids(QStringList::default());
@@ -262,8 +284,26 @@ fn apply_launcher_override(
     meta: &MediaMeta,
 ) {
     let current = meta.launcher_override.clone();
+    set_picker_entries(model.as_mut(), launchers, system_id, current.as_deref());
+    model
+        .as_mut()
+        .set_current_override(QString::from(current.unwrap_or_default().as_str()));
+}
+
+/// Rebuild `picker_ids`/`picker_labels` from `launchers` filtered to
+/// `system_id`, plus `current` (the launcher already selected, so the
+/// picker's own "Default"/"Current: X" rows land correctly). Shared by
+/// `apply_launcher_override` (a fresh `media.meta` result) and
+/// `apply_launchers` (launcher data arriving after `prepare_game` already
+/// ran, e.g. `LaunchersEndpoint` was still loading at menu-open time).
+fn set_picker_entries(
+    mut model: Pin<&mut ffi::GameLauncherOverride>,
+    launchers: &[LauncherInfo],
+    system_id: &str,
+    current: Option<&str>,
+) {
     let matching = launchers_for_system(launchers, system_id);
-    let entries = picker_entries_for_system(&matching, current.as_deref());
+    let entries = picker_entries_for_system(&matching, current);
     let mut ids = QStringList::default();
     let mut labels = QStringList::default();
     for entry in entries {
@@ -272,7 +312,4 @@ fn apply_launcher_override(
     }
     model.as_mut().set_picker_ids(ids);
     model.as_mut().set_picker_labels(labels);
-    model
-        .as_mut()
-        .set_current_override(QString::from(current.unwrap_or_default().as_str()));
 }

--- a/rust/frontend/src/models/game_launcher_override.rs
+++ b/rust/frontend/src/models/game_launcher_override.rs
@@ -1,0 +1,278 @@
+// Zaparoo Frontend
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+//
+// Per-media launcher override, read and written from the game context
+// menu's "Change launcher" entry. Mirrors `system_launchers` in shape
+// (same `Default`-first picker list, same "__default__" clear sentinel,
+// shared via `system_launchers::{DEFAULT_LAUNCHER_ID, launchers_for_system,
+// picker_entries_for_system}") but reads/writes Core's per-media
+// `media.meta`/`media.meta.update` instead of the per-system
+// `settings`/`settings.update` pair `SystemLaunchers` uses.
+//
+// `prepare_game` is a "small 1-item query": it checks the process-wide
+// `MediaMetaCache` first (a warm neighbor from the list-detail pane or a
+// prior menu open answers instantly), and only issues one `media.meta`
+// fetch on a cold miss. Nothing here ever runs across a whole page of
+// rows — see CLAUDE.md's caching/RAM constraints.
+
+use crate::media_image_cache::MediaKey;
+use crate::media_meta_cache::{
+    fetch_media_meta_with_path_fallback, global_media_meta_cache, MetaLookup,
+};
+use crate::models::system_launchers::{
+    launchers_for_system, picker_entries_for_system, DEFAULT_LAUNCHER_ID,
+};
+use crate::models::{global_handle, global_store};
+use cxx_qt::{CxxQtType, Initialize, Threading};
+use cxx_qt_lib::{QString, QStringList};
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use tracing::warn;
+use zaparoo_core::endpoints::launchers::LaunchersEndpoint;
+use zaparoo_core::media_types::{LauncherInfo, MediaMeta, MediaMetaParams, MediaMetaUpdateParams};
+use zaparoo_core::remote_resource::ResourceStatus;
+
+#[derive(Default)]
+pub struct GameLauncherOverrideRust {
+    loading: bool,
+    error_message: QString,
+    current_override: QString,
+    picker_ids: QStringList,
+    picker_labels: QStringList,
+    update_pending: bool,
+    update_error: QString,
+    launchers: Vec<LauncherInfo>,
+    seq: Arc<AtomicU64>,
+    update_seq: Arc<AtomicU64>,
+}
+
+#[cxx_qt::bridge]
+pub mod ffi {
+    unsafe extern "C++" {
+        include!("model_includes.h");
+
+        type QString = cxx_qt_lib::QString;
+        type QStringList = cxx_qt_lib::QStringList;
+    }
+
+    unsafe extern "RustQt" {
+        #[qobject]
+        #[qml_element]
+        #[qml_singleton]
+        #[qproperty(bool, loading)]
+        #[qproperty(QString, error_message)]
+        #[qproperty(QString, current_override)]
+        #[qproperty(QStringList, picker_ids)]
+        #[qproperty(QStringList, picker_labels)]
+        #[qproperty(bool, update_pending)]
+        #[qproperty(QString, update_error)]
+        type GameLauncherOverride = super::GameLauncherOverrideRust;
+
+        #[qinvokable]
+        fn prepare_game(self: Pin<&mut GameLauncherOverride>, system_id: QString, path: QString);
+
+        #[qinvokable]
+        fn set_game_launcher(
+            self: Pin<&mut GameLauncherOverride>,
+            system_id: QString,
+            path: QString,
+            launcher_id: QString,
+        );
+    }
+
+    impl cxx_qt::Initialize for GameLauncherOverride {}
+    impl cxx_qt::Threading for GameLauncherOverride {}
+}
+
+impl Initialize for ffi::GameLauncherOverride {
+    fn initialize(mut self: Pin<&mut Self>) {
+        // Shares the same cached `RemoteResource` `SystemLaunchers` already
+        // subscribes — `Store::subscribe` returns the same `Arc` for equal
+        // (endpoint, args), so this is a second cheap watcher, not a second
+        // fetch.
+        let mut launchers_rx = global_store()
+            .subscribe::<LaunchersEndpoint>(())
+            .subscribe();
+        apply_launchers(self.as_mut(), &launchers_rx.borrow_and_update());
+        let qt_thread = self.qt_thread();
+        global_handle().spawn(async move {
+            while launchers_rx.changed().await.is_ok() {
+                let status = launchers_rx.borrow_and_update().clone();
+                let _ = qt_thread.queue(move |model| apply_launchers(model, &status));
+            }
+        });
+    }
+}
+
+fn apply_launchers(
+    mut model: Pin<&mut ffi::GameLauncherOverride>,
+    status: &ResourceStatus<zaparoo_core::media_types::LaunchersResult>,
+) {
+    if let ResourceStatus::Ready(data) = status {
+        model
+            .as_mut()
+            .rust_mut()
+            .launchers
+            .clone_from(&data.launchers);
+    }
+}
+
+impl ffi::GameLauncherOverride {
+    #[allow(
+        clippy::needless_pass_by_value,
+        reason = "cxx-qt qinvokable signature requires QString by value"
+    )]
+    fn prepare_game(mut self: Pin<&mut Self>, system_id: QString, path: QString) {
+        let system_id = system_id.to_string();
+        let path = path.to_string();
+        self.as_mut().rust_mut().seq.fetch_add(1, Ordering::SeqCst);
+        let ticket = self.rust().seq.load(Ordering::SeqCst);
+        self.as_mut().set_current_override(QString::default());
+        self.as_mut().set_error_message(QString::default());
+        self.as_mut().set_picker_ids(QStringList::default());
+        self.as_mut().set_picker_labels(QStringList::default());
+        if system_id.trim().is_empty() || path.trim().is_empty() {
+            self.as_mut().set_loading(false);
+            return;
+        }
+        self.as_mut().set_loading(true);
+
+        let key = MediaKey::new(system_id.clone(), path.clone());
+        match global_media_meta_cache().lookup(&key) {
+            MetaLookup::Hit(meta) => {
+                let launchers = self.rust().launchers.clone();
+                apply_launcher_override(self.as_mut(), &launchers, &system_id, &meta);
+                self.as_mut().set_loading(false);
+                return;
+            }
+            MetaLookup::Negative => {
+                self.as_mut().set_loading(false);
+                return;
+            }
+            MetaLookup::Miss => {}
+        }
+
+        let params = MediaMetaParams::for_media(system_id.clone(), path.clone());
+        let seq = self.rust().seq.clone();
+        let qt_thread = self.qt_thread();
+        let fallback_system = system_id.clone();
+        let fallback_path = path.clone();
+        global_handle().spawn(async move {
+            let result =
+                fetch_media_meta_with_path_fallback(params, fallback_system, fallback_path).await;
+            global_media_meta_cache().store_fetch_result(key, &result);
+            let _ = qt_thread.queue(move |mut model| {
+                if seq.load(Ordering::SeqCst) != ticket {
+                    return;
+                }
+                model.as_mut().set_loading(false);
+                match result {
+                    Ok(result) => {
+                        let launchers = model.rust().launchers.clone();
+                        apply_launcher_override(
+                            model.as_mut(),
+                            &launchers,
+                            &system_id,
+                            &result.media,
+                        );
+                    }
+                    Err(e) => {
+                        warn!(
+                            "game launcher override fetch failed for {path}: {}",
+                            e.message
+                        );
+                        model
+                            .as_mut()
+                            .set_error_message(QString::from(e.message.as_str()));
+                    }
+                }
+            });
+        });
+    }
+
+    #[allow(
+        clippy::needless_pass_by_value,
+        reason = "cxx-qt qinvokable signature requires QString by value"
+    )]
+    fn set_game_launcher(
+        mut self: Pin<&mut Self>,
+        system_id: QString,
+        path: QString,
+        launcher_id: QString,
+    ) {
+        let system_id = system_id.to_string();
+        let path = path.to_string();
+        let launcher = launcher_id.to_string();
+        let launcher_override = if launcher == DEFAULT_LAUNCHER_ID {
+            None
+        } else {
+            Some(launcher)
+        };
+        let store = global_store();
+        let seq = self.rust().update_seq.clone();
+        let ticket = seq.fetch_add(1, Ordering::SeqCst) + 1;
+        self.as_mut().set_update_error(QString::default());
+        self.as_mut().set_update_pending(true);
+        let qt_thread = self.qt_thread();
+        let cache_key = MediaKey::new(system_id.clone(), path.clone());
+        let params =
+            MediaMetaUpdateParams::for_media(system_id.clone(), path.clone(), launcher_override);
+        global_handle().spawn(async move {
+            let result = store.client().media_meta_update(params).await;
+            let _ = qt_thread.queue(move |mut model| {
+                if seq.load(Ordering::SeqCst) != ticket {
+                    return;
+                }
+                model.as_mut().set_update_pending(false);
+                match result {
+                    Ok(result) => {
+                        model.as_mut().set_update_error(QString::default());
+                        global_media_meta_cache().store(cache_key, Some(result.media.clone()));
+                        let launchers = model.rust().launchers.clone();
+                        apply_launcher_override(
+                            model.as_mut(),
+                            &launchers,
+                            &system_id,
+                            &result.media,
+                        );
+                    }
+                    Err(e) => {
+                        warn!("game launcher override update failed: {}", e.message);
+                        model
+                            .as_mut()
+                            .set_update_error(QString::from(e.message.as_str()));
+                    }
+                }
+            });
+        });
+    }
+}
+
+/// Apply a fetched `MediaMeta`'s `launcher_override` to the model's
+/// `current_override` and rebuild the picker list against it. Shared by
+/// both the read path (`prepare_game`) and the write path
+/// (`set_game_launcher`'s success arm, whose `media.meta.update` response
+/// carries the same updated shape).
+fn apply_launcher_override(
+    mut model: Pin<&mut ffi::GameLauncherOverride>,
+    launchers: &[LauncherInfo],
+    system_id: &str,
+    meta: &MediaMeta,
+) {
+    let current = meta.launcher_override.clone();
+    let matching = launchers_for_system(launchers, system_id);
+    let entries = picker_entries_for_system(&matching, current.as_deref());
+    let mut ids = QStringList::default();
+    let mut labels = QStringList::default();
+    for entry in entries {
+        ids.append(QString::from(entry.id.as_str()));
+        labels.append(QString::from(entry.label.as_str()));
+    }
+    model.as_mut().set_picker_ids(ids);
+    model.as_mut().set_picker_labels(labels);
+    model
+        .as_mut()
+        .set_current_override(QString::from(current.unwrap_or_default().as_str()));
+}

--- a/rust/frontend/src/models/mod.rs
+++ b/rust/frontend/src/models/mod.rs
@@ -37,6 +37,7 @@ pub mod favorite_systems_state;
 pub mod favorites;
 pub mod favorites_state;
 pub mod game_info;
+pub mod game_launcher_override;
 pub mod games;
 pub mod games_state;
 pub mod hub_layout;

--- a/rust/frontend/src/models/system_launchers.rs
+++ b/rust/frontend/src/models/system_launchers.rs
@@ -17,7 +17,10 @@ use zaparoo_core::endpoints::system_launcher_default::{
 use zaparoo_core::media_types::{LauncherInfo, SettingsResult, SystemDefault};
 use zaparoo_core::remote_resource::ResourceStatus;
 
-const DEFAULT_LAUNCHER_ID: &str = "__default__";
+// `pub(crate)` — shared with `game_launcher_override`, whose picker uses
+// the same "Default" sentinel to mean "clear the stored override, fall
+// back to normal resolution."
+pub(crate) const DEFAULT_LAUNCHER_ID: &str = "__default__";
 
 #[allow(
     clippy::struct_excessive_bools,
@@ -68,6 +71,9 @@ pub mod ffi {
 
         #[qinvokable]
         fn launcher_count_for_system(self: &SystemLaunchers, system_id: &QString) -> i32;
+
+        #[qinvokable]
+        fn current_launcher_for_system(self: &SystemLaunchers, system_id: &QString) -> QString;
 
         #[qinvokable]
         fn set_system_launcher(
@@ -181,9 +187,9 @@ impl ffi::SystemLaunchers {
     )]
     fn prepare_system(mut self: Pin<&mut Self>, system_id: QString) {
         let system_id = system_id.to_string();
-        let current = current_launcher_for_system(&self.system_defaults, &system_id)
-            .unwrap_or_else(|| DEFAULT_LAUNCHER_ID.to_string());
-        let entries = picker_entries_for_system(&self.launchers, &self.system_defaults, &system_id);
+        let current = current_launcher_for_system(&self.system_defaults, &system_id);
+        let matching = launchers_for_system(&self.launchers, &system_id);
+        let entries = picker_entries_for_system(&matching, current.as_deref());
         let mut ids = QStringList::default();
         let mut labels = QStringList::default();
         for entry in entries {
@@ -192,12 +198,24 @@ impl ffi::SystemLaunchers {
         }
         self.as_mut().set_picker_ids(ids);
         self.as_mut().set_picker_labels(labels);
-        self.as_mut()
-            .set_current_launcher(QString::from(current.as_str()));
+        self.as_mut().set_current_launcher(QString::from(
+            current
+                .unwrap_or_else(|| DEFAULT_LAUNCHER_ID.to_string())
+                .as_str(),
+        ));
     }
 
     fn launcher_count_for_system(&self, system_id: &QString) -> i32 {
         launchers_for_system(&self.launchers, &system_id.to_string()).len() as i32
+    }
+
+    /// Synchronous read of the current system default launcher, for menu
+    /// labels that need it without going through `prepare_system` (which
+    /// also rebuilds the picker list). Empty string when no system default
+    /// is configured.
+    fn current_launcher_for_system(&self, system_id: &QString) -> QString {
+        current_launcher_for_system(&self.system_defaults, &system_id.to_string())
+            .map_or_else(QString::default, |id| QString::from(id.as_str()))
     }
 
     #[allow(
@@ -270,27 +288,31 @@ pub fn current_launcher_for_system(defaults: &[SystemDefault], system_id: &str) 
         })
 }
 
+/// Build the picker entry list: `Default` first, then `launchers` in
+/// order, then a synthetic `Current: <id>` row when `current` names a
+/// launcher not present in `launchers` (e.g. one uninstalled since it was
+/// selected). `launchers` must already be filtered to the target system or
+/// media row — this function is agnostic of that distinction so both the
+/// system-default picker and the per-game override picker share it.
 pub fn picker_entries_for_system(
     launchers: &[LauncherInfo],
-    defaults: &[SystemDefault],
-    system_id: &str,
+    current: Option<&str>,
 ) -> Vec<PickerEntry> {
     let mut entries = vec![PickerEntry {
         id: DEFAULT_LAUNCHER_ID.into(),
         label: "Default".into(),
     }];
-    let matching = launchers_for_system(launchers, system_id);
-    for launcher in &matching {
+    for launcher in launchers {
         entries.push(PickerEntry {
             id: launcher.id.clone(),
             label: launcher.id.clone(),
         });
     }
-    if let Some(current) = current_launcher_for_system(defaults, system_id) {
-        let known = matching.iter().any(|launcher| launcher.id == current);
+    if let Some(current) = current {
+        let known = launchers.iter().any(|launcher| launcher.id == current);
         if !known {
             entries.push(PickerEntry {
-                id: current.clone(),
+                id: current.to_string(),
                 label: format!("Current: {current}"),
             });
         }
@@ -310,14 +332,6 @@ mod tests {
         }
     }
 
-    fn default(system: &str, launcher: &str) -> SystemDefault {
-        SystemDefault {
-            system: system.into(),
-            launcher: launcher.into(),
-            before_exit: String::new(),
-        }
-    }
-
     #[test]
     fn filters_launchers_by_exact_system_id() {
         let launchers = vec![launcher("snes9x", "SNES"), launcher("nestopia", "NES")];
@@ -327,7 +341,7 @@ mod tests {
 
     #[test]
     fn picker_entries_put_default_first() {
-        let entries = picker_entries_for_system(&[launcher("snes9x", "SNES")], &[], "SNES");
+        let entries = picker_entries_for_system(&[launcher("snes9x", "SNES")], None);
         assert_eq!(entries[0].id, DEFAULT_LAUNCHER_ID);
         assert_eq!(entries[0].label, "Default");
         assert_eq!(entries[1].id, "snes9x");
@@ -335,11 +349,7 @@ mod tests {
 
     #[test]
     fn picker_entries_include_unknown_current_override() {
-        let entries = picker_entries_for_system(
-            &[launcher("snes9x", "SNES")],
-            &[default("SNES", "libretro")],
-            "SNES",
-        );
+        let entries = picker_entries_for_system(&[launcher("snes9x", "SNES")], Some("libretro"));
         assert_eq!(
             entries,
             vec![
@@ -354,6 +364,24 @@ mod tests {
                 PickerEntry {
                     id: "libretro".into(),
                     label: "Current: libretro".into()
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn picker_entries_omit_current_row_when_current_is_known() {
+        let entries = picker_entries_for_system(&[launcher("snes9x", "SNES")], Some("snes9x"));
+        assert_eq!(
+            entries,
+            vec![
+                PickerEntry {
+                    id: DEFAULT_LAUNCHER_ID.into(),
+                    label: "Default".into()
+                },
+                PickerEntry {
+                    id: "snes9x".into(),
+                    label: "snes9x".into()
                 },
             ]
         );

--- a/rust/mock-core/src/fixtures.rs
+++ b/rust/mock-core/src/fixtures.rs
@@ -9,9 +9,15 @@
 // into it.
 
 use serde_json::{json, Value};
+use std::collections::HashMap;
 use std::sync::{Mutex, OnceLock};
 
 static SYSTEM_DEFAULTS: OnceLock<Mutex<Vec<SystemDefaultFixture>>> = OnceLock::new();
+// Per-media launcher overrides set via `media.meta.update`, keyed by the
+// same `(system, path)` pair `media_ref_key` derives for `media.meta`.
+// Mirrors `SYSTEM_DEFAULTS`'s in-memory, process-lifetime pattern -- this
+// is dev-server state, not a real database.
+static LAUNCHER_OVERRIDES: OnceLock<Mutex<HashMap<(String, String), String>>> = OnceLock::new();
 
 pub(crate) const MOCK_SYSTEMS: &[(&str, &str, &str)] = &[
     ("NES", "Nintendo Entertainment System", "Consoles"),
@@ -122,6 +128,29 @@ fn system_defaults() -> &'static Mutex<Vec<SystemDefaultFixture>> {
             before_exit: String::new(),
         }])
     })
+}
+
+fn launcher_overrides() -> &'static Mutex<HashMap<(String, String), String>> {
+    LAUNCHER_OVERRIDES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Derive the `(system, path)` identity `media.meta`/`media.meta.update`
+/// share for one media ref -- a `mediaId`-only ref falls back to the same
+/// synthetic `/mock/media/<id>` path `media_for` already uses, and an
+/// absent `system` falls back to `"Mock"`, so both call sites agree on the
+/// same key regardless of which ref shape the caller sent.
+fn media_ref_key(reference: &Value) -> (String, String) {
+    let media_id = reference.get("mediaId").and_then(Value::as_i64);
+    let system = reference
+        .get("system")
+        .and_then(Value::as_str)
+        .unwrap_or("Mock")
+        .to_string();
+    let path = reference.get("path").and_then(Value::as_str).map_or_else(
+        || format!("/mock/media/{}", media_id.unwrap_or_default()),
+        str::to_string,
+    );
+    (system, path)
 }
 
 pub fn systems_response(params: &Value) -> Value {
@@ -457,15 +486,7 @@ pub fn media_browse_response(params: &Value) -> Value {
 
 pub fn media_meta_response(params: &Value) -> Value {
     fn media_for(reference: &Value) -> Value {
-        let media_id = reference.get("mediaId").and_then(Value::as_i64);
-        let system = reference
-            .get("system")
-            .and_then(Value::as_str)
-            .unwrap_or("Mock");
-        let path = reference.get("path").and_then(Value::as_str).map_or_else(
-            || format!("/mock/media/{}", media_id.unwrap_or_default()),
-            str::to_string,
-        );
+        let (system, path) = media_ref_key(reference);
         let name = path
             .rsplit('/')
             .next()
@@ -474,7 +495,11 @@ pub fn media_meta_response(params: &Value) -> Value {
             .next()
             .unwrap_or("Mock Game")
             .to_string();
-        json!({
+        let launcher_override = launcher_overrides()
+            .lock()
+            .ok()
+            .and_then(|overrides| overrides.get(&(system.clone(), path.clone())).cloned());
+        let mut media = json!({
             "path": path,
             "parentDir": "/mock",
             "isMissing": false,
@@ -486,7 +511,7 @@ pub fn media_meta_response(params: &Value) -> Value {
                 "name": name,
                 "slugLength": name.len(),
                 "slugWordCount": name.split_whitespace().count(),
-                "system": {"id": system, "name": system_display_for(system)},
+                "system": {"id": &system, "name": system_display_for(&system)},
                 "tags": [
                     {"type": "year", "tag": "1994"},
                     {"type": "developer", "tag": "Mock Studio"}
@@ -499,7 +524,11 @@ pub fn media_meta_response(params: &Value) -> Value {
                 },
                 "availableImageTypes": []
             }
-        })
+        });
+        if let Some(launcher_override) = launcher_override {
+            media["launcherOverride"] = json!(launcher_override);
+        }
+        media
     }
 
     if let Some(items) = params.get("items").and_then(Value::as_array) {
@@ -511,6 +540,51 @@ pub fn media_meta_response(params: &Value) -> Value {
         });
     }
     json!({"media": media_for(params)})
+}
+
+/// Mirrors Core's `media.meta.update`: sets or clears the per-media
+/// launcher override, validated against `launchers_response()`'s known
+/// launchers for the row's system, then returns the same shape
+/// `media.meta` would (via `media_meta_response`) so the caller sees its
+/// own write reflected immediately.
+pub fn media_meta_update_response(params: &Value) -> Result<Value, String> {
+    let key = media_ref_key(params);
+    let Some(field) = params
+        .get("media")
+        .and_then(|media| media.get("launcherOverride"))
+    else {
+        return Err("no supported media updates provided".to_string());
+    };
+    if field.is_null() {
+        if let Ok(mut overrides) = launcher_overrides().lock() {
+            overrides.remove(&key);
+        }
+    } else if let Some(launcher_id) = field.as_str() {
+        let (system, _path) = &key;
+        let known = launchers_response()["launchers"]
+            .as_array()
+            .is_some_and(|launchers| {
+                launchers.iter().any(|launcher| {
+                    launcher
+                        .get("id")
+                        .and_then(Value::as_str)
+                        .is_some_and(|id| id.eq_ignore_ascii_case(launcher_id))
+                        && launcher
+                            .get("systemId")
+                            .and_then(Value::as_str)
+                            .is_some_and(|system_id| system_id.eq_ignore_ascii_case(system))
+                })
+            });
+        if !known {
+            return Err(format!("launcher not found: {launcher_id}"));
+        }
+        if let Ok(mut overrides) = launcher_overrides().lock() {
+            overrides.insert(key.clone(), launcher_id.to_string());
+        }
+    } else {
+        return Err("media.launcherOverride must be a string or null".to_string());
+    }
+    Ok(media_meta_response(params))
 }
 
 pub fn media_browse_index_response(params: &Value) -> Value {

--- a/rust/mock-core/src/handler.rs
+++ b/rust/mock-core/src/handler.rs
@@ -69,6 +69,7 @@ pub fn dispatch(text: &str, notifier: &Notifier) -> String {
         "media.browse" => Some(Ok(fixtures::media_browse_response(&req.params))),
         "media.browse.index" => Some(Ok(fixtures::media_browse_index_response(&req.params))),
         "media.meta" => Some(Ok(fixtures::media_meta_response(&req.params))),
+        "media.meta.update" => Some(fixtures::media_meta_update_response(&req.params)),
         "media.history" => Some(Ok(fixtures::media_history_response(&req.params))),
         "media.history.latest" => Some(Ok(fixtures::media_history_latest_response())),
         "media" => Some(Ok(media_state::media_response())),
@@ -437,6 +438,51 @@ mod tests {
         assert_eq!(items[0]["media"]["path"], "/games/first.nes");
         assert_eq!(items[0]["media"]["title"]["system"]["id"], "NES");
         assert_eq!(items[1]["media"]["path"], "/mock/media/42");
+    }
+
+    #[test]
+    fn media_meta_update_sets_and_media_meta_reflects_the_override() {
+        let update = r#"{"jsonrpc":"2.0","id":"1","method":"media.meta.update","params":{"system":"SNES","path":"/games/set.sfc","media":{"launcherOverride":"snes9x"}}}"#;
+        let resp = parse(&dispatch(update));
+        assert_eq!(resp["result"]["media"]["launcherOverride"], "snes9x");
+
+        let read = r#"{"jsonrpc":"2.0","id":"2","method":"media.meta","params":{"system":"SNES","path":"/games/set.sfc"}}"#;
+        let resp = parse(&dispatch(read));
+        assert_eq!(resp["result"]["media"]["launcherOverride"], "snes9x");
+    }
+
+    #[test]
+    fn media_meta_update_clear_removes_the_override() {
+        let set = r#"{"jsonrpc":"2.0","id":"1","method":"media.meta.update","params":{"system":"SNES","path":"/games/clear.sfc","media":{"launcherOverride":"snes9x"}}}"#;
+        dispatch(set);
+
+        let clear = r#"{"jsonrpc":"2.0","id":"2","method":"media.meta.update","params":{"system":"SNES","path":"/games/clear.sfc","media":{"launcherOverride":null}}}"#;
+        let resp = parse(&dispatch(clear));
+        assert!(resp["result"]["media"]["launcherOverride"].is_null());
+    }
+
+    #[test]
+    fn media_meta_update_rejects_unknown_launcher() {
+        let update = r#"{"jsonrpc":"2.0","id":"1","method":"media.meta.update","params":{"system":"SNES","path":"/games/unknown.sfc","media":{"launcherOverride":"not-a-real-launcher"}}}"#;
+        let resp = parse(&dispatch(update));
+        assert_eq!(resp["error"]["code"], -32000);
+        assert!(resp["error"]["message"]
+            .as_str()
+            .expect("message")
+            .contains("launcher not found"));
+    }
+
+    #[test]
+    fn media_meta_update_rejects_launcher_from_a_different_system() {
+        // "nestopia" is a real fixture launcher, but it's registered for
+        // NES, not SNES.
+        let update = r#"{"jsonrpc":"2.0","id":"1","method":"media.meta.update","params":{"system":"SNES","path":"/games/wrong-system.sfc","media":{"launcherOverride":"nestopia"}}}"#;
+        let resp = parse(&dispatch(update));
+        assert_eq!(resp["error"]["code"], -32000);
+        assert!(resp["error"]["message"]
+            .as_str()
+            .expect("message")
+            .contains("launcher not found"));
     }
 
     #[test]

--- a/rust/zaparoo-core/src/client.rs
+++ b/rust/zaparoo-core/src/client.rs
@@ -18,11 +18,12 @@ use crate::media_types::{
     MediaBrowseIndexResult, MediaBrowseParams, MediaBrowseResult, MediaHistoryLatestResult,
     MediaHistoryParams, MediaHistoryResult, MediaHistoryTopParams, MediaHistoryTopResult,
     MediaImageParams, MediaImageResult, MediaIndexParams, MediaLookupParams, MediaLookupResult,
-    MediaMetaBatchParams, MediaMetaBatchResult, MediaMetaParams, MediaMetaResult, MediaResult,
-    MediaScrapeParams, MediaSearchParams, MediaSearchResult, MediaTagsParams, MediaTagsResult,
-    MediaTagsUpdateParams, MediaTagsUpdateResult, ReadersResult, ReadersWriteParams, RunParams,
-    ScrapersResult, ScrapingStatusResponse, SettingsResult, SystemsParams, SystemsResult,
-    TokensHistoryResult, TokensResult, UpdateSettingsParams, VersionResult,
+    MediaMetaBatchParams, MediaMetaBatchResult, MediaMetaParams, MediaMetaResult,
+    MediaMetaUpdateParams, MediaResult, MediaScrapeParams, MediaSearchParams, MediaSearchResult,
+    MediaTagsParams, MediaTagsResult, MediaTagsUpdateParams, MediaTagsUpdateResult, ReadersResult,
+    ReadersWriteParams, RunParams, ScrapersResult, ScrapingStatusResponse, SettingsResult,
+    SystemsParams, SystemsResult, TokensHistoryResult, TokensResult, UpdateSettingsParams,
+    VersionResult,
 };
 use futures_util::{SinkExt, StreamExt};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -712,6 +713,18 @@ impl Client {
             MediaMetaBatchParams::try_new(items).map_err(|message| ClientError { message })?;
         let val = self.call("media.meta", &params).await?;
         deserialize_timed("media.meta batch", val)
+    }
+
+    /// Sets or clears the per-media launcher override, then returns the
+    /// updated metadata graph (same response shape as `media_meta`). Core
+    /// validates the launcher exists and supports the row's system before
+    /// saving it.
+    pub async fn media_meta_update(
+        &self,
+        params: MediaMetaUpdateParams,
+    ) -> Result<MediaMetaResult, ClientError> {
+        let val = self.call("media.meta.update", &params).await?;
+        deserialize_timed("media.meta.update", val)
     }
 
     pub async fn media_history(

--- a/rust/zaparoo-core/src/media_types.rs
+++ b/rust/zaparoo-core/src/media_types.rs
@@ -676,6 +676,44 @@ impl MediaMetaParams {
     }
 }
 
+/// Parameters for `media.meta.update`. Identifies the media row the same
+/// way as `MediaMetaParams`; `media.launcher_override` is deliberately not
+/// `skip_serializing_if`-guarded, since Core requires the key present in
+/// every request (`null` to clear a stored override, a launcher ID to set
+/// one) and rejects a request that omits it entirely.
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MediaMetaUpdateParams {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub media_id: Option<i64>,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub system: String,
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub path: String,
+    pub media: MediaMetaUpdatePatch,
+}
+
+impl MediaMetaUpdateParams {
+    pub fn for_media(
+        system: impl Into<String>,
+        path: impl Into<String>,
+        launcher_override: Option<String>,
+    ) -> Self {
+        Self {
+            media_id: None,
+            system: system.into(),
+            path: path.into(),
+            media: MediaMetaUpdatePatch { launcher_override },
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MediaMetaUpdatePatch {
+    pub launcher_override: Option<String>,
+}
+
 pub const MEDIA_META_BATCH_MAX_ITEMS: usize = 100;
 
 /// Ordered batch request for `media.meta`. Core accepts one to 100 refs and
@@ -737,6 +775,11 @@ pub struct MediaMeta {
     pub properties: HashMap<String, MediaMetaProperty>,
     #[serde(default, deserialize_with = "deserialize_null_default")]
     pub available_image_types: Vec<String>,
+    /// Launcher ID stored for this media row, mirrored from
+    /// `property:launcher-override`. `None` when no override is stored;
+    /// Core omits the field entirely in that case.
+    #[serde(default)]
+    pub launcher_override: Option<String>,
     #[serde(default)]
     pub title: MediaMetaTitle,
 }
@@ -1313,11 +1356,11 @@ mod tests {
         MediaHistoryParams, MediaHistoryResult, MediaHistoryTopParams, MediaHistoryTopResult,
         MediaImageParams, MediaImageResult, MediaIndexParams, MediaItem, MediaLookupParams,
         MediaLookupResult, MediaMetaBatchParams, MediaMetaBatchResult, MediaMetaParams,
-        MediaMetaResult, MediaResult, MediaScrapeParams, MediaSearchParams, MediaSearchResult,
-        MediaTagsParams, MediaTagsResult, ReaderInfo, ReadersResult, ScrapersResult,
-        ScrapingStatusResponse, SettingsResult, SystemDefault, SystemsParams, SystemsResult,
-        TagInfo, TokensHistoryResult, TokensResult, UpdateSettingsParams, VersionResult,
-        MEDIA_IMAGE_DELIVERY_LOCAL_PATH, MEDIA_META_BATCH_MAX_ITEMS,
+        MediaMetaResult, MediaMetaUpdateParams, MediaResult, MediaScrapeParams, MediaSearchParams,
+        MediaSearchResult, MediaTagsParams, MediaTagsResult, ReaderInfo, ReadersResult,
+        ScrapersResult, ScrapingStatusResponse, SettingsResult, SystemDefault, SystemsParams,
+        SystemsResult, TagInfo, TokensHistoryResult, TokensResult, UpdateSettingsParams,
+        VersionResult, MEDIA_IMAGE_DELIVERY_LOCAL_PATH, MEDIA_META_BATCH_MAX_ITEMS,
     };
 
     #[test]
@@ -2220,6 +2263,72 @@ mod tests {
         let result: MediaMetaResult = serde_json::from_str(json).expect("parse");
         assert!(result.media.properties.is_empty());
         assert!(result.media.title.properties.is_empty());
+    }
+
+    #[test]
+    fn media_meta_launcher_override_parses_when_present() {
+        let json = r#"{
+            "media": {
+                "path": "/p", "parentDir": "/", "isMissing": false,
+                "tags": [], "properties": {}, "launcherOverride": "RetroArch",
+                "title": {
+                    "slug": "x", "name": "X", "slugLength": 1,
+                    "slugWordCount": 1, "system": {"id":"NES"},
+                    "tags": [], "properties": {}
+                }
+            }
+        }"#;
+        let result: MediaMetaResult = serde_json::from_str(json).expect("parse");
+        assert_eq!(result.media.launcher_override.as_deref(), Some("RetroArch"));
+    }
+
+    #[test]
+    fn media_meta_launcher_override_defaults_to_none_when_absent() {
+        let json = r#"{
+            "media": {
+                "path": "/p", "parentDir": "/", "isMissing": false,
+                "tags": [], "properties": {},
+                "title": {
+                    "slug": "x", "name": "X", "slugLength": 1,
+                    "slugWordCount": 1, "system": {"id":"NES"},
+                    "tags": [], "properties": {}
+                }
+            }
+        }"#;
+        let result: MediaMetaResult = serde_json::from_str(json).expect("parse");
+        assert!(result.media.launcher_override.is_none());
+    }
+
+    #[test]
+    fn media_meta_update_params_sets_launcher_override() {
+        let params =
+            MediaMetaUpdateParams::for_media("SNES", "/roms/snes/x.sfc", Some("RetroArch".into()));
+        let json = serde_json::to_value(&params).expect("serialise");
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "system": "SNES",
+                "path": "/roms/snes/x.sfc",
+                "media": {"launcherOverride": "RetroArch"}
+            })
+        );
+    }
+
+    #[test]
+    fn media_meta_update_params_clear_serialises_explicit_null() {
+        let params = MediaMetaUpdateParams::for_media("SNES", "/roms/snes/x.sfc", None);
+        let json = serde_json::to_value(&params).expect("serialise");
+        // Core rejects an update request that omits `launcherOverride`
+        // entirely, so the key must round-trip as an explicit `null`, not
+        // be dropped by a `skip_serializing_if`.
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "system": "SNES",
+                "path": "/roms/snes/x.sfc",
+                "media": {"launcherOverride": null}
+            })
+        );
     }
 
     #[test]

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -92,6 +92,13 @@ MainLayout {
     property string _pendingGameLauncherSystemId: ""
     property string _pendingGameLauncherPath: ""
     property string _pendingGameLauncherSelectionId: ""
+    // Set when "Change launcher" is accepted for a game while
+    // Browse.GameLauncherOverride.prepare_game (fired at context-menu open)
+    // hasn't resolved yet -- see handleContextMenuAccepted's games branch
+    // and the deferred-open Connections block below.
+    property bool _gameLauncherPickerPending: false
+    property string _gameLauncherPickerSystemId: ""
+    property string _gameLauncherPickerPath: ""
     property string cardWriteOwner: ""
     property int _cardWriteIndex: -1
     property string _gameInfoOwner: ""
@@ -2115,6 +2122,10 @@ MainLayout {
         function onLoadingChanged(): void {
             if (Browse.GameLauncherOverride.loading)
                 return;
+            if (root._gameLauncherPickerPending) {
+                root._gameLauncherPickerPending = false;
+                root._openGameLauncherPicker(root._gameLauncherPickerSystemId, root._gameLauncherPickerPath);
+            }
             if (!root.contextMenuVisible || root.contextMenuMode !== "main" || root.contextMenuOwner !== "games")
                 return;
             const currentGameLauncher = Browse.GameLauncherOverride.current_override;
@@ -2370,6 +2381,18 @@ MainLayout {
         return entries;
     }
 
+    // Opens the per-game launcher picker from Browse.GameLauncherOverride's
+    // current picker_ids/picker_labels/current_override. Callers must have
+    // already confirmed `!Browse.GameLauncherOverride.loading` -- see
+    // handleContextMenuAccepted's games "change_launcher" branch (opens
+    // immediately) and the deferred-open Connections block below (opens
+    // once a still-in-flight prepare_game resolves).
+    function _openGameLauncherPicker(gameSystemId: string, gamePath: string): void {
+        const entries = root._launcherPickerEntries(Browse.GameLauncherOverride.picker_ids, Browse.GameLauncherOverride.picker_labels);
+        if (entries.length > 0)
+            root.openListPickerModal(qsTr("Change launcher"), entries, Browse.GameLauncherOverride.current_override === "" ? "__default__" : Browse.GameLauncherOverride.current_override, "game_launcher:" + gameSystemId + "\n" + gamePath);
+    }
+
     // Relabels one row of a ListPickerModal entries array in place, id
     // unchanged. Used to show "Saving…" on just the row the user picked
     // while a launcher save is in flight -- every other row stays exactly
@@ -2570,8 +2593,14 @@ MainLayout {
         // after saving one).
         if (owner === "games" && entries.some(entry => entry.id === "change_launcher")) {
             const gamePath = Browse.GamesModel.path_at(index);
-            if (gamePath !== "")
+            if (gamePath !== "") {
+                // A pending deferred-open from a previous game's still-in-flight
+                // prepare_game (see the Browse.GameLauncherOverride Connections
+                // block) is now stale -- this prepare_game call supersedes it,
+                // same as the model's own sequence ticket does internally.
+                root._gameLauncherPickerPending = false;
                 Browse.GameLauncherOverride.prepare_game(systemId, gamePath);
+            }
         }
     }
 
@@ -2646,12 +2675,19 @@ MainLayout {
                 const gamePath = Browse.GamesModel.path_at(targetIndex);
                 if (gameSystemId === "" || gamePath === "")
                     return;
-                // picker_ids/picker_labels were already populated by
-                // openContextMenu's prepare_game call, so no second fetch
-                // is needed here.
-                const entries = root._launcherPickerEntries(Browse.GameLauncherOverride.picker_ids, Browse.GameLauncherOverride.picker_labels);
-                if (entries.length > 0)
-                    root.openListPickerModal(qsTr("Change launcher"), entries, Browse.GameLauncherOverride.current_override === "" ? "__default__" : Browse.GameLauncherOverride.current_override, "game_launcher:" + gameSystemId + "\n" + gamePath);
+                if (Browse.GameLauncherOverride.loading) {
+                    // openContextMenu's prepare_game call hasn't resolved
+                    // yet (a fast press, or Core busy elsewhere) --
+                    // picker_ids/picker_labels would still be empty. Wait
+                    // for it instead of opening nothing; the
+                    // Browse.GameLauncherOverride Connections below opens
+                    // the picker once loading clears.
+                    root._gameLauncherPickerPending = true;
+                    root._gameLauncherPickerSystemId = gameSystemId;
+                    root._gameLauncherPickerPath = gamePath;
+                    return;
+                }
+                root._openGameLauncherPicker(gameSystemId, gamePath);
                 return;
             }
             const systemId = Browse.SystemsModel.system_id_at(targetIndex);

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -89,6 +89,9 @@ MainLayout {
     property var _discoverParentEntries: []
     property string _pendingLauncherSystemId: ""
     property string _pendingLauncherSelectionId: ""
+    property string _pendingGameLauncherSystemId: ""
+    property string _pendingGameLauncherPath: ""
+    property string _pendingGameLauncherSelectionId: ""
     property string cardWriteOwner: ""
     property int _cardWriteIndex: -1
     property string _gameInfoOwner: ""
@@ -1819,6 +1822,12 @@ MainLayout {
                 // (SystemsModel.launch_at, GamesModel.launch_at, ...);
                 // the Hub just stays put and lets it happen.
                 Browse.HubLayout.run_script(id);
+                // Settle the push-in cue back to rest -- see
+                // HubScreen.releaseActivate()'s doc comment. Every other
+                // accept kind here navigates away and gets this for free
+                // via the screen's own settling reset.
+                if (root.hubScreen !== null)
+                    root.hubScreen.releaseActivate();
                 return;
             }
             // `system` and `folder` shortcuts land the user on Games having
@@ -1842,6 +1851,10 @@ MainLayout {
                 // an empty games browse.
                 if (Browse.SystemsModel.is_launchable_system(id)) {
                     Browse.SystemsModel.launch_system_id(id);
+                    // Settle the push-in cue back to rest -- same "stays
+                    // put" case as the zapscript branch above.
+                    if (root.hubScreen !== null)
+                        root.hubScreen.releaseActivate();
                     return;
                 }
                 root._navigateFromSystems(id, true);
@@ -2092,6 +2105,22 @@ MainLayout {
                 root.contextMenu.currentIndex = 0;
         }
     }
+    // Relabels the still-open games context menu's "Change launcher" entry
+    // once the one-row fetch `openContextMenu` kicked off resolves --
+    // Browse.GameLauncherOverride's own sequence ticket already discards a
+    // late response for a superseded game, so this only needs to confirm
+    // the menu is still showing a game's entries before relabeling.
+    Connections {
+        target: Browse.GameLauncherOverride
+        function onLoadingChanged(): void {
+            if (Browse.GameLauncherOverride.loading)
+                return;
+            if (!root.contextMenuVisible || root.contextMenuMode !== "main" || root.contextMenuOwner !== "games")
+                return;
+            const currentGameLauncher = Browse.GameLauncherOverride.current_override;
+            root._replaceContextMenuEntryLabel("change_launcher", currentGameLauncher !== "" ? qsTr("Change launcher: %1").arg(currentGameLauncher) : qsTr("Change launcher"), "change_launcher");
+        }
+    }
 
     // Pure helper — owner/entryType/mediaCapable/hasNfc/isFavorite → list of `{id,label}` entries.
     // Empty list = no menu (caller bails out of openContextMenu).
@@ -2122,9 +2151,10 @@ MainLayout {
                     label: qsTr("Random game")
                 });
             if (!launchable && !Browse.SystemLaunchers.loading && Browse.SystemLaunchers.error_message === "" && Browse.SystemLaunchers.launcher_count_for_system(systemId) > 0) {
+                const currentSystemLauncher = Browse.SystemLaunchers.current_launcher_for_system(systemId);
                 entries.push({
                     id: "change_launcher",
-                    label: qsTr("Change launcher")
+                    label: currentSystemLauncher !== "" ? qsTr("Change launcher: %1").arg(currentSystemLauncher) : qsTr("Change launcher")
                 });
             }
             entries.push({
@@ -2275,6 +2305,19 @@ MainLayout {
                     label: isFavorite ? qsTr("Remove from favorites") : qsTr("Add to favorites")
                 }
             ];
+            // Per-media launcher override -- Games only for now (see
+            // docs/content-style.md's "library" scope for this feature).
+            // Gated the same way as the system-level entry: launchers must
+            // be loaded and the game's system must have more than one to
+            // choose between. The label itself (with the current override
+            // name, if any) is filled in asynchronously once the context
+            // menu opens -- see openContextMenu's `prepare_game` call and
+            // the Browse.GameLauncherOverride Connections block below.
+            if (owner === "games" && !Browse.SystemLaunchers.loading && Browse.SystemLaunchers.error_message === "" && Browse.SystemLaunchers.launcher_count_for_system(systemId) > 0)
+                entries.push({
+                    id: "change_launcher",
+                    label: qsTr("Change launcher")
+                });
             if (hasNfc)
                 entries.push({
                     id: "write_card",
@@ -2305,6 +2348,41 @@ MainLayout {
     // hands the scanned zapscript back to a Core/frontend pairing.
     function _buildQrPayload(zapscript: string): string {
         return "https://zaparoo.app/write?v=" + encodeURIComponent(zapscript);
+    }
+
+    // Shared by the system- and game-scoped "Change launcher" pickers --
+    // both Browse.SystemLaunchers and Browse.GameLauncherOverride publish
+    // parallel picker_ids/picker_labels lists built by the same Rust
+    // `picker_entries_for_system` helper: "__default__" first (labelled
+    // "Default"), then each launcher id, then an optional synthetic
+    // "Current: <id>" row when the current value isn't in the launcher
+    // list. This just localizes those two special-cased labels.
+    function _launcherPickerEntries(ids: var, labels: var): var {
+        const entries = [];
+        for (let i = 0; i < ids.length; i++) {
+            const launcherId = ids[i];
+            const label = labels[i];
+            entries.push({
+                id: launcherId,
+                label: launcherId === "__default__" ? qsTr("Default") : (label.indexOf("Current: ") === 0 ? qsTr("Current: %1").arg(launcherId) : label)
+            });
+        }
+        return entries;
+    }
+
+    // Relabels one row of a ListPickerModal entries array in place, id
+    // unchanged. Used to show "Saving…" on just the row the user picked
+    // while a launcher save is in flight -- every other row stays exactly
+    // as it was, matching the picker's normal appearance rather than
+    // collapsing to a single placeholder row. The lock in handleAction's
+    // modalListPicker branch (grep "system_launcher_pending") is what
+    // actually stops Up/Down from moving focus off this row, or Accept/
+    // Cancel from doing anything, while pending.
+    function _relabelPickerEntry(entries: var, targetId: string, nextLabel: string): var {
+        return entries.map(entry => entry.id === targetId ? {
+            id: entry.id,
+            label: nextLabel
+        } : entry);
     }
 
     function _replaceContextMenuEntryLabel(targetId: string, nextLabel: string, nextId: string): void {
@@ -2478,6 +2556,23 @@ MainLayout {
         root.contextMenuVisible = true;
         if (ScreenManager.topModal !== root.modalContextMenu)
             ScreenManager.pushModal(root.modalContextMenu);
+        // Games' "Change launcher" entry starts with a plain label; prime
+        // the one-row fetch here so Browse.GameLauncherOverride.current_override
+        // is ready to relabel it in place (see the Connections block below)
+        // by the time the menu is likely to be looked at. Checking the
+        // built `entries` (rather than re-deriving the gating condition)
+        // keeps this in lockstep with buildContextMenuEntries' own gate.
+        // Must run after contextMenuVisible flips true: a warm cache
+        // resolves synchronously inside prepare_game, and the relabel
+        // Connections below only acts while contextMenuVisible is true --
+        // firing this earlier silently dropped the relabel on every
+        // reopen for a game whose override was already cached (e.g. right
+        // after saving one).
+        if (owner === "games" && entries.some(entry => entry.id === "change_launcher")) {
+            const gamePath = Browse.GamesModel.path_at(index);
+            if (gamePath !== "")
+                Browse.GameLauncherOverride.prepare_game(systemId, gamePath);
+        }
     }
 
     function handleContextMenuCloseRequested(): void {
@@ -2546,19 +2641,24 @@ MainLayout {
         }
         root.closeContextMenu();
         if (id === "change_launcher") {
+            if (owner === "games") {
+                const gameSystemId = Browse.GamesModel.system_id_at(targetIndex);
+                const gamePath = Browse.GamesModel.path_at(targetIndex);
+                if (gameSystemId === "" || gamePath === "")
+                    return;
+                // picker_ids/picker_labels were already populated by
+                // openContextMenu's prepare_game call, so no second fetch
+                // is needed here.
+                const entries = root._launcherPickerEntries(Browse.GameLauncherOverride.picker_ids, Browse.GameLauncherOverride.picker_labels);
+                if (entries.length > 0)
+                    root.openListPickerModal(qsTr("Change launcher"), entries, Browse.GameLauncherOverride.current_override === "" ? "__default__" : Browse.GameLauncherOverride.current_override, "game_launcher:" + gameSystemId + "\n" + gamePath);
+                return;
+            }
             const systemId = Browse.SystemsModel.system_id_at(targetIndex);
             if (systemId === "")
                 return;
             Browse.SystemLaunchers.prepare_system(systemId);
-            const entries = [];
-            for (let i = 0; i < Browse.SystemLaunchers.picker_ids.length; i++) {
-                const launcherId = Browse.SystemLaunchers.picker_ids[i];
-                const label = Browse.SystemLaunchers.picker_labels[i];
-                entries.push({
-                    id: launcherId,
-                    label: launcherId === "__default__" ? qsTr("Default") : (label.indexOf("Current: ") === 0 ? qsTr("Current: %1").arg(launcherId) : label)
-                });
-            }
+            const entries = root._launcherPickerEntries(Browse.SystemLaunchers.picker_ids, Browse.SystemLaunchers.picker_labels);
             if (entries.length > 0)
                 root.openListPickerModal(qsTr("Change launcher"), entries, Browse.SystemLaunchers.current_launcher, "system_launcher:" + systemId);
         } else if (id.startsWith("alternate_version:")) {
@@ -3550,35 +3650,63 @@ MainLayout {
 
     onCloseCrtCalibrationRequested: root.closeCrtCalibrationModal()
 
+    // Shared by the system- and game-scoped launcher saves below: only one
+    // of either can be in flight at a time (one ListPickerModal instance),
+    // so a single delay timer + relabel target covers both.
+    //
+    // The row keeps its normal label through `launcherSavingDelay`'s
+    // window and only switches to "Saving…" if the write is still pending
+    // once it elapses -- 300ms, the same threshold already used
+    // everywhere else a loading cue can show in this app
+    // (MainLayout.loadingIndicatorDelayMs, ScreenStateOverlay.loadingDelayMs).
+    // A save that completes inside that window never shows "Saving…" at
+    // all, so there's nothing to flash. No animation on the swap itself.
+    property string _pendingLauncherRelabelId: ""
+
+    Timer {
+        id: launcherSavingDelay
+        interval: 300
+        repeat: false
+        onTriggered: {
+            if (root._pendingLauncherRelabelId !== "")
+                root.listPickerEntries = root._relabelPickerEntry(root.listPickerEntries, root._pendingLauncherRelabelId, qsTr("Saving…"));
+        }
+    }
+
     function beginSystemLauncherUpdate(systemId: string, selectedId: string): void {
         root._pendingLauncherSystemId = systemId;
         root._pendingLauncherSelectionId = selectedId;
-        root.listPickerTitle = qsTr("Saving launcher");
-        root.listPickerEntries = [
-            {
-                id: "saving",
-                label: qsTr("Saving…")
-            }
-        ];
-        root.listPickerInitialId = "saving";
+        // Entries/title are untouched here -- the full list stays exactly
+        // as it was when the user pressed Accept. initialId still needs to
+        // move to the picked row now, ahead of the delayed relabel: that
+        // reassigns listPickerEntries, which re-derives currentIndex from
+        // initialId (see ListPickerModal's onEntriesChanged), and it would
+        // otherwise still be the old current launcher's id from when the
+        // picker first opened.
+        root.listPickerInitialId = selectedId;
         root.listPickerFieldId = "system_launcher_pending";
+        root._pendingLauncherRelabelId = selectedId;
+        launcherSavingDelay.restart();
         Browse.SystemLaunchers.set_system_launcher(systemId, selectedId);
     }
 
     function clearPendingLauncherUpdate(): void {
         root._pendingLauncherSystemId = "";
         root._pendingLauncherSelectionId = "";
+        launcherSavingDelay.stop();
+        root._pendingLauncherRelabelId = "";
     }
 
     function retrySystemLauncherUpdate(systemId: string, selectedId: string): void {
-        root.openListPickerModal(qsTr("Saving launcher"), [
-            {
-                id: "saving",
-                label: qsTr("Saving…")
-            }
-        ], "saving", "system_launcher_pending");
+        // The picker was closed for the error modal, so the full list is
+        // gone -- rebuild it the same way the original "Change launcher"
+        // open did, from the already-loaded picker_ids/picker_labels.
+        const entries = root._launcherPickerEntries(Browse.SystemLaunchers.picker_ids, Browse.SystemLaunchers.picker_labels);
+        root.openListPickerModal(qsTr("Change launcher"), entries, selectedId, "system_launcher_pending");
         root._pendingLauncherSystemId = systemId;
         root._pendingLauncherSelectionId = selectedId;
+        root._pendingLauncherRelabelId = selectedId;
+        launcherSavingDelay.restart();
         Browse.SystemLaunchers.set_system_launcher(systemId, selectedId);
     }
 
@@ -3592,8 +3720,53 @@ MainLayout {
         });
     }
 
+    // Per-game counterparts of the four functions above -- same "keep the
+    // full list, delay-then-relabel the picked row" shape, writing through
+    // Browse.GameLauncherOverride (media.meta.update) instead of
+    // Browse.SystemLaunchers (settings.update).
+    function beginGameLauncherUpdate(systemId: string, path: string, selectedId: string): void {
+        root._pendingGameLauncherSystemId = systemId;
+        root._pendingGameLauncherPath = path;
+        root._pendingGameLauncherSelectionId = selectedId;
+        root.listPickerInitialId = selectedId;
+        root.listPickerFieldId = "game_launcher_pending";
+        root._pendingLauncherRelabelId = selectedId;
+        launcherSavingDelay.restart();
+        Browse.GameLauncherOverride.set_game_launcher(systemId, path, selectedId);
+    }
+
+    function clearPendingGameLauncherUpdate(): void {
+        root._pendingGameLauncherSystemId = "";
+        root._pendingGameLauncherPath = "";
+        root._pendingGameLauncherSelectionId = "";
+        launcherSavingDelay.stop();
+        root._pendingLauncherRelabelId = "";
+    }
+
+    function retryGameLauncherUpdate(systemId: string, path: string, selectedId: string): void {
+        const entries = root._launcherPickerEntries(Browse.GameLauncherOverride.picker_ids, Browse.GameLauncherOverride.picker_labels);
+        root.openListPickerModal(qsTr("Change launcher"), entries, selectedId, "game_launcher_pending");
+        root._pendingGameLauncherSystemId = systemId;
+        root._pendingGameLauncherPath = path;
+        root._pendingGameLauncherSelectionId = selectedId;
+        root._pendingLauncherRelabelId = selectedId;
+        launcherSavingDelay.restart();
+        Browse.GameLauncherOverride.set_game_launcher(systemId, path, selectedId);
+    }
+
+    function showGameLauncherUpdateError(): void {
+        const systemId = root._pendingGameLauncherSystemId;
+        const path = root._pendingGameLauncherPath;
+        const selectedId = root._pendingGameLauncherSelectionId;
+        root.closeListPickerModal();
+        root.clearPendingGameLauncherUpdate();
+        root.presentActionError("game_launcher:" + systemId + "\n" + path, qsTr("Launcher update failed"), qsTr("Could not change the launcher. Check Zaparoo Core and try again."), qsTr("Retry"), function () {
+            root.retryGameLauncherUpdate(systemId, path, selectedId);
+        });
+    }
+
     function handleListPickerCloseRequested(): void {
-        if (root.listPickerFieldId === "system_launcher_pending")
+        if (root.listPickerFieldId === "system_launcher_pending" || root.listPickerFieldId === "game_launcher_pending")
             return;
         root.closeListPickerModal();
     }
@@ -3704,10 +3877,22 @@ MainLayout {
                 root.favoritesScreen.restoreSelection();
             return;
         }
-        if (fieldId === "system_launcher_pending")
+        if (fieldId === "system_launcher_pending" || fieldId === "game_launcher_pending")
             return;
         if (fieldId.startsWith("system_launcher:")) {
             root.beginSystemLauncherUpdate(fieldId.slice("system_launcher:".length), selectedId);
+            return;
+        }
+        if (fieldId.startsWith("game_launcher:")) {
+            // "game_launcher:<systemId>\n<path>" -- see openContextMenu's
+            // gameSystemId/gamePath pairing for why a newline separator is
+            // safe (system IDs never contain one; paths never contain a
+            // literal newline either).
+            const rest = fieldId.slice("game_launcher:".length);
+            const separatorIndex = rest.indexOf("\n");
+            if (separatorIndex < 0)
+                return;
+            root.beginGameLauncherUpdate(rest.slice(0, separatorIndex), rest.slice(separatorIndex + 1), selectedId);
             return;
         }
         // Round 10: nested picker opened by ScrapeSetupModal itself
@@ -3808,6 +3993,20 @@ MainLayout {
                 root.closeListPickerModal();
             } else {
                 root.showSystemLauncherUpdateError();
+            }
+        }
+    }
+
+    Connections {
+        target: Browse.GameLauncherOverride
+        function onUpdate_pendingChanged(): void {
+            if (root._pendingGameLauncherSystemId === "" || Browse.GameLauncherOverride.update_pending)
+                return;
+            if (Browse.GameLauncherOverride.update_error === "") {
+                root.clearPendingGameLauncherUpdate();
+                root.closeListPickerModal();
+            } else {
+                root.showGameLauncherUpdateError();
             }
         }
     }
@@ -4028,6 +4227,16 @@ MainLayout {
                 if (root.settingNeedsRestartModal !== null)
                     root.settingNeedsRestartModal.handleAction(action);
             } else if (ScreenManager.topModal === root.modalListPicker) {
+                // Locked while a launcher save is in flight -- no focus
+                // movement, no cancel, no resubmit. Accept/Cancel are
+                // already separately no-ops downstream once they reach
+                // onListPickerAccepted/handleListPickerCloseRequested (that
+                // still matters for a direct mouse click on a row, which
+                // bypasses this action routing entirely), but gating here
+                // too is what actually stops Up/Down from moving focus off
+                // the "Saving…" row.
+                if (root.listPickerFieldId === "system_launcher_pending" || root.listPickerFieldId === "game_launcher_pending")
+                    return;
                 if (action === "page_menu" && root._isViewListPicker(root.listPickerFieldId))
                     root.closeListPickerModal();
                 else if (root.listPickerModal !== null)

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -1356,6 +1356,17 @@ ApplicationWindow {
                                 label: qsTr("OK")
                             }
                         ];
+                    // A launcher save in flight locks the list picker on its
+                    // "Saving…" row (Main.qml's modalListPicker routing
+                    // branch swallows every action while this is true) --
+                    // Move/Select/Cancel would be false advertising, so swap
+                    // them for the same status text the row itself shows.
+                    if (root.listPickerModalVisible && (root.listPickerFieldId === "system_launcher_pending" || root.listPickerFieldId === "game_launcher_pending"))
+                        return [
+                            {
+                                label: qsTr("Saving…")
+                            }
+                        ];
                     if (root.quitConfirmModalVisible || root.settingNeedsRestartModalVisible || root.listPickerModalVisible || root.letterJumpModalVisible)
                         return [
                             {
@@ -1746,7 +1757,11 @@ ApplicationWindow {
                             required property var modelData
                             spacing: Sizing.pctW(0.6)
 
-                            readonly property var buttonList: helpEntry.modelData.buttons !== undefined ? helpEntry.modelData.buttons : [helpEntry.modelData.button]
+                            // A status-only entry (e.g. "Saving…" while a
+                            // pending save locks the list picker, below)
+                            // supplies neither `button` nor `buttons` --
+                            // renders as a bare label with no icon.
+                            readonly property var buttonList: helpEntry.modelData.buttons !== undefined ? helpEntry.modelData.buttons : (helpEntry.modelData.button !== undefined ? [helpEntry.modelData.button] : [])
 
                             Repeater {
                                 model: helpEntry.buttonList

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -1118,6 +1118,10 @@ ApplicationWindow {
                         title: root.listPickerTitle
                         entries: root.listPickerEntries
                         initialId: root.listPickerInitialId
+                        // A launcher save in flight locks the picker on
+                        // its "Saving…" row -- see ListPickerModal's own
+                        // `locked` doc comment.
+                        locked: root.listPickerFieldId === "system_launcher_pending" || root.listPickerFieldId === "game_launcher_pending"
                         onAccepted: id => root.listPickerAccepted(root.listPickerFieldId, id)
                         onCloseRequested: root.listPickerCloseRequested(root.listPickerFieldId)
                     }

--- a/src/ui/components/ListPickerModal.qml
+++ b/src/ui/components/ListPickerModal.qml
@@ -37,6 +37,13 @@ Item {
     // whose id matches. Empty string or no match falls back to 0.
     property string initialId: ""
     property int currentIndex: 0
+    // True while a caller-owned save is in flight and the picker must stay
+    // frozen on the row it's showing progress for. Disables each row's
+    // MouseArea entirely (hover-to-focus and click-to-accept both go
+    // through it) -- the keyboard/gamepad path is gated by the consumer
+    // not forwarding handleAction() at all while this is true (see
+    // Main.qml's modalListPicker routing branch).
+    property bool locked: false
 
     property int _activatePulse: 0
     property string _pendingId: ""
@@ -338,7 +345,9 @@ Item {
                             }
 
                             MouseArea {
+                                objectName: "listPickerRowMouseArea"
                                 anchors.fill: parent
+                                enabled: !modal.locked
                                 hoverEnabled: true
                                 acceptedButtons: Qt.LeftButton
                                 cursorShape: Qt.PointingHandCursor

--- a/src/ui/screens/HubScreen.qml
+++ b/src/ui/screens/HubScreen.qml
@@ -175,6 +175,9 @@ Item {
     // animation. Forwarded to the grid, which forwards it to every tile;
     // only the focused+selected Tile fires its animation.
     property int activatePulse: 0
+    // Incremented by releaseActivate() (below) to settle the push-in cue
+    // back to rest. Forwarded to the grid the same way activatePulse is.
+    property int releasePulse: 0
     // False until the user takes control of focus (first input). Combined
     // with `_restoreDone` into `_focusReady`, which gates whether the tiles
     // render focus at all.
@@ -1013,6 +1016,20 @@ Item {
         pressCommit.arm();
     }
 
+    // Settle the push-in cue back to rest. Only needed for accept kinds
+    // that keep Hub as the active screen -- a raw ZapScript shortcut, or a
+    // launch-only virtual system (Main.qml's onRequestAccept calls this
+    // right where it has already decided no screen transition is
+    // happening, mirroring the same split GamesScreen's own pressCommit
+    // makes between its folder-navigate and launch branches). Every other
+    // accept kind (category/system/folder navigation) leaves Hub and gets
+    // the cue reset for free via `screenSettling` (`!hub.visible`) --
+    // calling this there too would be harmless but pointless, so Main.qml
+    // only calls it for the two kinds that actually need it.
+    function releaseActivate(): void {
+        hub.releasePulse++;
+    }
+
     // ── Move (Options -> Move) ──────────────────────────────────────────
     // Armed by Main.qml's `hub_move` dispatch (see handleContextMenuAccepted
     // there). Board model, origin-anchored: every direction/page press
@@ -1434,6 +1451,7 @@ Item {
         skipEmptyCells: !hub.moveArmed
 
         activatePulse: hub.activatePulse
+        releasePulse: hub.releasePulse
         screenSettling: !hub.visible
         focusReady: hub._focusReady
 

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -683,86 +683,86 @@ Français - Wilfried</source>
         <translation type="vanished">تشغيل النواة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
-        <location filename="../app/Main.qml" line="2319"/>
-        <location filename="../app/Main.qml" line="2654"/>
-        <location filename="../app/Main.qml" line="2663"/>
-        <location filename="../app/Main.qml" line="3705"/>
-        <location filename="../app/Main.qml" line="3748"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2330"/>
+        <location filename="../app/Main.qml" line="2393"/>
+        <location filename="../app/Main.qml" line="2699"/>
+        <location filename="../app/Main.qml" line="3741"/>
+        <location filename="../app/Main.qml" line="3784"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2207"/>
+        <location filename="../app/Main.qml" line="2183"/>
+        <location filename="../app/Main.qml" line="2218"/>
         <source>Update media database</source>
         <translation type="unfinished">تحديث قاعدة بيانات الوسائط</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2175"/>
-        <location filename="../app/Main.qml" line="2210"/>
+        <location filename="../app/Main.qml" line="2186"/>
+        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">استخراج البيانات الوصفية</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1056"/>
+        <location filename="../app/Main.qml" line="1063"/>
         <source>Settings</source>
         <translation type="unfinished">الإعدادات</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2089"/>
+        <location filename="../app/Main.qml" line="2096"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2153"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2243"/>
-        <location filename="../app/Main.qml" line="2297"/>
+        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2308"/>
         <source>Launch game</source>
         <translation>تشغيل اللعبة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2247"/>
-        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2258"/>
+        <location filename="../app/Main.qml" line="2312"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2267"/>
-        <location filename="../app/Main.qml" line="2335"/>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2346"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Remove from favorites</source>
         <translation>إزالة من المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Add to favorites</source>
         <translation>أضف إلى المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2253"/>
-        <location filename="../app/Main.qml" line="2324"/>
+        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2335"/>
         <source>Write to NFC token</source>
         <translation>الكتابة إلى رمز NFC</translation>
     </message>
@@ -771,371 +771,371 @@ Français - Wilfried</source>
         <translation type="vanished">رمز QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Default</source>
         <translation type="unfinished">افتراضي</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="2378"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2151"/>
-        <location filename="../app/Main.qml" line="2202"/>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3364"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2230"/>
+        <location filename="../app/Main.qml" line="2238"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3396"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3432"/>
         <source>Favorites</source>
         <translation type="unfinished">المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1063"/>
-        <location filename="../app/Main.qml" line="3381"/>
-        <location filename="../app/Main.qml" line="3428"/>
-        <location filename="../app/Main.qml" line="3438"/>
+        <location filename="../app/Main.qml" line="1070"/>
+        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3464"/>
+        <location filename="../app/Main.qml" line="3474"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3409"/>
+        <location filename="../app/Main.qml" line="3445"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3406"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3475"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3511"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3428"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3479"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="3436"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1028"/>
+        <location filename="../app/Main.qml" line="1035"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1048"/>
+        <location filename="../app/Main.qml" line="1055"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1052"/>
+        <location filename="../app/Main.qml" line="1059"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="1067"/>
         <source>Quit</source>
         <translation type="unfinished">إنهاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2290"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2173"/>
+        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2350"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2257"/>
-        <location filename="../app/Main.qml" line="2328"/>
+        <location filename="../app/Main.qml" line="2268"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2461"/>
         <source>Move</source>
         <translation type="unfinished">تحريك</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2638"/>
+        <location filename="../app/Main.qml" line="2667"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
-        <location filename="../app/Main.qml" line="3007"/>
-        <location filename="../app/Main.qml" line="3029"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3095"/>
+        <location filename="../app/Main.qml" line="1032"/>
+        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3131"/>
         <source>OK</source>
         <translation type="unfinished">حسنًا</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3062"/>
+        <location filename="../app/Main.qml" line="3098"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3099"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3101"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3068"/>
+        <location filename="../app/Main.qml" line="3104"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3105"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3107"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3072"/>
+        <location filename="../app/Main.qml" line="3108"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3074"/>
+        <location filename="../app/Main.qml" line="3110"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3111"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3077"/>
+        <location filename="../app/Main.qml" line="3113"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3078"/>
+        <location filename="../app/Main.qml" line="3114"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3080"/>
+        <location filename="../app/Main.qml" line="3116"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3084"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3120"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3122"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3087"/>
+        <location filename="../app/Main.qml" line="3123"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3125"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3090"/>
+        <location filename="../app/Main.qml" line="3126"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3092"/>
+        <location filename="../app/Main.qml" line="3128"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3129"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3217"/>
+        <location filename="../app/Main.qml" line="3253"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3233"/>
+        <location filename="../app/Main.qml" line="3269"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3242"/>
+        <location filename="../app/Main.qml" line="3278"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3307"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
-        <location filename="../app/Main.qml" line="3425"/>
+        <location filename="../app/Main.qml" line="3415"/>
+        <location filename="../app/Main.qml" line="3461"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3413"/>
-        <location filename="../app/Main.qml" line="3435"/>
+        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3489"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3485"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3456"/>
+        <location filename="../app/Main.qml" line="3492"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3672"/>
+        <location filename="../app/Main.qml" line="3708"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3083"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3119"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
-        <location filename="../app/Main.qml" line="3282"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Retry</source>
         <translation type="unfinished">إعادة المحاولة</translation>
     </message>
@@ -1144,37 +1144,37 @@ Français - Wilfried</source>
         <translation type="obsolete">إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4812"/>
+        <location filename="../app/Main.qml" line="4848"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4814"/>
+        <location filename="../app/Main.qml" line="4850"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4816"/>
+        <location filename="../app/Main.qml" line="4852"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4819"/>
+        <location filename="../app/Main.qml" line="4855"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4821"/>
+        <location filename="../app/Main.qml" line="4857"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4823"/>
+        <location filename="../app/Main.qml" line="4859"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4825"/>
+        <location filename="../app/Main.qml" line="4861"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>
@@ -1254,19 +1254,19 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1480"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1585"/>
-        <location filename="../app/MainLayout.qml" line="1604"/>
-        <location filename="../app/MainLayout.qml" line="1677"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1454"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1540"/>
+        <location filename="../app/MainLayout.qml" line="1596"/>
+        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Move</source>
         <translation>تحريك</translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Select</source>
         <translation>تحديد</translation>
     </message>
@@ -1282,8 +1282,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="1290"/>
         <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1371"/>
-        <location filename="../app/MainLayout.qml" line="1414"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
@@ -1294,10 +1294,10 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1556"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1567"/>
+        <location filename="../app/MainLayout.qml" line="1716"/>
         <source>Retry</source>
         <translation>إعادة المحاولة</translation>
     </message>
@@ -1307,22 +1307,27 @@ Français - Wilfried</source>
         <translation>أفهم</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
+        <source>Saving…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="1389"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1417"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1331,11 +1336,11 @@ Français - Wilfried</source>
         <translation type="vanished">ابدأ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1485"/>
-        <location filename="../app/MainLayout.qml" line="1534"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1682"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1601"/>
+        <location filename="../app/MainLayout.qml" line="1693"/>
         <source>Open</source>
         <translation>فتح</translation>
     </message>
@@ -1344,28 +1349,28 @@ Français - Wilfried</source>
         <translation type="vanished">إنهاء</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1466"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1477"/>
         <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1518"/>
-        <location filename="../app/MainLayout.qml" line="1548"/>
-        <location filename="../app/MainLayout.qml" line="1566"/>
-        <location filename="../app/MainLayout.qml" line="1578"/>
-        <location filename="../app/MainLayout.qml" line="1594"/>
-        <location filename="../app/MainLayout.qml" line="1628"/>
-        <location filename="../app/MainLayout.qml" line="1649"/>
-        <location filename="../app/MainLayout.qml" line="1658"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
-        <location filename="../app/MainLayout.qml" line="1717"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1559"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1589"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1639"/>
+        <location filename="../app/MainLayout.qml" line="1660"/>
+        <location filename="../app/MainLayout.qml" line="1669"/>
+        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1728"/>
         <source>Back</source>
         <translation>رجوع</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1457"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1468"/>
+        <location filename="../app/MainLayout.qml" line="1555"/>
+        <location filename="../app/MainLayout.qml" line="1573"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1724"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1374,25 +1379,25 @@ Français - Wilfried</source>
         <translation type="vanished">صفحة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1488"/>
-        <location filename="../app/MainLayout.qml" line="1539"/>
-        <location filename="../app/MainLayout.qml" line="1687"/>
+        <location filename="../app/MainLayout.qml" line="1464"/>
+        <location filename="../app/MainLayout.qml" line="1499"/>
+        <location filename="../app/MainLayout.qml" line="1550"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
         <source>Options</source>
         <translation>الخيارات</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1613"/>
+        <location filename="../app/MainLayout.qml" line="1624"/>
         <source>Change</source>
         <translation>تغيير</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1619"/>
+        <location filename="../app/MainLayout.qml" line="1630"/>
         <source>Toggle</source>
         <translation>تبديل</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1645"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Scroll</source>
         <translation>تمرير</translation>
     </message>

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -527,23 +527,23 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
-        <location filename="../screens/HubScreen.qml" line="1288"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="1305"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>No recent games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>Resume: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="303"/>
         <source>Favorites</source>
         <translation>المفضلة</translation>
     </message>
@@ -552,32 +552,32 @@ Français - Wilfried</source>
         <translation type="vanished">تم لعبها مؤخرًا</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>No internet connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="352"/>
+        <location filename="../screens/HubScreen.qml" line="355"/>
         <source>Not available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="309"/>
+        <location filename="../screens/HubScreen.qml" line="312"/>
         <source>Settings</source>
         <translation>الإعدادات</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="302"/>
+        <location filename="../screens/HubScreen.qml" line="305"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1591"/>
+        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>لا توجد أنظمة متاحة. شغّل تحديث قاعدة بيانات الوسائط من الإعدادات.</translation>
     </message>
@@ -683,81 +683,86 @@ Français - Wilfried</source>
         <translation type="vanished">تشغيل النواة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2563"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2319"/>
+        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2663"/>
+        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3748"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2207"/>
         <source>Update media database</source>
         <translation type="unfinished">تحديث قاعدة بيانات الوسائط</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2145"/>
-        <location filename="../app/Main.qml" line="2180"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2210"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">استخراج البيانات الوصفية</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2166"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1053"/>
+        <location filename="../app/Main.qml" line="1056"/>
         <source>Settings</source>
         <translation type="unfinished">الإعدادات</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2076"/>
+        <location filename="../app/Main.qml" line="2089"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2142"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2243"/>
+        <location filename="../app/Main.qml" line="2297"/>
         <source>Launch game</source>
         <translation>تشغيل اللعبة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2217"/>
-        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2247"/>
+        <location filename="../app/Main.qml" line="2301"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2237"/>
-        <location filename="../app/Main.qml" line="2292"/>
-        <location filename="../app/Main.qml" line="2333"/>
+        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Remove from favorites</source>
         <translation>إزالة من المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Add to favorites</source>
         <translation>أضف إلى المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2281"/>
+        <location filename="../app/Main.qml" line="2253"/>
+        <location filename="../app/Main.qml" line="2324"/>
         <source>Write to NFC token</source>
         <translation>الكتابة إلى رمز NFC</translation>
     </message>
@@ -766,369 +771,371 @@ Français - Wilfried</source>
         <translation type="vanished">رمز QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3371"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Default</source>
         <translation type="unfinished">افتراضي</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="2367"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2122"/>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2189"/>
-        <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="3264"/>
+        <location filename="../app/Main.qml" line="2151"/>
+        <location filename="../app/Main.qml" line="2202"/>
+        <location filename="../app/Main.qml" line="2219"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3364"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3296"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3396"/>
         <source>Favorites</source>
         <translation type="unfinished">المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
-        <location filename="../app/Main.qml" line="3281"/>
-        <location filename="../app/Main.qml" line="3328"/>
-        <location filename="../app/Main.qml" line="3338"/>
+        <location filename="../app/Main.qml" line="1063"/>
+        <location filename="../app/Main.qml" line="3381"/>
+        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3438"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3309"/>
+        <location filename="../app/Main.qml" line="3409"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3370"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3375"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3475"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3292"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3479"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1028"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1045"/>
+        <location filename="../app/Main.qml" line="1048"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1049"/>
+        <location filename="../app/Main.qml" line="1052"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1057"/>
+        <location filename="../app/Main.qml" line="1060"/>
         <source>Quit</source>
         <translation type="unfinished">إنهاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2241"/>
-        <location filename="../app/Main.qml" line="2260"/>
-        <location filename="../app/Main.qml" line="2296"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2290"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="2285"/>
+        <location filename="../app/Main.qml" line="2257"/>
+        <location filename="../app/Main.qml" line="2328"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2360"/>
+        <location filename="../app/Main.qml" line="2438"/>
         <source>Move</source>
         <translation type="unfinished">تحريك</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2638"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
-        <location filename="../app/Main.qml" line="2907"/>
-        <location filename="../app/Main.qml" line="2929"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="3007"/>
+        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>OK</source>
         <translation type="unfinished">حسنًا</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <source>Change launcher: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3053"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2962"/>
+        <location filename="../app/Main.qml" line="3062"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2963"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2965"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2968"/>
+        <location filename="../app/Main.qml" line="3068"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2969"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2971"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2972"/>
+        <location filename="../app/Main.qml" line="3072"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2974"/>
+        <location filename="../app/Main.qml" line="3074"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2975"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2977"/>
+        <location filename="../app/Main.qml" line="3077"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2978"/>
+        <location filename="../app/Main.qml" line="3078"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2980"/>
+        <location filename="../app/Main.qml" line="3080"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2981"/>
+        <location filename="../app/Main.qml" line="3081"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2984"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3084"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2986"/>
+        <location filename="../app/Main.qml" line="3086"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2987"/>
+        <location filename="../app/Main.qml" line="3087"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2989"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2990"/>
+        <location filename="../app/Main.qml" line="3090"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2992"/>
+        <location filename="../app/Main.qml" line="3092"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3217"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3233"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3142"/>
+        <location filename="../app/Main.qml" line="3242"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3271"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3256"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
-        <location filename="../app/Main.qml" line="3325"/>
+        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3425"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3313"/>
-        <location filename="../app/Main.qml" line="3335"/>
+        <location filename="../app/Main.qml" line="3413"/>
+        <location filename="../app/Main.qml" line="3435"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3317"/>
+        <location filename="../app/Main.qml" line="3417"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3353"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3349"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3449"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3456"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3556"/>
-        <location filename="../app/Main.qml" line="3574"/>
-        <source>Saving launcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3560"/>
-        <location filename="../app/Main.qml" line="3577"/>
+        <location filename="../app/Main.qml" line="3672"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2983"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3083"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
-        <location filename="../app/Main.qml" line="3182"/>
-        <location filename="../app/Main.qml" line="3590"/>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Retry</source>
         <translation type="unfinished">إعادة المحاولة</translation>
     </message>
@@ -1137,37 +1144,37 @@ Français - Wilfried</source>
         <translation type="obsolete">إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4603"/>
+        <location filename="../app/Main.qml" line="4812"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4605"/>
+        <location filename="../app/Main.qml" line="4814"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4607"/>
+        <location filename="../app/Main.qml" line="4816"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4610"/>
+        <location filename="../app/Main.qml" line="4819"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4612"/>
+        <location filename="../app/Main.qml" line="4821"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4614"/>
+        <location filename="../app/Main.qml" line="4823"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4616"/>
+        <location filename="../app/Main.qml" line="4825"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>
@@ -1221,7 +1228,7 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
         <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
         <source>OK</source>
         <translation type="unfinished">حسنًا</translation>
     </message>
@@ -1246,76 +1253,76 @@ Français - Wilfried</source>
         <translation>هل أنت متأكد أنك تريد الخروج؟</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1271"/>
-        <location filename="../app/MainLayout.qml" line="1359"/>
-        <location filename="../app/MainLayout.qml" line="1439"/>
-        <location filename="../app/MainLayout.qml" line="1476"/>
-        <location filename="../app/MainLayout.qml" line="1525"/>
-        <location filename="../app/MainLayout.qml" line="1581"/>
-        <location filename="../app/MainLayout.qml" line="1600"/>
-        <location filename="../app/MainLayout.qml" line="1673"/>
+        <location filename="../app/MainLayout.qml" line="1275"/>
+        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1443"/>
+        <location filename="../app/MainLayout.qml" line="1480"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1585"/>
+        <location filename="../app/MainLayout.qml" line="1604"/>
+        <location filename="../app/MainLayout.qml" line="1677"/>
         <source>Move</source>
         <translation>تحريك</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1279"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
         <source>Select</source>
         <translation>تحديد</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1293"/>
-        <location filename="../app/MainLayout.qml" line="1308"/>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1345"/>
+        <location filename="../app/MainLayout.qml" line="1283"/>
+        <location filename="../app/MainLayout.qml" line="1297"/>
+        <location filename="../app/MainLayout.qml" line="1312"/>
+        <location filename="../app/MainLayout.qml" line="1323"/>
+        <location filename="../app/MainLayout.qml" line="1349"/>
         <source>Close</source>
         <translation>إغلاق</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1326"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1290"/>
+        <location filename="../app/MainLayout.qml" line="1330"/>
+        <location filename="../app/MainLayout.qml" line="1371"/>
+        <location filename="../app/MainLayout.qml" line="1414"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1304"/>
+        <location filename="../app/MainLayout.qml" line="1308"/>
         <source>Done</source>
         <translation>تم</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1315"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1494"/>
-        <location filename="../app/MainLayout.qml" line="1552"/>
-        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1319"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1498"/>
+        <location filename="../app/MainLayout.qml" line="1556"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
         <source>Retry</source>
         <translation>إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1334"/>
+        <location filename="../app/MainLayout.qml" line="1338"/>
         <source>I understand</source>
         <translation>أفهم</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1406"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1410"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1324,11 +1331,11 @@ Français - Wilfried</source>
         <translation type="vanished">ابدأ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1481"/>
-        <location filename="../app/MainLayout.qml" line="1530"/>
-        <location filename="../app/MainLayout.qml" line="1586"/>
-        <location filename="../app/MainLayout.qml" line="1678"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1590"/>
+        <location filename="../app/MainLayout.qml" line="1682"/>
         <source>Open</source>
         <translation>فتح</translation>
     </message>
@@ -1337,28 +1344,28 @@ Français - Wilfried</source>
         <translation type="vanished">إنهاء</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1462"/>
-        <location filename="../app/MainLayout.qml" line="1487"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1514"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1574"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1624"/>
-        <location filename="../app/MainLayout.qml" line="1645"/>
-        <location filename="../app/MainLayout.qml" line="1654"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1518"/>
+        <location filename="../app/MainLayout.qml" line="1548"/>
+        <location filename="../app/MainLayout.qml" line="1566"/>
+        <location filename="../app/MainLayout.qml" line="1578"/>
+        <location filename="../app/MainLayout.qml" line="1594"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1649"/>
+        <location filename="../app/MainLayout.qml" line="1658"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1717"/>
         <source>Back</source>
         <translation>رجوع</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1558"/>
-        <location filename="../app/MainLayout.qml" line="1690"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1544"/>
+        <location filename="../app/MainLayout.qml" line="1562"/>
+        <location filename="../app/MainLayout.qml" line="1694"/>
+        <location filename="../app/MainLayout.qml" line="1713"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1367,25 +1374,25 @@ Français - Wilfried</source>
         <translation type="vanished">صفحة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1449"/>
-        <location filename="../app/MainLayout.qml" line="1484"/>
-        <location filename="../app/MainLayout.qml" line="1535"/>
-        <location filename="../app/MainLayout.qml" line="1683"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
+        <location filename="../app/MainLayout.qml" line="1488"/>
+        <location filename="../app/MainLayout.qml" line="1539"/>
+        <location filename="../app/MainLayout.qml" line="1687"/>
         <source>Options</source>
         <translation>الخيارات</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1613"/>
         <source>Change</source>
         <translation>تغيير</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1619"/>
         <source>Toggle</source>
         <translation>تبديل</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1641"/>
+        <location filename="../app/MainLayout.qml" line="1645"/>
         <source>Scroll</source>
         <translation>تمرير</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -519,23 +519,23 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
-        <location filename="../screens/HubScreen.qml" line="1288"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="1305"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>No recent games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>Resume: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="303"/>
         <source>Favorites</source>
         <translation>Favoriten</translation>
     </message>
@@ -544,32 +544,32 @@ Français - Wilfried</source>
         <translation type="vanished">Zuletzt gespielt</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>No internet connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="352"/>
+        <location filename="../screens/HubScreen.qml" line="355"/>
         <source>Not available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="309"/>
+        <location filename="../screens/HubScreen.qml" line="312"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="302"/>
+        <location filename="../screens/HubScreen.qml" line="305"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1591"/>
+        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Keine Systeme verfügbar. Bitte Mediendatenbank unter Einstellungen aktualisieren.</translation>
     </message>
@@ -675,24 +675,29 @@ Français - Wilfried</source>
         <translation type="vanished">Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2563"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2319"/>
+        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2663"/>
+        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3748"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Remove from favorites</source>
         <translation>Aus Favoriten entfernen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Add to favorites</source>
         <translation>Zu Favoriten hinzufügen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2281"/>
+        <location filename="../app/Main.qml" line="2253"/>
+        <location filename="../app/Main.qml" line="2324"/>
         <source>Write to NFC token</source>
         <translation>Auf NFC-Token schreiben</translation>
     </message>
@@ -701,441 +706,443 @@ Français - Wilfried</source>
         <translation type="vanished">QR-Code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2243"/>
+        <location filename="../app/Main.qml" line="2297"/>
         <source>Launch game</source>
         <translation>Spiel starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
-        <location filename="../app/Main.qml" line="3281"/>
-        <location filename="../app/Main.qml" line="3328"/>
-        <location filename="../app/Main.qml" line="3338"/>
+        <location filename="../app/Main.qml" line="1063"/>
+        <location filename="../app/Main.qml" line="3381"/>
+        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3438"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3317"/>
+        <location filename="../app/Main.qml" line="3417"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4603"/>
+        <location filename="../app/Main.qml" line="4812"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4610"/>
+        <location filename="../app/Main.qml" line="4819"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4605"/>
+        <location filename="../app/Main.qml" line="4814"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2207"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediendatenbank aktualisieren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2145"/>
-        <location filename="../app/Main.qml" line="2180"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2210"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadaten abrufen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2166"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1053"/>
+        <location filename="../app/Main.qml" line="1056"/>
         <source>Settings</source>
         <translation type="unfinished">Einstellungen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2076"/>
+        <location filename="../app/Main.qml" line="2089"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2142"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2217"/>
-        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2247"/>
+        <location filename="../app/Main.qml" line="2301"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2237"/>
-        <location filename="../app/Main.qml" line="2292"/>
-        <location filename="../app/Main.qml" line="2333"/>
+        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3371"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Default</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="2367"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2122"/>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2189"/>
-        <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="3264"/>
+        <location filename="../app/Main.qml" line="2151"/>
+        <location filename="../app/Main.qml" line="2202"/>
+        <location filename="../app/Main.qml" line="2219"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3364"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3309"/>
+        <location filename="../app/Main.qml" line="3409"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3370"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3375"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3475"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3292"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3479"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1028"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1045"/>
+        <location filename="../app/Main.qml" line="1048"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1049"/>
+        <location filename="../app/Main.qml" line="1052"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1057"/>
+        <location filename="../app/Main.qml" line="1060"/>
         <source>Quit</source>
         <translation type="unfinished">Beenden</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2241"/>
-        <location filename="../app/Main.qml" line="2260"/>
-        <location filename="../app/Main.qml" line="2296"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2290"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="2285"/>
+        <location filename="../app/Main.qml" line="2257"/>
+        <location filename="../app/Main.qml" line="2328"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2360"/>
+        <location filename="../app/Main.qml" line="2438"/>
         <source>Move</source>
         <translation type="unfinished">Bewegen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2638"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
-        <location filename="../app/Main.qml" line="2907"/>
-        <location filename="../app/Main.qml" line="2929"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="3007"/>
+        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>OK</source>
         <translation type="unfinished">In Ordnung</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <source>Change launcher: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3053"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2962"/>
+        <location filename="../app/Main.qml" line="3062"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2963"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2965"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2968"/>
+        <location filename="../app/Main.qml" line="3068"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2969"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2971"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2972"/>
+        <location filename="../app/Main.qml" line="3072"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2974"/>
+        <location filename="../app/Main.qml" line="3074"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2975"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2977"/>
+        <location filename="../app/Main.qml" line="3077"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2978"/>
+        <location filename="../app/Main.qml" line="3078"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2980"/>
+        <location filename="../app/Main.qml" line="3080"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2981"/>
+        <location filename="../app/Main.qml" line="3081"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2984"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3084"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2986"/>
+        <location filename="../app/Main.qml" line="3086"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2987"/>
+        <location filename="../app/Main.qml" line="3087"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2989"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2990"/>
+        <location filename="../app/Main.qml" line="3090"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2992"/>
+        <location filename="../app/Main.qml" line="3092"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3217"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3233"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3142"/>
+        <location filename="../app/Main.qml" line="3242"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3271"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3256"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3296"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3396"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoriten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
-        <location filename="../app/Main.qml" line="3325"/>
+        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3425"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3313"/>
-        <location filename="../app/Main.qml" line="3335"/>
+        <location filename="../app/Main.qml" line="3413"/>
+        <location filename="../app/Main.qml" line="3435"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3353"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3349"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3449"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3456"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3556"/>
-        <location filename="../app/Main.qml" line="3574"/>
-        <source>Saving launcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3560"/>
-        <location filename="../app/Main.qml" line="3577"/>
+        <location filename="../app/Main.qml" line="3672"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2983"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3083"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
-        <location filename="../app/Main.qml" line="3182"/>
-        <location filename="../app/Main.qml" line="3590"/>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Retry</source>
         <translation type="unfinished">Wiederholen</translation>
     </message>
@@ -1144,22 +1151,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4607"/>
+        <location filename="../app/Main.qml" line="4816"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4612"/>
+        <location filename="../app/Main.qml" line="4821"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4614"/>
+        <location filename="../app/Main.qml" line="4823"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4616"/>
+        <location filename="../app/Main.qml" line="4825"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>
@@ -1188,7 +1195,7 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
         <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
         <source>OK</source>
         <translation type="unfinished">In Ordnung</translation>
     </message>
@@ -1208,45 +1215,45 @@ Français - Wilfried</source>
         <translation>Wirklich beenden?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1279"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
         <source>Select</source>
         <translation>Auswählen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1293"/>
-        <location filename="../app/MainLayout.qml" line="1308"/>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1345"/>
+        <location filename="../app/MainLayout.qml" line="1283"/>
+        <location filename="../app/MainLayout.qml" line="1297"/>
+        <location filename="../app/MainLayout.qml" line="1312"/>
+        <location filename="../app/MainLayout.qml" line="1323"/>
+        <location filename="../app/MainLayout.qml" line="1349"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1326"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1290"/>
+        <location filename="../app/MainLayout.qml" line="1330"/>
+        <location filename="../app/MainLayout.qml" line="1371"/>
+        <location filename="../app/MainLayout.qml" line="1414"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1304"/>
+        <location filename="../app/MainLayout.qml" line="1308"/>
         <source>Done</source>
         <translation>Fertig</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1334"/>
+        <location filename="../app/MainLayout.qml" line="1338"/>
         <source>I understand</source>
         <translation>Ich verstehe</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1255,28 +1262,28 @@ Français - Wilfried</source>
         <translation type="vanished">Starten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1641"/>
+        <location filename="../app/MainLayout.qml" line="1645"/>
         <source>Scroll</source>
         <translation>Scrollen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1558"/>
-        <location filename="../app/MainLayout.qml" line="1690"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1544"/>
+        <location filename="../app/MainLayout.qml" line="1562"/>
+        <location filename="../app/MainLayout.qml" line="1694"/>
+        <location filename="../app/MainLayout.qml" line="1713"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1271"/>
-        <location filename="../app/MainLayout.qml" line="1359"/>
-        <location filename="../app/MainLayout.qml" line="1439"/>
-        <location filename="../app/MainLayout.qml" line="1476"/>
-        <location filename="../app/MainLayout.qml" line="1525"/>
-        <location filename="../app/MainLayout.qml" line="1581"/>
-        <location filename="../app/MainLayout.qml" line="1600"/>
-        <location filename="../app/MainLayout.qml" line="1673"/>
+        <location filename="../app/MainLayout.qml" line="1275"/>
+        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1443"/>
+        <location filename="../app/MainLayout.qml" line="1480"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1585"/>
+        <location filename="../app/MainLayout.qml" line="1604"/>
+        <location filename="../app/MainLayout.qml" line="1677"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
@@ -1311,21 +1318,21 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1406"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1410"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1481"/>
-        <location filename="../app/MainLayout.qml" line="1530"/>
-        <location filename="../app/MainLayout.qml" line="1586"/>
-        <location filename="../app/MainLayout.qml" line="1678"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1590"/>
+        <location filename="../app/MainLayout.qml" line="1682"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
@@ -1334,19 +1341,19 @@ Français - Wilfried</source>
         <translation type="vanished">Beenden</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1462"/>
-        <location filename="../app/MainLayout.qml" line="1487"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1514"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1574"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1624"/>
-        <location filename="../app/MainLayout.qml" line="1645"/>
-        <location filename="../app/MainLayout.qml" line="1654"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1518"/>
+        <location filename="../app/MainLayout.qml" line="1548"/>
+        <location filename="../app/MainLayout.qml" line="1566"/>
+        <location filename="../app/MainLayout.qml" line="1578"/>
+        <location filename="../app/MainLayout.qml" line="1594"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1649"/>
+        <location filename="../app/MainLayout.qml" line="1658"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1717"/>
         <source>Back</source>
         <translation>Zurück</translation>
     </message>
@@ -1355,29 +1362,29 @@ Français - Wilfried</source>
         <translation type="vanished">Seite</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1449"/>
-        <location filename="../app/MainLayout.qml" line="1484"/>
-        <location filename="../app/MainLayout.qml" line="1535"/>
-        <location filename="../app/MainLayout.qml" line="1683"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
+        <location filename="../app/MainLayout.qml" line="1488"/>
+        <location filename="../app/MainLayout.qml" line="1539"/>
+        <location filename="../app/MainLayout.qml" line="1687"/>
         <source>Options</source>
         <translation>Optionen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1315"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1494"/>
-        <location filename="../app/MainLayout.qml" line="1552"/>
-        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1319"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1498"/>
+        <location filename="../app/MainLayout.qml" line="1556"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
         <source>Retry</source>
         <translation>Wiederholen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1613"/>
         <source>Change</source>
         <translation>Ändern</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1619"/>
         <source>Toggle</source>
         <translation>Umschalten</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -675,29 +675,29 @@ Français - Wilfried</source>
         <translation type="vanished">Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
-        <location filename="../app/Main.qml" line="2319"/>
-        <location filename="../app/Main.qml" line="2654"/>
-        <location filename="../app/Main.qml" line="2663"/>
-        <location filename="../app/Main.qml" line="3705"/>
-        <location filename="../app/Main.qml" line="3748"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2330"/>
+        <location filename="../app/Main.qml" line="2393"/>
+        <location filename="../app/Main.qml" line="2699"/>
+        <location filename="../app/Main.qml" line="3741"/>
+        <location filename="../app/Main.qml" line="3784"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Remove from favorites</source>
         <translation>Aus Favoriten entfernen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Add to favorites</source>
         <translation>Zu Favoriten hinzufügen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2253"/>
-        <location filename="../app/Main.qml" line="2324"/>
+        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2335"/>
         <source>Write to NFC token</source>
         <translation>Auf NFC-Token schreiben</translation>
     </message>
@@ -706,443 +706,443 @@ Français - Wilfried</source>
         <translation type="vanished">QR-Code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2243"/>
-        <location filename="../app/Main.qml" line="2297"/>
+        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2308"/>
         <source>Launch game</source>
         <translation>Spiel starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1063"/>
-        <location filename="../app/Main.qml" line="3381"/>
-        <location filename="../app/Main.qml" line="3428"/>
-        <location filename="../app/Main.qml" line="3438"/>
+        <location filename="../app/Main.qml" line="1070"/>
+        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3464"/>
+        <location filename="../app/Main.qml" line="3474"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4812"/>
+        <location filename="../app/Main.qml" line="4848"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4819"/>
+        <location filename="../app/Main.qml" line="4855"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4814"/>
+        <location filename="../app/Main.qml" line="4850"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2207"/>
+        <location filename="../app/Main.qml" line="2183"/>
+        <location filename="../app/Main.qml" line="2218"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediendatenbank aktualisieren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2175"/>
-        <location filename="../app/Main.qml" line="2210"/>
+        <location filename="../app/Main.qml" line="2186"/>
+        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadaten abrufen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1056"/>
+        <location filename="../app/Main.qml" line="1063"/>
         <source>Settings</source>
         <translation type="unfinished">Einstellungen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2089"/>
+        <location filename="../app/Main.qml" line="2096"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2153"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2247"/>
-        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2258"/>
+        <location filename="../app/Main.qml" line="2312"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2267"/>
-        <location filename="../app/Main.qml" line="2335"/>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2346"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Default</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="2378"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2151"/>
-        <location filename="../app/Main.qml" line="2202"/>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3364"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2230"/>
+        <location filename="../app/Main.qml" line="2238"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3409"/>
+        <location filename="../app/Main.qml" line="3445"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3406"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3475"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3511"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3428"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3479"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="3436"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1028"/>
+        <location filename="../app/Main.qml" line="1035"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1048"/>
+        <location filename="../app/Main.qml" line="1055"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1052"/>
+        <location filename="../app/Main.qml" line="1059"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="1067"/>
         <source>Quit</source>
         <translation type="unfinished">Beenden</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2290"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2173"/>
+        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2350"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2257"/>
-        <location filename="../app/Main.qml" line="2328"/>
+        <location filename="../app/Main.qml" line="2268"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2461"/>
         <source>Move</source>
         <translation type="unfinished">Bewegen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2638"/>
+        <location filename="../app/Main.qml" line="2667"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
-        <location filename="../app/Main.qml" line="3007"/>
-        <location filename="../app/Main.qml" line="3029"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3095"/>
+        <location filename="../app/Main.qml" line="1032"/>
+        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3131"/>
         <source>OK</source>
         <translation type="unfinished">In Ordnung</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3062"/>
+        <location filename="../app/Main.qml" line="3098"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3099"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3101"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3068"/>
+        <location filename="../app/Main.qml" line="3104"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3105"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3107"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3072"/>
+        <location filename="../app/Main.qml" line="3108"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3074"/>
+        <location filename="../app/Main.qml" line="3110"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3111"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3077"/>
+        <location filename="../app/Main.qml" line="3113"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3078"/>
+        <location filename="../app/Main.qml" line="3114"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3080"/>
+        <location filename="../app/Main.qml" line="3116"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3084"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3120"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3122"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3087"/>
+        <location filename="../app/Main.qml" line="3123"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3125"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3090"/>
+        <location filename="../app/Main.qml" line="3126"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3092"/>
+        <location filename="../app/Main.qml" line="3128"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3129"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3217"/>
+        <location filename="../app/Main.qml" line="3253"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3233"/>
+        <location filename="../app/Main.qml" line="3269"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3242"/>
+        <location filename="../app/Main.qml" line="3278"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3307"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3396"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3432"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoriten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
-        <location filename="../app/Main.qml" line="3425"/>
+        <location filename="../app/Main.qml" line="3415"/>
+        <location filename="../app/Main.qml" line="3461"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3413"/>
-        <location filename="../app/Main.qml" line="3435"/>
+        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3489"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3485"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3456"/>
+        <location filename="../app/Main.qml" line="3492"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3672"/>
+        <location filename="../app/Main.qml" line="3708"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3083"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3119"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
-        <location filename="../app/Main.qml" line="3282"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Retry</source>
         <translation type="unfinished">Wiederholen</translation>
     </message>
@@ -1151,22 +1151,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4816"/>
+        <location filename="../app/Main.qml" line="4852"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4821"/>
+        <location filename="../app/Main.qml" line="4857"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4823"/>
+        <location filename="../app/Main.qml" line="4859"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4825"/>
+        <location filename="../app/Main.qml" line="4861"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>
@@ -1216,7 +1216,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Select</source>
         <translation>Auswählen</translation>
     </message>
@@ -1232,8 +1232,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="1290"/>
         <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1371"/>
-        <location filename="../app/MainLayout.qml" line="1414"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
@@ -1248,12 +1248,17 @@ Français - Wilfried</source>
         <translation>Ich verstehe</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
+        <source>Saving…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="1389"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1262,28 +1267,28 @@ Français - Wilfried</source>
         <translation type="vanished">Starten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1645"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Scroll</source>
         <translation>Scrollen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1457"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1468"/>
+        <location filename="../app/MainLayout.qml" line="1555"/>
+        <location filename="../app/MainLayout.qml" line="1573"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1724"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1480"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1585"/>
-        <location filename="../app/MainLayout.qml" line="1604"/>
-        <location filename="../app/MainLayout.qml" line="1677"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1454"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1540"/>
+        <location filename="../app/MainLayout.qml" line="1596"/>
+        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
@@ -1318,21 +1323,21 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1417"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1485"/>
-        <location filename="../app/MainLayout.qml" line="1534"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1682"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1601"/>
+        <location filename="../app/MainLayout.qml" line="1693"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
@@ -1341,19 +1346,19 @@ Français - Wilfried</source>
         <translation type="vanished">Beenden</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1466"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1477"/>
         <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1518"/>
-        <location filename="../app/MainLayout.qml" line="1548"/>
-        <location filename="../app/MainLayout.qml" line="1566"/>
-        <location filename="../app/MainLayout.qml" line="1578"/>
-        <location filename="../app/MainLayout.qml" line="1594"/>
-        <location filename="../app/MainLayout.qml" line="1628"/>
-        <location filename="../app/MainLayout.qml" line="1649"/>
-        <location filename="../app/MainLayout.qml" line="1658"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
-        <location filename="../app/MainLayout.qml" line="1717"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1559"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1589"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1639"/>
+        <location filename="../app/MainLayout.qml" line="1660"/>
+        <location filename="../app/MainLayout.qml" line="1669"/>
+        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1728"/>
         <source>Back</source>
         <translation>Zurück</translation>
     </message>
@@ -1362,29 +1367,29 @@ Français - Wilfried</source>
         <translation type="vanished">Seite</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1488"/>
-        <location filename="../app/MainLayout.qml" line="1539"/>
-        <location filename="../app/MainLayout.qml" line="1687"/>
+        <location filename="../app/MainLayout.qml" line="1464"/>
+        <location filename="../app/MainLayout.qml" line="1499"/>
+        <location filename="../app/MainLayout.qml" line="1550"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
         <source>Options</source>
         <translation>Optionen</translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1556"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1567"/>
+        <location filename="../app/MainLayout.qml" line="1716"/>
         <source>Retry</source>
         <translation>Wiederholen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1613"/>
+        <location filename="../app/MainLayout.qml" line="1624"/>
         <source>Change</source>
         <translation>Ändern</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1619"/>
+        <location filename="../app/MainLayout.qml" line="1630"/>
         <source>Toggle</source>
         <translation>Umschalten</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -519,23 +519,23 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
-        <location filename="../screens/HubScreen.qml" line="1288"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="1305"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>No recent games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>Resume: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="303"/>
         <source>Favorites</source>
         <translation>Αγαπημένα</translation>
     </message>
@@ -544,32 +544,32 @@ Français - Wilfried</source>
         <translation type="vanished">Πρόσφατα Παιγμένα</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>No internet connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="352"/>
+        <location filename="../screens/HubScreen.qml" line="355"/>
         <source>Not available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="309"/>
+        <location filename="../screens/HubScreen.qml" line="312"/>
         <source>Settings</source>
         <translation>Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="302"/>
+        <location filename="../screens/HubScreen.qml" line="305"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1591"/>
+        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Δεν υπάρχουν διαθέσιμα συστήματα. Εκτελέστε Ενημέρωση βάσης δεδομένων από τις Ρυθμίσεις.</translation>
     </message>
@@ -675,24 +675,29 @@ Français - Wilfried</source>
         <translation type="vanished">Εκκίνηση Core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2563"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2319"/>
+        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2663"/>
+        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3748"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Remove from favorites</source>
         <translation>Αφαίρεση από αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Add to favorites</source>
         <translation>Προσθήκη στα αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2281"/>
+        <location filename="../app/Main.qml" line="2253"/>
+        <location filename="../app/Main.qml" line="2324"/>
         <source>Write to NFC token</source>
         <translation>Εγγραφή σε NFC token</translation>
     </message>
@@ -701,441 +706,443 @@ Français - Wilfried</source>
         <translation type="vanished">Κωδικός QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2243"/>
+        <location filename="../app/Main.qml" line="2297"/>
         <source>Launch game</source>
         <translation>Εκκίνηση παιχνιδιού</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
-        <location filename="../app/Main.qml" line="3281"/>
-        <location filename="../app/Main.qml" line="3328"/>
-        <location filename="../app/Main.qml" line="3338"/>
+        <location filename="../app/Main.qml" line="1063"/>
+        <location filename="../app/Main.qml" line="3381"/>
+        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3438"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3317"/>
+        <location filename="../app/Main.qml" line="3417"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4603"/>
+        <location filename="../app/Main.qml" line="4812"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4610"/>
+        <location filename="../app/Main.qml" line="4819"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4605"/>
+        <location filename="../app/Main.qml" line="4814"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2207"/>
         <source>Update media database</source>
         <translation type="unfinished">Ενημέρωση βάσης δεδομένων</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2145"/>
-        <location filename="../app/Main.qml" line="2180"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2210"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Ανάκτηση μεταδεδομένων</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2166"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1053"/>
+        <location filename="../app/Main.qml" line="1056"/>
         <source>Settings</source>
         <translation type="unfinished">Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2076"/>
+        <location filename="../app/Main.qml" line="2089"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2142"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2217"/>
-        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2247"/>
+        <location filename="../app/Main.qml" line="2301"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2237"/>
-        <location filename="../app/Main.qml" line="2292"/>
-        <location filename="../app/Main.qml" line="2333"/>
+        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3371"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Default</source>
         <translation type="unfinished">Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="2367"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2122"/>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2189"/>
-        <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="3264"/>
+        <location filename="../app/Main.qml" line="2151"/>
+        <location filename="../app/Main.qml" line="2202"/>
+        <location filename="../app/Main.qml" line="2219"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3364"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3309"/>
+        <location filename="../app/Main.qml" line="3409"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3370"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3375"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3475"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3292"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3479"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1028"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1045"/>
+        <location filename="../app/Main.qml" line="1048"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1049"/>
+        <location filename="../app/Main.qml" line="1052"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1057"/>
+        <location filename="../app/Main.qml" line="1060"/>
         <source>Quit</source>
         <translation type="unfinished">Έξοδος</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2241"/>
-        <location filename="../app/Main.qml" line="2260"/>
-        <location filename="../app/Main.qml" line="2296"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2290"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="2285"/>
+        <location filename="../app/Main.qml" line="2257"/>
+        <location filename="../app/Main.qml" line="2328"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2360"/>
+        <location filename="../app/Main.qml" line="2438"/>
         <source>Move</source>
         <translation type="unfinished">Μετακίνηση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2638"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
-        <location filename="../app/Main.qml" line="2907"/>
-        <location filename="../app/Main.qml" line="2929"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="3007"/>
+        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>OK</source>
         <translation type="unfinished">Εντάξει</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <source>Change launcher: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3053"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2962"/>
+        <location filename="../app/Main.qml" line="3062"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2963"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2965"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2968"/>
+        <location filename="../app/Main.qml" line="3068"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2969"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2971"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2972"/>
+        <location filename="../app/Main.qml" line="3072"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2974"/>
+        <location filename="../app/Main.qml" line="3074"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2975"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2977"/>
+        <location filename="../app/Main.qml" line="3077"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2978"/>
+        <location filename="../app/Main.qml" line="3078"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2980"/>
+        <location filename="../app/Main.qml" line="3080"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2981"/>
+        <location filename="../app/Main.qml" line="3081"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2984"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3084"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2986"/>
+        <location filename="../app/Main.qml" line="3086"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2987"/>
+        <location filename="../app/Main.qml" line="3087"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2989"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2990"/>
+        <location filename="../app/Main.qml" line="3090"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2992"/>
+        <location filename="../app/Main.qml" line="3092"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3217"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3233"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3142"/>
+        <location filename="../app/Main.qml" line="3242"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3271"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3256"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3296"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3396"/>
         <source>Favorites</source>
         <translation type="unfinished">Αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
-        <location filename="../app/Main.qml" line="3325"/>
+        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3425"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3313"/>
-        <location filename="../app/Main.qml" line="3335"/>
+        <location filename="../app/Main.qml" line="3413"/>
+        <location filename="../app/Main.qml" line="3435"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3353"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3349"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3449"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3456"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3556"/>
-        <location filename="../app/Main.qml" line="3574"/>
-        <source>Saving launcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3560"/>
-        <location filename="../app/Main.qml" line="3577"/>
+        <location filename="../app/Main.qml" line="3672"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2983"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3083"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
-        <location filename="../app/Main.qml" line="3182"/>
-        <location filename="../app/Main.qml" line="3590"/>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Retry</source>
         <translation type="unfinished">Επανάληψη</translation>
     </message>
@@ -1144,22 +1151,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4607"/>
+        <location filename="../app/Main.qml" line="4816"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4612"/>
+        <location filename="../app/Main.qml" line="4821"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4614"/>
+        <location filename="../app/Main.qml" line="4823"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4616"/>
+        <location filename="../app/Main.qml" line="4825"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>
@@ -1188,7 +1195,7 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
         <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
         <source>OK</source>
         <translation type="unfinished">Εντάξει</translation>
     </message>
@@ -1208,45 +1215,45 @@ Français - Wilfried</source>
         <translation>Είστε σίγουροι ότι θέλετε να βγείτε;</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1279"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
         <source>Select</source>
         <translation>Επιλογή</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1293"/>
-        <location filename="../app/MainLayout.qml" line="1308"/>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1345"/>
+        <location filename="../app/MainLayout.qml" line="1283"/>
+        <location filename="../app/MainLayout.qml" line="1297"/>
+        <location filename="../app/MainLayout.qml" line="1312"/>
+        <location filename="../app/MainLayout.qml" line="1323"/>
+        <location filename="../app/MainLayout.qml" line="1349"/>
         <source>Close</source>
         <translation>Κλείσιμο</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1326"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1290"/>
+        <location filename="../app/MainLayout.qml" line="1330"/>
+        <location filename="../app/MainLayout.qml" line="1371"/>
+        <location filename="../app/MainLayout.qml" line="1414"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1304"/>
+        <location filename="../app/MainLayout.qml" line="1308"/>
         <source>Done</source>
         <translation>Ολοκληρώθηκε</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1334"/>
+        <location filename="../app/MainLayout.qml" line="1338"/>
         <source>I understand</source>
         <translation>Κατανοώ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1255,28 +1262,28 @@ Français - Wilfried</source>
         <translation type="vanished">Έναρξη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1641"/>
+        <location filename="../app/MainLayout.qml" line="1645"/>
         <source>Scroll</source>
         <translation>Κύλιση</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1558"/>
-        <location filename="../app/MainLayout.qml" line="1690"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1544"/>
+        <location filename="../app/MainLayout.qml" line="1562"/>
+        <location filename="../app/MainLayout.qml" line="1694"/>
+        <location filename="../app/MainLayout.qml" line="1713"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1271"/>
-        <location filename="../app/MainLayout.qml" line="1359"/>
-        <location filename="../app/MainLayout.qml" line="1439"/>
-        <location filename="../app/MainLayout.qml" line="1476"/>
-        <location filename="../app/MainLayout.qml" line="1525"/>
-        <location filename="../app/MainLayout.qml" line="1581"/>
-        <location filename="../app/MainLayout.qml" line="1600"/>
-        <location filename="../app/MainLayout.qml" line="1673"/>
+        <location filename="../app/MainLayout.qml" line="1275"/>
+        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1443"/>
+        <location filename="../app/MainLayout.qml" line="1480"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1585"/>
+        <location filename="../app/MainLayout.qml" line="1604"/>
+        <location filename="../app/MainLayout.qml" line="1677"/>
         <source>Move</source>
         <translation>Μετακίνηση</translation>
     </message>
@@ -1311,21 +1318,21 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1406"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1410"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1481"/>
-        <location filename="../app/MainLayout.qml" line="1530"/>
-        <location filename="../app/MainLayout.qml" line="1586"/>
-        <location filename="../app/MainLayout.qml" line="1678"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1590"/>
+        <location filename="../app/MainLayout.qml" line="1682"/>
         <source>Open</source>
         <translation>Άνοιγμα</translation>
     </message>
@@ -1334,19 +1341,19 @@ Français - Wilfried</source>
         <translation type="vanished">Έξοδος</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1462"/>
-        <location filename="../app/MainLayout.qml" line="1487"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1514"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1574"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1624"/>
-        <location filename="../app/MainLayout.qml" line="1645"/>
-        <location filename="../app/MainLayout.qml" line="1654"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1518"/>
+        <location filename="../app/MainLayout.qml" line="1548"/>
+        <location filename="../app/MainLayout.qml" line="1566"/>
+        <location filename="../app/MainLayout.qml" line="1578"/>
+        <location filename="../app/MainLayout.qml" line="1594"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1649"/>
+        <location filename="../app/MainLayout.qml" line="1658"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1717"/>
         <source>Back</source>
         <translation>Πίσω</translation>
     </message>
@@ -1355,29 +1362,29 @@ Français - Wilfried</source>
         <translation type="vanished">Σελίδα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1449"/>
-        <location filename="../app/MainLayout.qml" line="1484"/>
-        <location filename="../app/MainLayout.qml" line="1535"/>
-        <location filename="../app/MainLayout.qml" line="1683"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
+        <location filename="../app/MainLayout.qml" line="1488"/>
+        <location filename="../app/MainLayout.qml" line="1539"/>
+        <location filename="../app/MainLayout.qml" line="1687"/>
         <source>Options</source>
         <translation>Επιλογές</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1315"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1494"/>
-        <location filename="../app/MainLayout.qml" line="1552"/>
-        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1319"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1498"/>
+        <location filename="../app/MainLayout.qml" line="1556"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
         <source>Retry</source>
         <translation>Επανάληψη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1613"/>
         <source>Change</source>
         <translation>Αλλαγή</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1619"/>
         <source>Toggle</source>
         <translation>Εναλλαγή</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -675,29 +675,29 @@ Français - Wilfried</source>
         <translation type="vanished">Εκκίνηση Core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
-        <location filename="../app/Main.qml" line="2319"/>
-        <location filename="../app/Main.qml" line="2654"/>
-        <location filename="../app/Main.qml" line="2663"/>
-        <location filename="../app/Main.qml" line="3705"/>
-        <location filename="../app/Main.qml" line="3748"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2330"/>
+        <location filename="../app/Main.qml" line="2393"/>
+        <location filename="../app/Main.qml" line="2699"/>
+        <location filename="../app/Main.qml" line="3741"/>
+        <location filename="../app/Main.qml" line="3784"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Remove from favorites</source>
         <translation>Αφαίρεση από αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Add to favorites</source>
         <translation>Προσθήκη στα αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2253"/>
-        <location filename="../app/Main.qml" line="2324"/>
+        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2335"/>
         <source>Write to NFC token</source>
         <translation>Εγγραφή σε NFC token</translation>
     </message>
@@ -706,443 +706,443 @@ Français - Wilfried</source>
         <translation type="vanished">Κωδικός QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2243"/>
-        <location filename="../app/Main.qml" line="2297"/>
+        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2308"/>
         <source>Launch game</source>
         <translation>Εκκίνηση παιχνιδιού</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1063"/>
-        <location filename="../app/Main.qml" line="3381"/>
-        <location filename="../app/Main.qml" line="3428"/>
-        <location filename="../app/Main.qml" line="3438"/>
+        <location filename="../app/Main.qml" line="1070"/>
+        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3464"/>
+        <location filename="../app/Main.qml" line="3474"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4812"/>
+        <location filename="../app/Main.qml" line="4848"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4819"/>
+        <location filename="../app/Main.qml" line="4855"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4814"/>
+        <location filename="../app/Main.qml" line="4850"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2207"/>
+        <location filename="../app/Main.qml" line="2183"/>
+        <location filename="../app/Main.qml" line="2218"/>
         <source>Update media database</source>
         <translation type="unfinished">Ενημέρωση βάσης δεδομένων</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2175"/>
-        <location filename="../app/Main.qml" line="2210"/>
+        <location filename="../app/Main.qml" line="2186"/>
+        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Ανάκτηση μεταδεδομένων</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1056"/>
+        <location filename="../app/Main.qml" line="1063"/>
         <source>Settings</source>
         <translation type="unfinished">Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2089"/>
+        <location filename="../app/Main.qml" line="2096"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2153"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2247"/>
-        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2258"/>
+        <location filename="../app/Main.qml" line="2312"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2267"/>
-        <location filename="../app/Main.qml" line="2335"/>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2346"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Default</source>
         <translation type="unfinished">Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="2378"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2151"/>
-        <location filename="../app/Main.qml" line="2202"/>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3364"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2230"/>
+        <location filename="../app/Main.qml" line="2238"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3409"/>
+        <location filename="../app/Main.qml" line="3445"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3406"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3475"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3511"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3428"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3479"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="3436"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1028"/>
+        <location filename="../app/Main.qml" line="1035"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1048"/>
+        <location filename="../app/Main.qml" line="1055"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1052"/>
+        <location filename="../app/Main.qml" line="1059"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="1067"/>
         <source>Quit</source>
         <translation type="unfinished">Έξοδος</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2290"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2173"/>
+        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2350"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2257"/>
-        <location filename="../app/Main.qml" line="2328"/>
+        <location filename="../app/Main.qml" line="2268"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2461"/>
         <source>Move</source>
         <translation type="unfinished">Μετακίνηση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2638"/>
+        <location filename="../app/Main.qml" line="2667"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
-        <location filename="../app/Main.qml" line="3007"/>
-        <location filename="../app/Main.qml" line="3029"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3095"/>
+        <location filename="../app/Main.qml" line="1032"/>
+        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3131"/>
         <source>OK</source>
         <translation type="unfinished">Εντάξει</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3062"/>
+        <location filename="../app/Main.qml" line="3098"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3099"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3101"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3068"/>
+        <location filename="../app/Main.qml" line="3104"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3105"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3107"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3072"/>
+        <location filename="../app/Main.qml" line="3108"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3074"/>
+        <location filename="../app/Main.qml" line="3110"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3111"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3077"/>
+        <location filename="../app/Main.qml" line="3113"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3078"/>
+        <location filename="../app/Main.qml" line="3114"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3080"/>
+        <location filename="../app/Main.qml" line="3116"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3084"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3120"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3122"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3087"/>
+        <location filename="../app/Main.qml" line="3123"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3125"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3090"/>
+        <location filename="../app/Main.qml" line="3126"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3092"/>
+        <location filename="../app/Main.qml" line="3128"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3129"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3217"/>
+        <location filename="../app/Main.qml" line="3253"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3233"/>
+        <location filename="../app/Main.qml" line="3269"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3242"/>
+        <location filename="../app/Main.qml" line="3278"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3307"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3396"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3432"/>
         <source>Favorites</source>
         <translation type="unfinished">Αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
-        <location filename="../app/Main.qml" line="3425"/>
+        <location filename="../app/Main.qml" line="3415"/>
+        <location filename="../app/Main.qml" line="3461"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3413"/>
-        <location filename="../app/Main.qml" line="3435"/>
+        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3489"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3485"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3456"/>
+        <location filename="../app/Main.qml" line="3492"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3672"/>
+        <location filename="../app/Main.qml" line="3708"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3083"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3119"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
-        <location filename="../app/Main.qml" line="3282"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Retry</source>
         <translation type="unfinished">Επανάληψη</translation>
     </message>
@@ -1151,22 +1151,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4816"/>
+        <location filename="../app/Main.qml" line="4852"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4821"/>
+        <location filename="../app/Main.qml" line="4857"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4823"/>
+        <location filename="../app/Main.qml" line="4859"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4825"/>
+        <location filename="../app/Main.qml" line="4861"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>
@@ -1216,7 +1216,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Select</source>
         <translation>Επιλογή</translation>
     </message>
@@ -1232,8 +1232,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="1290"/>
         <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1371"/>
-        <location filename="../app/MainLayout.qml" line="1414"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
@@ -1248,12 +1248,17 @@ Français - Wilfried</source>
         <translation>Κατανοώ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
+        <source>Saving…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="1389"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1262,28 +1267,28 @@ Français - Wilfried</source>
         <translation type="vanished">Έναρξη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1645"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Scroll</source>
         <translation>Κύλιση</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1457"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1468"/>
+        <location filename="../app/MainLayout.qml" line="1555"/>
+        <location filename="../app/MainLayout.qml" line="1573"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1724"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1480"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1585"/>
-        <location filename="../app/MainLayout.qml" line="1604"/>
-        <location filename="../app/MainLayout.qml" line="1677"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1454"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1540"/>
+        <location filename="../app/MainLayout.qml" line="1596"/>
+        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Move</source>
         <translation>Μετακίνηση</translation>
     </message>
@@ -1318,21 +1323,21 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1417"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1485"/>
-        <location filename="../app/MainLayout.qml" line="1534"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1682"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1601"/>
+        <location filename="../app/MainLayout.qml" line="1693"/>
         <source>Open</source>
         <translation>Άνοιγμα</translation>
     </message>
@@ -1341,19 +1346,19 @@ Français - Wilfried</source>
         <translation type="vanished">Έξοδος</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1466"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1477"/>
         <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1518"/>
-        <location filename="../app/MainLayout.qml" line="1548"/>
-        <location filename="../app/MainLayout.qml" line="1566"/>
-        <location filename="../app/MainLayout.qml" line="1578"/>
-        <location filename="../app/MainLayout.qml" line="1594"/>
-        <location filename="../app/MainLayout.qml" line="1628"/>
-        <location filename="../app/MainLayout.qml" line="1649"/>
-        <location filename="../app/MainLayout.qml" line="1658"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
-        <location filename="../app/MainLayout.qml" line="1717"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1559"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1589"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1639"/>
+        <location filename="../app/MainLayout.qml" line="1660"/>
+        <location filename="../app/MainLayout.qml" line="1669"/>
+        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1728"/>
         <source>Back</source>
         <translation>Πίσω</translation>
     </message>
@@ -1362,29 +1367,29 @@ Français - Wilfried</source>
         <translation type="vanished">Σελίδα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1488"/>
-        <location filename="../app/MainLayout.qml" line="1539"/>
-        <location filename="../app/MainLayout.qml" line="1687"/>
+        <location filename="../app/MainLayout.qml" line="1464"/>
+        <location filename="../app/MainLayout.qml" line="1499"/>
+        <location filename="../app/MainLayout.qml" line="1550"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
         <source>Options</source>
         <translation>Επιλογές</translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1556"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1567"/>
+        <location filename="../app/MainLayout.qml" line="1716"/>
         <source>Retry</source>
         <translation>Επανάληψη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1613"/>
+        <location filename="../app/MainLayout.qml" line="1624"/>
         <source>Change</source>
         <translation>Αλλαγή</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1619"/>
+        <location filename="../app/MainLayout.qml" line="1630"/>
         <source>Toggle</source>
         <translation>Εναλλαγή</translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -589,470 +589,470 @@ Français - Wilfried</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
-        <location filename="../app/Main.qml" line="2319"/>
-        <location filename="../app/Main.qml" line="2654"/>
-        <location filename="../app/Main.qml" line="2663"/>
-        <location filename="../app/Main.qml" line="3705"/>
-        <location filename="../app/Main.qml" line="3748"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2330"/>
+        <location filename="../app/Main.qml" line="2393"/>
+        <location filename="../app/Main.qml" line="2699"/>
+        <location filename="../app/Main.qml" line="3741"/>
+        <location filename="../app/Main.qml" line="3784"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Add to favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2253"/>
-        <location filename="../app/Main.qml" line="2324"/>
+        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2335"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Write to NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2243"/>
-        <location filename="../app/Main.qml" line="2297"/>
+        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2308"/>
         <source>Launch game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1063"/>
-        <location filename="../app/Main.qml" line="3381"/>
-        <location filename="../app/Main.qml" line="3428"/>
-        <location filename="../app/Main.qml" line="3438"/>
+        <location filename="../app/Main.qml" line="1070"/>
+        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3464"/>
+        <location filename="../app/Main.qml" line="3474"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4812"/>
+        <location filename="../app/Main.qml" line="4848"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4819"/>
+        <location filename="../app/Main.qml" line="4855"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4814"/>
+        <location filename="../app/Main.qml" line="4850"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2207"/>
+        <location filename="../app/Main.qml" line="2183"/>
+        <location filename="../app/Main.qml" line="2218"/>
         <source>Update media database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2175"/>
-        <location filename="../app/Main.qml" line="2210"/>
+        <location filename="../app/Main.qml" line="2186"/>
+        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1056"/>
+        <location filename="../app/Main.qml" line="1063"/>
         <source>Settings</source>
         <translation type="unfinished">Settings</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2089"/>
+        <location filename="../app/Main.qml" line="2096"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2153"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2247"/>
-        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2258"/>
+        <location filename="../app/Main.qml" line="2312"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2267"/>
-        <location filename="../app/Main.qml" line="2335"/>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2346"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="2378"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2151"/>
-        <location filename="../app/Main.qml" line="2202"/>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3364"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2230"/>
+        <location filename="../app/Main.qml" line="2238"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3409"/>
+        <location filename="../app/Main.qml" line="3445"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3406"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3475"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3511"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3428"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3479"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="3436"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1028"/>
+        <location filename="../app/Main.qml" line="1035"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1048"/>
+        <location filename="../app/Main.qml" line="1055"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1052"/>
+        <location filename="../app/Main.qml" line="1059"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="1067"/>
         <source>Quit</source>
         <translation type="unfinished">Quit</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2290"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2173"/>
+        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2350"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2257"/>
-        <location filename="../app/Main.qml" line="2328"/>
+        <location filename="../app/Main.qml" line="2268"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2461"/>
         <source>Move</source>
         <translation type="unfinished">Move</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2638"/>
+        <location filename="../app/Main.qml" line="2667"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
-        <location filename="../app/Main.qml" line="3007"/>
-        <location filename="../app/Main.qml" line="3029"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3095"/>
+        <location filename="../app/Main.qml" line="1032"/>
+        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3131"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3062"/>
+        <location filename="../app/Main.qml" line="3098"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3099"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3101"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3068"/>
+        <location filename="../app/Main.qml" line="3104"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3105"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3107"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3072"/>
+        <location filename="../app/Main.qml" line="3108"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3074"/>
+        <location filename="../app/Main.qml" line="3110"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3111"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3077"/>
+        <location filename="../app/Main.qml" line="3113"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3078"/>
+        <location filename="../app/Main.qml" line="3114"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3080"/>
+        <location filename="../app/Main.qml" line="3116"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3084"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3120"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3122"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3087"/>
+        <location filename="../app/Main.qml" line="3123"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3125"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3090"/>
+        <location filename="../app/Main.qml" line="3126"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3092"/>
+        <location filename="../app/Main.qml" line="3128"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3129"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3217"/>
+        <location filename="../app/Main.qml" line="3253"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3233"/>
+        <location filename="../app/Main.qml" line="3269"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3242"/>
+        <location filename="../app/Main.qml" line="3278"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3307"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3396"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3432"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorites</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
-        <location filename="../app/Main.qml" line="3425"/>
+        <location filename="../app/Main.qml" line="3415"/>
+        <location filename="../app/Main.qml" line="3461"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3413"/>
-        <location filename="../app/Main.qml" line="3435"/>
+        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3489"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3485"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3456"/>
+        <location filename="../app/Main.qml" line="3492"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3672"/>
+        <location filename="../app/Main.qml" line="3708"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3083"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3119"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
-        <location filename="../app/Main.qml" line="3282"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Retry</source>
         <translation type="unfinished">Retry</translation>
     </message>
@@ -1061,22 +1061,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Cancel</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4816"/>
+        <location filename="../app/Main.qml" line="4852"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4821"/>
+        <location filename="../app/Main.qml" line="4857"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4823"/>
+        <location filename="../app/Main.qml" line="4859"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4825"/>
+        <location filename="../app/Main.qml" line="4861"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>
@@ -1126,7 +1126,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Select</source>
         <translation>Select</translation>
     </message>
@@ -1142,8 +1142,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="1290"/>
         <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1371"/>
-        <location filename="../app/MainLayout.qml" line="1414"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
@@ -1158,48 +1158,53 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
+        <source>Saving…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="1389"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1417"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1645"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Scroll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1457"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1468"/>
+        <location filename="../app/MainLayout.qml" line="1555"/>
+        <location filename="../app/MainLayout.qml" line="1573"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1724"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1480"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1585"/>
-        <location filename="../app/MainLayout.qml" line="1604"/>
-        <location filename="../app/MainLayout.qml" line="1677"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1454"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1540"/>
+        <location filename="../app/MainLayout.qml" line="1596"/>
+        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Move</source>
         <translation>Move</translation>
     </message>
@@ -1234,11 +1239,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1485"/>
-        <location filename="../app/MainLayout.qml" line="1534"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1682"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1601"/>
+        <location filename="../app/MainLayout.qml" line="1693"/>
         <source>Open</source>
         <translation>Open</translation>
     </message>
@@ -1247,46 +1252,46 @@ Français - Wilfried</source>
         <translation type="vanished">Quit</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1466"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1477"/>
         <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1518"/>
-        <location filename="../app/MainLayout.qml" line="1548"/>
-        <location filename="../app/MainLayout.qml" line="1566"/>
-        <location filename="../app/MainLayout.qml" line="1578"/>
-        <location filename="../app/MainLayout.qml" line="1594"/>
-        <location filename="../app/MainLayout.qml" line="1628"/>
-        <location filename="../app/MainLayout.qml" line="1649"/>
-        <location filename="../app/MainLayout.qml" line="1658"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
-        <location filename="../app/MainLayout.qml" line="1717"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1559"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1589"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1639"/>
+        <location filename="../app/MainLayout.qml" line="1660"/>
+        <location filename="../app/MainLayout.qml" line="1669"/>
+        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1728"/>
         <source>Back</source>
         <translation>Back</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1488"/>
-        <location filename="../app/MainLayout.qml" line="1539"/>
-        <location filename="../app/MainLayout.qml" line="1687"/>
+        <location filename="../app/MainLayout.qml" line="1464"/>
+        <location filename="../app/MainLayout.qml" line="1499"/>
+        <location filename="../app/MainLayout.qml" line="1550"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1556"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1567"/>
+        <location filename="../app/MainLayout.qml" line="1716"/>
         <source>Retry</source>
         <translation>Retry</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1613"/>
+        <location filename="../app/MainLayout.qml" line="1624"/>
         <source>Change</source>
         <translation>Change</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1619"/>
+        <location filename="../app/MainLayout.qml" line="1630"/>
         <source>Toggle</source>
         <translation>Toggle</translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -420,7 +420,7 @@ Français - Wilfried</source>
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>Resume: %1</source>
         <translation>Resume: %1</translation>
     </message>
@@ -454,18 +454,18 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
-        <location filename="../screens/HubScreen.qml" line="1288"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="1305"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>No recent games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="303"/>
         <source>Favorites</source>
         <translation>Favorites</translation>
     </message>
@@ -474,32 +474,32 @@ Français - Wilfried</source>
         <translation type="vanished">Recently Played</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>No internet connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="352"/>
+        <location filename="../screens/HubScreen.qml" line="355"/>
         <source>Not available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="309"/>
+        <location filename="../screens/HubScreen.qml" line="312"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="302"/>
+        <location filename="../screens/HubScreen.qml" line="305"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1591"/>
+        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -589,463 +589,470 @@ Français - Wilfried</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2563"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2319"/>
+        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2663"/>
+        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3748"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Add to favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2281"/>
+        <location filename="../app/Main.qml" line="2253"/>
+        <location filename="../app/Main.qml" line="2324"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Write to NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2243"/>
+        <location filename="../app/Main.qml" line="2297"/>
         <source>Launch game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
-        <location filename="../app/Main.qml" line="3281"/>
-        <location filename="../app/Main.qml" line="3328"/>
-        <location filename="../app/Main.qml" line="3338"/>
+        <location filename="../app/Main.qml" line="1063"/>
+        <location filename="../app/Main.qml" line="3381"/>
+        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3438"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3317"/>
+        <location filename="../app/Main.qml" line="3417"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4603"/>
+        <location filename="../app/Main.qml" line="4812"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4610"/>
+        <location filename="../app/Main.qml" line="4819"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4605"/>
+        <location filename="../app/Main.qml" line="4814"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2207"/>
         <source>Update media database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2145"/>
-        <location filename="../app/Main.qml" line="2180"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2210"/>
         <source>Scrape metadata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2166"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1053"/>
+        <location filename="../app/Main.qml" line="1056"/>
         <source>Settings</source>
         <translation type="unfinished">Settings</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2076"/>
+        <location filename="../app/Main.qml" line="2089"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2142"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2217"/>
-        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2247"/>
+        <location filename="../app/Main.qml" line="2301"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2237"/>
-        <location filename="../app/Main.qml" line="2292"/>
-        <location filename="../app/Main.qml" line="2333"/>
+        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3371"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="2367"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2122"/>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2189"/>
-        <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="3264"/>
+        <location filename="../app/Main.qml" line="2151"/>
+        <location filename="../app/Main.qml" line="2202"/>
+        <location filename="../app/Main.qml" line="2219"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3364"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3309"/>
+        <location filename="../app/Main.qml" line="3409"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3370"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3375"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3475"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3292"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3479"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1028"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1045"/>
+        <location filename="../app/Main.qml" line="1048"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1049"/>
+        <location filename="../app/Main.qml" line="1052"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1057"/>
+        <location filename="../app/Main.qml" line="1060"/>
         <source>Quit</source>
         <translation type="unfinished">Quit</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2241"/>
-        <location filename="../app/Main.qml" line="2260"/>
-        <location filename="../app/Main.qml" line="2296"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2290"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="2285"/>
+        <location filename="../app/Main.qml" line="2257"/>
+        <location filename="../app/Main.qml" line="2328"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2360"/>
+        <location filename="../app/Main.qml" line="2438"/>
         <source>Move</source>
         <translation type="unfinished">Move</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2638"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
-        <location filename="../app/Main.qml" line="2907"/>
-        <location filename="../app/Main.qml" line="2929"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="3007"/>
+        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <source>Change launcher: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3053"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2962"/>
+        <location filename="../app/Main.qml" line="3062"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2963"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2965"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2968"/>
+        <location filename="../app/Main.qml" line="3068"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2969"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2971"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2972"/>
+        <location filename="../app/Main.qml" line="3072"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2974"/>
+        <location filename="../app/Main.qml" line="3074"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2975"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2977"/>
+        <location filename="../app/Main.qml" line="3077"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2978"/>
+        <location filename="../app/Main.qml" line="3078"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2980"/>
+        <location filename="../app/Main.qml" line="3080"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2981"/>
+        <location filename="../app/Main.qml" line="3081"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2984"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3084"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2986"/>
+        <location filename="../app/Main.qml" line="3086"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2987"/>
+        <location filename="../app/Main.qml" line="3087"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2989"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2990"/>
+        <location filename="../app/Main.qml" line="3090"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2992"/>
+        <location filename="../app/Main.qml" line="3092"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3217"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3233"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3142"/>
+        <location filename="../app/Main.qml" line="3242"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3271"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3256"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3296"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3396"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorites</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
-        <location filename="../app/Main.qml" line="3325"/>
+        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3425"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3313"/>
-        <location filename="../app/Main.qml" line="3335"/>
+        <location filename="../app/Main.qml" line="3413"/>
+        <location filename="../app/Main.qml" line="3435"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3353"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3349"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3449"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3456"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3556"/>
-        <location filename="../app/Main.qml" line="3574"/>
-        <source>Saving launcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3560"/>
-        <location filename="../app/Main.qml" line="3577"/>
+        <location filename="../app/Main.qml" line="3672"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2983"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3083"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
-        <location filename="../app/Main.qml" line="3182"/>
-        <location filename="../app/Main.qml" line="3590"/>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Retry</source>
         <translation type="unfinished">Retry</translation>
     </message>
@@ -1054,22 +1061,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Cancel</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4607"/>
+        <location filename="../app/Main.qml" line="4816"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4612"/>
+        <location filename="../app/Main.qml" line="4821"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4614"/>
+        <location filename="../app/Main.qml" line="4823"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4616"/>
+        <location filename="../app/Main.qml" line="4825"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>
@@ -1098,7 +1105,7 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
         <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
@@ -1118,81 +1125,81 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1279"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
         <source>Select</source>
         <translation>Select</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1293"/>
-        <location filename="../app/MainLayout.qml" line="1308"/>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1345"/>
+        <location filename="../app/MainLayout.qml" line="1283"/>
+        <location filename="../app/MainLayout.qml" line="1297"/>
+        <location filename="../app/MainLayout.qml" line="1312"/>
+        <location filename="../app/MainLayout.qml" line="1323"/>
+        <location filename="../app/MainLayout.qml" line="1349"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1326"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1290"/>
+        <location filename="../app/MainLayout.qml" line="1330"/>
+        <location filename="../app/MainLayout.qml" line="1371"/>
+        <location filename="../app/MainLayout.qml" line="1414"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1304"/>
+        <location filename="../app/MainLayout.qml" line="1308"/>
         <source>Done</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1334"/>
+        <location filename="../app/MainLayout.qml" line="1338"/>
         <source>I understand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1406"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1410"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1641"/>
+        <location filename="../app/MainLayout.qml" line="1645"/>
         <source>Scroll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1558"/>
-        <location filename="../app/MainLayout.qml" line="1690"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1544"/>
+        <location filename="../app/MainLayout.qml" line="1562"/>
+        <location filename="../app/MainLayout.qml" line="1694"/>
+        <location filename="../app/MainLayout.qml" line="1713"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1271"/>
-        <location filename="../app/MainLayout.qml" line="1359"/>
-        <location filename="../app/MainLayout.qml" line="1439"/>
-        <location filename="../app/MainLayout.qml" line="1476"/>
-        <location filename="../app/MainLayout.qml" line="1525"/>
-        <location filename="../app/MainLayout.qml" line="1581"/>
-        <location filename="../app/MainLayout.qml" line="1600"/>
-        <location filename="../app/MainLayout.qml" line="1673"/>
+        <location filename="../app/MainLayout.qml" line="1275"/>
+        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1443"/>
+        <location filename="../app/MainLayout.qml" line="1480"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1585"/>
+        <location filename="../app/MainLayout.qml" line="1604"/>
+        <location filename="../app/MainLayout.qml" line="1677"/>
         <source>Move</source>
         <translation>Move</translation>
     </message>
@@ -1227,11 +1234,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1481"/>
-        <location filename="../app/MainLayout.qml" line="1530"/>
-        <location filename="../app/MainLayout.qml" line="1586"/>
-        <location filename="../app/MainLayout.qml" line="1678"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1590"/>
+        <location filename="../app/MainLayout.qml" line="1682"/>
         <source>Open</source>
         <translation>Open</translation>
     </message>
@@ -1240,46 +1247,46 @@ Français - Wilfried</source>
         <translation type="vanished">Quit</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1462"/>
-        <location filename="../app/MainLayout.qml" line="1487"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1514"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1574"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1624"/>
-        <location filename="../app/MainLayout.qml" line="1645"/>
-        <location filename="../app/MainLayout.qml" line="1654"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1518"/>
+        <location filename="../app/MainLayout.qml" line="1548"/>
+        <location filename="../app/MainLayout.qml" line="1566"/>
+        <location filename="../app/MainLayout.qml" line="1578"/>
+        <location filename="../app/MainLayout.qml" line="1594"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1649"/>
+        <location filename="../app/MainLayout.qml" line="1658"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1717"/>
         <source>Back</source>
         <translation>Back</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1449"/>
-        <location filename="../app/MainLayout.qml" line="1484"/>
-        <location filename="../app/MainLayout.qml" line="1535"/>
-        <location filename="../app/MainLayout.qml" line="1683"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
+        <location filename="../app/MainLayout.qml" line="1488"/>
+        <location filename="../app/MainLayout.qml" line="1539"/>
+        <location filename="../app/MainLayout.qml" line="1687"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1315"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1494"/>
-        <location filename="../app/MainLayout.qml" line="1552"/>
-        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1319"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1498"/>
+        <location filename="../app/MainLayout.qml" line="1556"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
         <source>Retry</source>
         <translation>Retry</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1613"/>
         <source>Change</source>
         <translation>Change</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1619"/>
         <source>Toggle</source>
         <translation>Toggle</translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -675,29 +675,29 @@ Français - Wilfried</source>
         <translation type="vanished">Lanzar core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
-        <location filename="../app/Main.qml" line="2319"/>
-        <location filename="../app/Main.qml" line="2654"/>
-        <location filename="../app/Main.qml" line="2663"/>
-        <location filename="../app/Main.qml" line="3705"/>
-        <location filename="../app/Main.qml" line="3748"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2330"/>
+        <location filename="../app/Main.qml" line="2393"/>
+        <location filename="../app/Main.qml" line="2699"/>
+        <location filename="../app/Main.qml" line="3741"/>
+        <location filename="../app/Main.qml" line="3784"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Remove from favorites</source>
         <translation>Eliminar de favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Add to favorites</source>
         <translation>Agregar a favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2253"/>
-        <location filename="../app/Main.qml" line="2324"/>
+        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2335"/>
         <source>Write to NFC token</source>
         <translation>Escribir en token NFC</translation>
     </message>
@@ -706,443 +706,443 @@ Français - Wilfried</source>
         <translation type="vanished">Código QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2243"/>
-        <location filename="../app/Main.qml" line="2297"/>
+        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2308"/>
         <source>Launch game</source>
         <translation>Iniciar juego</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1063"/>
-        <location filename="../app/Main.qml" line="3381"/>
-        <location filename="../app/Main.qml" line="3428"/>
-        <location filename="../app/Main.qml" line="3438"/>
+        <location filename="../app/Main.qml" line="1070"/>
+        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3464"/>
+        <location filename="../app/Main.qml" line="3474"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4812"/>
+        <location filename="../app/Main.qml" line="4848"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4819"/>
+        <location filename="../app/Main.qml" line="4855"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4814"/>
+        <location filename="../app/Main.qml" line="4850"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2207"/>
+        <location filename="../app/Main.qml" line="2183"/>
+        <location filename="../app/Main.qml" line="2218"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizar base de datos de medios</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2175"/>
-        <location filename="../app/Main.qml" line="2210"/>
+        <location filename="../app/Main.qml" line="2186"/>
+        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extraer metadatos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1056"/>
+        <location filename="../app/Main.qml" line="1063"/>
         <source>Settings</source>
         <translation type="unfinished">Ajustes</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2089"/>
+        <location filename="../app/Main.qml" line="2096"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2153"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2247"/>
-        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2258"/>
+        <location filename="../app/Main.qml" line="2312"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2267"/>
-        <location filename="../app/Main.qml" line="2335"/>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2346"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Default</source>
         <translation type="unfinished">Por defecto</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="2378"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2151"/>
-        <location filename="../app/Main.qml" line="2202"/>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3364"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2230"/>
+        <location filename="../app/Main.qml" line="2238"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3409"/>
+        <location filename="../app/Main.qml" line="3445"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3406"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3475"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3511"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3428"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3479"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="3436"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1028"/>
+        <location filename="../app/Main.qml" line="1035"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1048"/>
+        <location filename="../app/Main.qml" line="1055"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1052"/>
+        <location filename="../app/Main.qml" line="1059"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="1067"/>
         <source>Quit</source>
         <translation type="unfinished">Salir</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2290"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2173"/>
+        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2350"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2257"/>
-        <location filename="../app/Main.qml" line="2328"/>
+        <location filename="../app/Main.qml" line="2268"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2461"/>
         <source>Move</source>
         <translation type="unfinished">Mover</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2638"/>
+        <location filename="../app/Main.qml" line="2667"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
-        <location filename="../app/Main.qml" line="3007"/>
-        <location filename="../app/Main.qml" line="3029"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3095"/>
+        <location filename="../app/Main.qml" line="1032"/>
+        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3131"/>
         <source>OK</source>
         <translation type="unfinished">Aceptar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3062"/>
+        <location filename="../app/Main.qml" line="3098"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3099"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3101"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3068"/>
+        <location filename="../app/Main.qml" line="3104"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3105"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3107"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3072"/>
+        <location filename="../app/Main.qml" line="3108"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3074"/>
+        <location filename="../app/Main.qml" line="3110"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3111"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3077"/>
+        <location filename="../app/Main.qml" line="3113"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3078"/>
+        <location filename="../app/Main.qml" line="3114"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3080"/>
+        <location filename="../app/Main.qml" line="3116"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3084"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3120"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3122"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3087"/>
+        <location filename="../app/Main.qml" line="3123"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3125"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3090"/>
+        <location filename="../app/Main.qml" line="3126"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3092"/>
+        <location filename="../app/Main.qml" line="3128"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3129"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3217"/>
+        <location filename="../app/Main.qml" line="3253"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3233"/>
+        <location filename="../app/Main.qml" line="3269"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3242"/>
+        <location filename="../app/Main.qml" line="3278"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3307"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3396"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3432"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
-        <location filename="../app/Main.qml" line="3425"/>
+        <location filename="../app/Main.qml" line="3415"/>
+        <location filename="../app/Main.qml" line="3461"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3413"/>
-        <location filename="../app/Main.qml" line="3435"/>
+        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3489"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3485"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3456"/>
+        <location filename="../app/Main.qml" line="3492"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3672"/>
+        <location filename="../app/Main.qml" line="3708"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3083"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3119"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
-        <location filename="../app/Main.qml" line="3282"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Retry</source>
         <translation type="unfinished">Reintentar</translation>
     </message>
@@ -1151,22 +1151,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4816"/>
+        <location filename="../app/Main.qml" line="4852"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4821"/>
+        <location filename="../app/Main.qml" line="4857"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4823"/>
+        <location filename="../app/Main.qml" line="4859"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4825"/>
+        <location filename="../app/Main.qml" line="4861"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>
@@ -1216,7 +1216,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Select</source>
         <translation>Seleccionar</translation>
     </message>
@@ -1232,8 +1232,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="1290"/>
         <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1371"/>
-        <location filename="../app/MainLayout.qml" line="1414"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -1248,12 +1248,17 @@ Français - Wilfried</source>
         <translation>Entendido</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
+        <source>Saving…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="1389"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1262,28 +1267,28 @@ Français - Wilfried</source>
         <translation type="vanished">Iniciar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1645"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Scroll</source>
         <translation>Desplazar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1457"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1468"/>
+        <location filename="../app/MainLayout.qml" line="1555"/>
+        <location filename="../app/MainLayout.qml" line="1573"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1724"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1480"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1585"/>
-        <location filename="../app/MainLayout.qml" line="1604"/>
-        <location filename="../app/MainLayout.qml" line="1677"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1454"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1540"/>
+        <location filename="../app/MainLayout.qml" line="1596"/>
+        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Move</source>
         <translation>Mover</translation>
     </message>
@@ -1314,21 +1319,21 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1417"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1485"/>
-        <location filename="../app/MainLayout.qml" line="1534"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1682"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1601"/>
+        <location filename="../app/MainLayout.qml" line="1693"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
@@ -1337,19 +1342,19 @@ Français - Wilfried</source>
         <translation type="vanished">Salir</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1466"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1477"/>
         <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1518"/>
-        <location filename="../app/MainLayout.qml" line="1548"/>
-        <location filename="../app/MainLayout.qml" line="1566"/>
-        <location filename="../app/MainLayout.qml" line="1578"/>
-        <location filename="../app/MainLayout.qml" line="1594"/>
-        <location filename="../app/MainLayout.qml" line="1628"/>
-        <location filename="../app/MainLayout.qml" line="1649"/>
-        <location filename="../app/MainLayout.qml" line="1658"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
-        <location filename="../app/MainLayout.qml" line="1717"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1559"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1589"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1639"/>
+        <location filename="../app/MainLayout.qml" line="1660"/>
+        <location filename="../app/MainLayout.qml" line="1669"/>
+        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1728"/>
         <source>Back</source>
         <translation>Atrás</translation>
     </message>
@@ -1358,29 +1363,29 @@ Français - Wilfried</source>
         <translation type="vanished">Página</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1488"/>
-        <location filename="../app/MainLayout.qml" line="1539"/>
-        <location filename="../app/MainLayout.qml" line="1687"/>
+        <location filename="../app/MainLayout.qml" line="1464"/>
+        <location filename="../app/MainLayout.qml" line="1499"/>
+        <location filename="../app/MainLayout.qml" line="1550"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
         <source>Options</source>
         <translation>Opciones</translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1556"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1567"/>
+        <location filename="../app/MainLayout.qml" line="1716"/>
         <source>Retry</source>
         <translation>Reintentar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1613"/>
+        <location filename="../app/MainLayout.qml" line="1624"/>
         <source>Change</source>
         <translation>Cambiar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1619"/>
+        <location filename="../app/MainLayout.qml" line="1630"/>
         <source>Toggle</source>
         <translation>Alternar</translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -519,23 +519,23 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
-        <location filename="../screens/HubScreen.qml" line="1288"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="1305"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>No recent games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>Resume: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="303"/>
         <source>Favorites</source>
         <translation>Favoritos</translation>
     </message>
@@ -544,32 +544,32 @@ Français - Wilfried</source>
         <translation type="vanished">Recientemente Jugados</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>No internet connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="352"/>
+        <location filename="../screens/HubScreen.qml" line="355"/>
         <source>Not available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="309"/>
+        <location filename="../screens/HubScreen.qml" line="312"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="302"/>
+        <location filename="../screens/HubScreen.qml" line="305"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1591"/>
+        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>No hay sistemas disponibles. Ejecuta Actualizar la base de datos de medios desde Ajustes.</translation>
     </message>
@@ -675,24 +675,29 @@ Français - Wilfried</source>
         <translation type="vanished">Lanzar core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2563"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2319"/>
+        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2663"/>
+        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3748"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Remove from favorites</source>
         <translation>Eliminar de favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Add to favorites</source>
         <translation>Agregar a favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2281"/>
+        <location filename="../app/Main.qml" line="2253"/>
+        <location filename="../app/Main.qml" line="2324"/>
         <source>Write to NFC token</source>
         <translation>Escribir en token NFC</translation>
     </message>
@@ -701,441 +706,443 @@ Français - Wilfried</source>
         <translation type="vanished">Código QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2243"/>
+        <location filename="../app/Main.qml" line="2297"/>
         <source>Launch game</source>
         <translation>Iniciar juego</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
-        <location filename="../app/Main.qml" line="3281"/>
-        <location filename="../app/Main.qml" line="3328"/>
-        <location filename="../app/Main.qml" line="3338"/>
+        <location filename="../app/Main.qml" line="1063"/>
+        <location filename="../app/Main.qml" line="3381"/>
+        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3438"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3317"/>
+        <location filename="../app/Main.qml" line="3417"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4603"/>
+        <location filename="../app/Main.qml" line="4812"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4610"/>
+        <location filename="../app/Main.qml" line="4819"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4605"/>
+        <location filename="../app/Main.qml" line="4814"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2207"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizar base de datos de medios</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2145"/>
-        <location filename="../app/Main.qml" line="2180"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2210"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extraer metadatos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2166"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1053"/>
+        <location filename="../app/Main.qml" line="1056"/>
         <source>Settings</source>
         <translation type="unfinished">Ajustes</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2076"/>
+        <location filename="../app/Main.qml" line="2089"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2142"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2217"/>
-        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2247"/>
+        <location filename="../app/Main.qml" line="2301"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2237"/>
-        <location filename="../app/Main.qml" line="2292"/>
-        <location filename="../app/Main.qml" line="2333"/>
+        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3371"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Default</source>
         <translation type="unfinished">Por defecto</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="2367"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2122"/>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2189"/>
-        <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="3264"/>
+        <location filename="../app/Main.qml" line="2151"/>
+        <location filename="../app/Main.qml" line="2202"/>
+        <location filename="../app/Main.qml" line="2219"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3364"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3309"/>
+        <location filename="../app/Main.qml" line="3409"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3370"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3375"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3475"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3292"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3479"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1028"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1045"/>
+        <location filename="../app/Main.qml" line="1048"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1049"/>
+        <location filename="../app/Main.qml" line="1052"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1057"/>
+        <location filename="../app/Main.qml" line="1060"/>
         <source>Quit</source>
         <translation type="unfinished">Salir</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2241"/>
-        <location filename="../app/Main.qml" line="2260"/>
-        <location filename="../app/Main.qml" line="2296"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2290"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="2285"/>
+        <location filename="../app/Main.qml" line="2257"/>
+        <location filename="../app/Main.qml" line="2328"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2360"/>
+        <location filename="../app/Main.qml" line="2438"/>
         <source>Move</source>
         <translation type="unfinished">Mover</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2638"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
-        <location filename="../app/Main.qml" line="2907"/>
-        <location filename="../app/Main.qml" line="2929"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="3007"/>
+        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>OK</source>
         <translation type="unfinished">Aceptar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <source>Change launcher: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3053"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2962"/>
+        <location filename="../app/Main.qml" line="3062"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2963"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2965"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2968"/>
+        <location filename="../app/Main.qml" line="3068"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2969"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2971"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2972"/>
+        <location filename="../app/Main.qml" line="3072"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2974"/>
+        <location filename="../app/Main.qml" line="3074"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2975"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2977"/>
+        <location filename="../app/Main.qml" line="3077"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2978"/>
+        <location filename="../app/Main.qml" line="3078"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2980"/>
+        <location filename="../app/Main.qml" line="3080"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2981"/>
+        <location filename="../app/Main.qml" line="3081"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2984"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3084"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2986"/>
+        <location filename="../app/Main.qml" line="3086"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2987"/>
+        <location filename="../app/Main.qml" line="3087"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2989"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2990"/>
+        <location filename="../app/Main.qml" line="3090"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2992"/>
+        <location filename="../app/Main.qml" line="3092"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3217"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3233"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3142"/>
+        <location filename="../app/Main.qml" line="3242"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3271"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3256"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3296"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3396"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
-        <location filename="../app/Main.qml" line="3325"/>
+        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3425"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3313"/>
-        <location filename="../app/Main.qml" line="3335"/>
+        <location filename="../app/Main.qml" line="3413"/>
+        <location filename="../app/Main.qml" line="3435"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3353"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3349"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3449"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3456"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3556"/>
-        <location filename="../app/Main.qml" line="3574"/>
-        <source>Saving launcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3560"/>
-        <location filename="../app/Main.qml" line="3577"/>
+        <location filename="../app/Main.qml" line="3672"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2983"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3083"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
-        <location filename="../app/Main.qml" line="3182"/>
-        <location filename="../app/Main.qml" line="3590"/>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Retry</source>
         <translation type="unfinished">Reintentar</translation>
     </message>
@@ -1144,22 +1151,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4607"/>
+        <location filename="../app/Main.qml" line="4816"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4612"/>
+        <location filename="../app/Main.qml" line="4821"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4614"/>
+        <location filename="../app/Main.qml" line="4823"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4616"/>
+        <location filename="../app/Main.qml" line="4825"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>
@@ -1188,7 +1195,7 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
         <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
         <source>OK</source>
         <translation type="unfinished">Aceptar</translation>
     </message>
@@ -1208,45 +1215,45 @@ Français - Wilfried</source>
         <translation>¿Seguro que quieres salir?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1279"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
         <source>Select</source>
         <translation>Seleccionar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1293"/>
-        <location filename="../app/MainLayout.qml" line="1308"/>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1345"/>
+        <location filename="../app/MainLayout.qml" line="1283"/>
+        <location filename="../app/MainLayout.qml" line="1297"/>
+        <location filename="../app/MainLayout.qml" line="1312"/>
+        <location filename="../app/MainLayout.qml" line="1323"/>
+        <location filename="../app/MainLayout.qml" line="1349"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1326"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1290"/>
+        <location filename="../app/MainLayout.qml" line="1330"/>
+        <location filename="../app/MainLayout.qml" line="1371"/>
+        <location filename="../app/MainLayout.qml" line="1414"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1304"/>
+        <location filename="../app/MainLayout.qml" line="1308"/>
         <source>Done</source>
         <translation>Hecho</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1334"/>
+        <location filename="../app/MainLayout.qml" line="1338"/>
         <source>I understand</source>
         <translation>Entendido</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1255,28 +1262,28 @@ Français - Wilfried</source>
         <translation type="vanished">Iniciar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1641"/>
+        <location filename="../app/MainLayout.qml" line="1645"/>
         <source>Scroll</source>
         <translation>Desplazar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1558"/>
-        <location filename="../app/MainLayout.qml" line="1690"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1544"/>
+        <location filename="../app/MainLayout.qml" line="1562"/>
+        <location filename="../app/MainLayout.qml" line="1694"/>
+        <location filename="../app/MainLayout.qml" line="1713"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1271"/>
-        <location filename="../app/MainLayout.qml" line="1359"/>
-        <location filename="../app/MainLayout.qml" line="1439"/>
-        <location filename="../app/MainLayout.qml" line="1476"/>
-        <location filename="../app/MainLayout.qml" line="1525"/>
-        <location filename="../app/MainLayout.qml" line="1581"/>
-        <location filename="../app/MainLayout.qml" line="1600"/>
-        <location filename="../app/MainLayout.qml" line="1673"/>
+        <location filename="../app/MainLayout.qml" line="1275"/>
+        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1443"/>
+        <location filename="../app/MainLayout.qml" line="1480"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1585"/>
+        <location filename="../app/MainLayout.qml" line="1604"/>
+        <location filename="../app/MainLayout.qml" line="1677"/>
         <source>Move</source>
         <translation>Mover</translation>
     </message>
@@ -1307,21 +1314,21 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1406"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1410"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1481"/>
-        <location filename="../app/MainLayout.qml" line="1530"/>
-        <location filename="../app/MainLayout.qml" line="1586"/>
-        <location filename="../app/MainLayout.qml" line="1678"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1590"/>
+        <location filename="../app/MainLayout.qml" line="1682"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
@@ -1330,19 +1337,19 @@ Français - Wilfried</source>
         <translation type="vanished">Salir</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1462"/>
-        <location filename="../app/MainLayout.qml" line="1487"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1514"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1574"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1624"/>
-        <location filename="../app/MainLayout.qml" line="1645"/>
-        <location filename="../app/MainLayout.qml" line="1654"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1518"/>
+        <location filename="../app/MainLayout.qml" line="1548"/>
+        <location filename="../app/MainLayout.qml" line="1566"/>
+        <location filename="../app/MainLayout.qml" line="1578"/>
+        <location filename="../app/MainLayout.qml" line="1594"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1649"/>
+        <location filename="../app/MainLayout.qml" line="1658"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1717"/>
         <source>Back</source>
         <translation>Atrás</translation>
     </message>
@@ -1351,29 +1358,29 @@ Français - Wilfried</source>
         <translation type="vanished">Página</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1449"/>
-        <location filename="../app/MainLayout.qml" line="1484"/>
-        <location filename="../app/MainLayout.qml" line="1535"/>
-        <location filename="../app/MainLayout.qml" line="1683"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
+        <location filename="../app/MainLayout.qml" line="1488"/>
+        <location filename="../app/MainLayout.qml" line="1539"/>
+        <location filename="../app/MainLayout.qml" line="1687"/>
         <source>Options</source>
         <translation>Opciones</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1315"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1494"/>
-        <location filename="../app/MainLayout.qml" line="1552"/>
-        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1319"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1498"/>
+        <location filename="../app/MainLayout.qml" line="1556"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
         <source>Retry</source>
         <translation>Reintentar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1613"/>
         <source>Change</source>
         <translation>Cambiar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1619"/>
         <source>Toggle</source>
         <translation>Alternar</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -691,29 +691,29 @@ Français - Wilfried</source>
         <translation type="obsolete">Exekutatu nukleoa</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
-        <location filename="../app/Main.qml" line="2319"/>
-        <location filename="../app/Main.qml" line="2654"/>
-        <location filename="../app/Main.qml" line="2663"/>
-        <location filename="../app/Main.qml" line="3705"/>
-        <location filename="../app/Main.qml" line="3748"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2330"/>
+        <location filename="../app/Main.qml" line="2393"/>
+        <location filename="../app/Main.qml" line="2699"/>
+        <location filename="../app/Main.qml" line="3741"/>
+        <location filename="../app/Main.qml" line="3784"/>
         <source>Change launcher</source>
         <translation type="unfinished">Aldatu abiarazlea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Remove from favorites</source>
         <translation type="unfinished">Kendu gogokoetatik</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Add to favorites</source>
         <translation type="unfinished">Gehitu gogokoetan</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2253"/>
-        <location filename="../app/Main.qml" line="2324"/>
+        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2335"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Idatzi NFC token-a</translation>
     </message>
@@ -722,412 +722,412 @@ Français - Wilfried</source>
         <translation type="obsolete">QR kodea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2243"/>
-        <location filename="../app/Main.qml" line="2297"/>
+        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2308"/>
         <source>Launch game</source>
         <translation type="unfinished">Abiarazi jokua</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1063"/>
-        <location filename="../app/Main.qml" line="3381"/>
-        <location filename="../app/Main.qml" line="3428"/>
-        <location filename="../app/Main.qml" line="3438"/>
+        <location filename="../app/Main.qml" line="1070"/>
+        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3464"/>
+        <location filename="../app/Main.qml" line="3474"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4812"/>
+        <location filename="../app/Main.qml" line="4848"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4819"/>
+        <location filename="../app/Main.qml" line="4855"/>
         <source>Loading favorites…</source>
         <translation type="unfinished">Gogokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4814"/>
+        <location filename="../app/Main.qml" line="4850"/>
         <source>Loading games…</source>
         <translation type="unfinished">Jokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2207"/>
+        <location filename="../app/Main.qml" line="2183"/>
+        <location filename="../app/Main.qml" line="2218"/>
         <source>Update media database</source>
         <translation type="unfinished">Eguneratu multimedia datu-basea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2175"/>
-        <location filename="../app/Main.qml" line="2210"/>
+        <location filename="../app/Main.qml" line="2186"/>
+        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadatuak scrapeatu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1056"/>
+        <location filename="../app/Main.qml" line="1063"/>
         <source>Settings</source>
         <translation type="unfinished">Ezarpenak</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2089"/>
+        <location filename="../app/Main.qml" line="2096"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2153"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2247"/>
-        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2258"/>
+        <location filename="../app/Main.qml" line="2312"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2267"/>
-        <location filename="../app/Main.qml" line="2335"/>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2346"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Default</source>
         <translation type="unfinished">Lehenetsia</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="2378"/>
         <source>Current: %1</source>
         <translation type="unfinished">Unekoa: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2151"/>
-        <location filename="../app/Main.qml" line="2202"/>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3364"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2230"/>
+        <location filename="../app/Main.qml" line="2238"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3409"/>
+        <location filename="../app/Main.qml" line="3445"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3406"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3475"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3511"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3428"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3479"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="3436"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1028"/>
+        <location filename="../app/Main.qml" line="1035"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1048"/>
+        <location filename="../app/Main.qml" line="1055"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1052"/>
+        <location filename="../app/Main.qml" line="1059"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="1067"/>
         <source>Quit</source>
         <translation type="unfinished">Irten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2290"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2173"/>
+        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2350"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2257"/>
-        <location filename="../app/Main.qml" line="2328"/>
+        <location filename="../app/Main.qml" line="2268"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2461"/>
         <source>Move</source>
         <translation type="unfinished">Mugitu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2638"/>
+        <location filename="../app/Main.qml" line="2667"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
-        <location filename="../app/Main.qml" line="3007"/>
-        <location filename="../app/Main.qml" line="3029"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3095"/>
+        <location filename="../app/Main.qml" line="1032"/>
+        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3131"/>
         <source>OK</source>
         <translation type="unfinished">Ados</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3062"/>
+        <location filename="../app/Main.qml" line="3098"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3099"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3101"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3068"/>
+        <location filename="../app/Main.qml" line="3104"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3105"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3107"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3072"/>
+        <location filename="../app/Main.qml" line="3108"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3074"/>
+        <location filename="../app/Main.qml" line="3110"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3111"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3077"/>
+        <location filename="../app/Main.qml" line="3113"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3078"/>
+        <location filename="../app/Main.qml" line="3114"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3080"/>
+        <location filename="../app/Main.qml" line="3116"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3084"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3120"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3122"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3087"/>
+        <location filename="../app/Main.qml" line="3123"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3125"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3090"/>
+        <location filename="../app/Main.qml" line="3126"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3092"/>
+        <location filename="../app/Main.qml" line="3128"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3129"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3217"/>
+        <location filename="../app/Main.qml" line="3253"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3233"/>
+        <location filename="../app/Main.qml" line="3269"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3242"/>
+        <location filename="../app/Main.qml" line="3278"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3307"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3396"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3432"/>
         <source>Favorites</source>
         <translation type="unfinished">Gogokoak</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
-        <location filename="../app/Main.qml" line="3425"/>
+        <location filename="../app/Main.qml" line="3415"/>
+        <location filename="../app/Main.qml" line="3461"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3413"/>
-        <location filename="../app/Main.qml" line="3435"/>
+        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3489"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3485"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3456"/>
+        <location filename="../app/Main.qml" line="3492"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1136,24 +1136,24 @@ Français - Wilfried</source>
         <translation type="obsolete">Abiarazlea gordetzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3672"/>
+        <location filename="../app/Main.qml" line="3708"/>
         <source>Saving…</source>
         <translation type="unfinished">Gordetzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3083"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3119"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Launcher update failed</source>
         <translation type="unfinished">Abiarazle egukeraketak huts egin du</translation>
     </message>
@@ -1162,11 +1162,11 @@ Français - Wilfried</source>
         <translation type="obsolete">Errorea: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
-        <location filename="../app/Main.qml" line="3282"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Retry</source>
         <translation type="unfinished">Berriro saiatu</translation>
     </message>
@@ -1175,22 +1175,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Utzi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4816"/>
+        <location filename="../app/Main.qml" line="4852"/>
         <source>Loading game…</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4821"/>
+        <location filename="../app/Main.qml" line="4857"/>
         <source>Loading recently played…</source>
         <translation type="unfinished">Duela gutxi jokatutakoak kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4823"/>
+        <location filename="../app/Main.qml" line="4859"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4825"/>
+        <location filename="../app/Main.qml" line="4861"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
@@ -1240,7 +1240,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Select</source>
         <translation>Aukeratu</translation>
     </message>
@@ -1256,8 +1256,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="1290"/>
         <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1371"/>
-        <location filename="../app/MainLayout.qml" line="1414"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Cancel</source>
         <translation>Utzi</translation>
     </message>
@@ -1272,12 +1272,17 @@ Français - Wilfried</source>
         <translation type="unfinished">Ulertzen dut</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
+        <source>Saving…</source>
+        <translation type="unfinished">Gordetzen...</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="1389"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1286,28 +1291,28 @@ Français - Wilfried</source>
         <translation type="obsolete">Hasi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1645"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Scroll</source>
         <translation type="unfinished">Scroll-a egin</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1457"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1468"/>
+        <location filename="../app/MainLayout.qml" line="1555"/>
+        <location filename="../app/MainLayout.qml" line="1573"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1724"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1480"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1585"/>
-        <location filename="../app/MainLayout.qml" line="1604"/>
-        <location filename="../app/MainLayout.qml" line="1677"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1454"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1540"/>
+        <location filename="../app/MainLayout.qml" line="1596"/>
+        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Move</source>
         <translation>Mugitu</translation>
     </message>
@@ -1342,21 +1347,21 @@ Français - Wilfried</source>
         <translation type="unfinished">Itxi Zaparoo Frontend?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1417"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1485"/>
-        <location filename="../app/MainLayout.qml" line="1534"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1682"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1601"/>
+        <location filename="../app/MainLayout.qml" line="1693"/>
         <source>Open</source>
         <translation>Ireki</translation>
     </message>
@@ -1365,19 +1370,19 @@ Français - Wilfried</source>
         <translation type="vanished">Irten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1466"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1477"/>
         <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1518"/>
-        <location filename="../app/MainLayout.qml" line="1548"/>
-        <location filename="../app/MainLayout.qml" line="1566"/>
-        <location filename="../app/MainLayout.qml" line="1578"/>
-        <location filename="../app/MainLayout.qml" line="1594"/>
-        <location filename="../app/MainLayout.qml" line="1628"/>
-        <location filename="../app/MainLayout.qml" line="1649"/>
-        <location filename="../app/MainLayout.qml" line="1658"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
-        <location filename="../app/MainLayout.qml" line="1717"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1559"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1589"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1639"/>
+        <location filename="../app/MainLayout.qml" line="1660"/>
+        <location filename="../app/MainLayout.qml" line="1669"/>
+        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1728"/>
         <source>Back</source>
         <translation>Atzera</translation>
     </message>
@@ -1386,29 +1391,29 @@ Français - Wilfried</source>
         <translation type="obsolete">Orria</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1488"/>
-        <location filename="../app/MainLayout.qml" line="1539"/>
-        <location filename="../app/MainLayout.qml" line="1687"/>
+        <location filename="../app/MainLayout.qml" line="1464"/>
+        <location filename="../app/MainLayout.qml" line="1499"/>
+        <location filename="../app/MainLayout.qml" line="1550"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
         <source>Options</source>
         <translation type="unfinished">Aukerak</translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1556"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1567"/>
+        <location filename="../app/MainLayout.qml" line="1716"/>
         <source>Retry</source>
         <translation>Berriro saiatu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1613"/>
+        <location filename="../app/MainLayout.qml" line="1624"/>
         <source>Change</source>
         <translation>Aldatu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1619"/>
+        <location filename="../app/MainLayout.qml" line="1630"/>
         <source>Toggle</source>
         <translation>Txandakatu</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -506,7 +506,7 @@ Français - Wilfried</source>
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>Resume: %1</source>
         <translation>Berrekin: %1</translation>
     </message>
@@ -540,18 +540,18 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
-        <location filename="../screens/HubScreen.qml" line="1288"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="1305"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>No recent games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="303"/>
         <source>Favorites</source>
         <translation>Gogokoak</translation>
     </message>
@@ -560,32 +560,32 @@ Français - Wilfried</source>
         <translation type="vanished">Duela gutxi jolastuta</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>No internet connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="352"/>
+        <location filename="../screens/HubScreen.qml" line="355"/>
         <source>Not available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="309"/>
+        <location filename="../screens/HubScreen.qml" line="312"/>
         <source>Settings</source>
         <translation>Ezarpenak</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="302"/>
+        <location filename="../screens/HubScreen.qml" line="305"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1591"/>
+        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation type="unfinished">Ez dago sistemarik eskuragarri. Exekutatu Eguneratu baliabide datubasea Aukeretatik</translation>
     </message>
@@ -691,24 +691,29 @@ Français - Wilfried</source>
         <translation type="obsolete">Exekutatu nukleoa</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2563"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2319"/>
+        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2663"/>
+        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3748"/>
         <source>Change launcher</source>
         <translation type="unfinished">Aldatu abiarazlea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Remove from favorites</source>
         <translation type="unfinished">Kendu gogokoetatik</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Add to favorites</source>
         <translation type="unfinished">Gehitu gogokoetan</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2281"/>
+        <location filename="../app/Main.qml" line="2253"/>
+        <location filename="../app/Main.qml" line="2324"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Idatzi NFC token-a</translation>
     </message>
@@ -717,433 +722,438 @@ Français - Wilfried</source>
         <translation type="obsolete">QR kodea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2243"/>
+        <location filename="../app/Main.qml" line="2297"/>
         <source>Launch game</source>
         <translation type="unfinished">Abiarazi jokua</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
-        <location filename="../app/Main.qml" line="3281"/>
-        <location filename="../app/Main.qml" line="3328"/>
-        <location filename="../app/Main.qml" line="3338"/>
+        <location filename="../app/Main.qml" line="1063"/>
+        <location filename="../app/Main.qml" line="3381"/>
+        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3438"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3317"/>
+        <location filename="../app/Main.qml" line="3417"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4603"/>
+        <location filename="../app/Main.qml" line="4812"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4610"/>
+        <location filename="../app/Main.qml" line="4819"/>
         <source>Loading favorites…</source>
         <translation type="unfinished">Gogokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4605"/>
+        <location filename="../app/Main.qml" line="4814"/>
         <source>Loading games…</source>
         <translation type="unfinished">Jokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2207"/>
         <source>Update media database</source>
         <translation type="unfinished">Eguneratu multimedia datu-basea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2145"/>
-        <location filename="../app/Main.qml" line="2180"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2210"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadatuak scrapeatu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2166"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1053"/>
+        <location filename="../app/Main.qml" line="1056"/>
         <source>Settings</source>
         <translation type="unfinished">Ezarpenak</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2076"/>
+        <location filename="../app/Main.qml" line="2089"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2142"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2217"/>
-        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2247"/>
+        <location filename="../app/Main.qml" line="2301"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2237"/>
-        <location filename="../app/Main.qml" line="2292"/>
-        <location filename="../app/Main.qml" line="2333"/>
+        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3371"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Default</source>
         <translation type="unfinished">Lehenetsia</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="2367"/>
         <source>Current: %1</source>
         <translation type="unfinished">Unekoa: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2122"/>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2189"/>
-        <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="3264"/>
+        <location filename="../app/Main.qml" line="2151"/>
+        <location filename="../app/Main.qml" line="2202"/>
+        <location filename="../app/Main.qml" line="2219"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3364"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3309"/>
+        <location filename="../app/Main.qml" line="3409"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3370"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3375"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3475"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3292"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3479"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1028"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1045"/>
+        <location filename="../app/Main.qml" line="1048"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1049"/>
+        <location filename="../app/Main.qml" line="1052"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1057"/>
+        <location filename="../app/Main.qml" line="1060"/>
         <source>Quit</source>
         <translation type="unfinished">Irten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2241"/>
-        <location filename="../app/Main.qml" line="2260"/>
-        <location filename="../app/Main.qml" line="2296"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2290"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="2285"/>
+        <location filename="../app/Main.qml" line="2257"/>
+        <location filename="../app/Main.qml" line="2328"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2360"/>
+        <location filename="../app/Main.qml" line="2438"/>
         <source>Move</source>
         <translation type="unfinished">Mugitu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2638"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
-        <location filename="../app/Main.qml" line="2907"/>
-        <location filename="../app/Main.qml" line="2929"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="3007"/>
+        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>OK</source>
         <translation type="unfinished">Ados</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <source>Change launcher: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3053"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2962"/>
+        <location filename="../app/Main.qml" line="3062"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2963"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2965"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2968"/>
+        <location filename="../app/Main.qml" line="3068"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2969"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2971"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2972"/>
+        <location filename="../app/Main.qml" line="3072"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2974"/>
+        <location filename="../app/Main.qml" line="3074"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2975"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2977"/>
+        <location filename="../app/Main.qml" line="3077"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2978"/>
+        <location filename="../app/Main.qml" line="3078"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2980"/>
+        <location filename="../app/Main.qml" line="3080"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2981"/>
+        <location filename="../app/Main.qml" line="3081"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2984"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3084"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2986"/>
+        <location filename="../app/Main.qml" line="3086"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2987"/>
+        <location filename="../app/Main.qml" line="3087"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2989"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2990"/>
+        <location filename="../app/Main.qml" line="3090"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2992"/>
+        <location filename="../app/Main.qml" line="3092"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3217"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3233"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3142"/>
+        <location filename="../app/Main.qml" line="3242"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3271"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3256"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3296"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3396"/>
         <source>Favorites</source>
         <translation type="unfinished">Gogokoak</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
-        <location filename="../app/Main.qml" line="3325"/>
+        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3425"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3313"/>
-        <location filename="../app/Main.qml" line="3335"/>
+        <location filename="../app/Main.qml" line="3413"/>
+        <location filename="../app/Main.qml" line="3435"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3353"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3349"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3449"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3456"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3556"/>
-        <location filename="../app/Main.qml" line="3574"/>
         <source>Saving launcher</source>
-        <translation type="unfinished">Abiarazlea gordetzen</translation>
+        <translation type="obsolete">Abiarazlea gordetzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3560"/>
-        <location filename="../app/Main.qml" line="3577"/>
+        <location filename="../app/Main.qml" line="3672"/>
         <source>Saving…</source>
         <translation type="unfinished">Gordetzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2983"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3083"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Launcher update failed</source>
         <translation type="unfinished">Abiarazle egukeraketak huts egin du</translation>
     </message>
@@ -1152,10 +1162,11 @@ Français - Wilfried</source>
         <translation type="obsolete">Errorea: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
-        <location filename="../app/Main.qml" line="3182"/>
-        <location filename="../app/Main.qml" line="3590"/>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Retry</source>
         <translation type="unfinished">Berriro saiatu</translation>
     </message>
@@ -1164,22 +1175,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Utzi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4607"/>
+        <location filename="../app/Main.qml" line="4816"/>
         <source>Loading game…</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4612"/>
+        <location filename="../app/Main.qml" line="4821"/>
         <source>Loading recently played…</source>
         <translation type="unfinished">Duela gutxi jokatutakoak kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4614"/>
+        <location filename="../app/Main.qml" line="4823"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4616"/>
+        <location filename="../app/Main.qml" line="4825"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
@@ -1208,7 +1219,7 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
         <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
         <source>OK</source>
         <translation type="unfinished">Ados</translation>
     </message>
@@ -1228,45 +1239,45 @@ Français - Wilfried</source>
         <translation type="unfinished">Ziur zaude irten nahi duzula?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1279"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
         <source>Select</source>
         <translation>Aukeratu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1293"/>
-        <location filename="../app/MainLayout.qml" line="1308"/>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1345"/>
+        <location filename="../app/MainLayout.qml" line="1283"/>
+        <location filename="../app/MainLayout.qml" line="1297"/>
+        <location filename="../app/MainLayout.qml" line="1312"/>
+        <location filename="../app/MainLayout.qml" line="1323"/>
+        <location filename="../app/MainLayout.qml" line="1349"/>
         <source>Close</source>
         <translation>Itxi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1326"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1290"/>
+        <location filename="../app/MainLayout.qml" line="1330"/>
+        <location filename="../app/MainLayout.qml" line="1371"/>
+        <location filename="../app/MainLayout.qml" line="1414"/>
         <source>Cancel</source>
         <translation>Utzi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1304"/>
+        <location filename="../app/MainLayout.qml" line="1308"/>
         <source>Done</source>
         <translation type="unfinished">Eginda</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1334"/>
+        <location filename="../app/MainLayout.qml" line="1338"/>
         <source>I understand</source>
         <translation type="unfinished">Ulertzen dut</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1275,28 +1286,28 @@ Français - Wilfried</source>
         <translation type="obsolete">Hasi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1641"/>
+        <location filename="../app/MainLayout.qml" line="1645"/>
         <source>Scroll</source>
         <translation type="unfinished">Scroll-a egin</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1558"/>
-        <location filename="../app/MainLayout.qml" line="1690"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1544"/>
+        <location filename="../app/MainLayout.qml" line="1562"/>
+        <location filename="../app/MainLayout.qml" line="1694"/>
+        <location filename="../app/MainLayout.qml" line="1713"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1271"/>
-        <location filename="../app/MainLayout.qml" line="1359"/>
-        <location filename="../app/MainLayout.qml" line="1439"/>
-        <location filename="../app/MainLayout.qml" line="1476"/>
-        <location filename="../app/MainLayout.qml" line="1525"/>
-        <location filename="../app/MainLayout.qml" line="1581"/>
-        <location filename="../app/MainLayout.qml" line="1600"/>
-        <location filename="../app/MainLayout.qml" line="1673"/>
+        <location filename="../app/MainLayout.qml" line="1275"/>
+        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1443"/>
+        <location filename="../app/MainLayout.qml" line="1480"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1585"/>
+        <location filename="../app/MainLayout.qml" line="1604"/>
+        <location filename="../app/MainLayout.qml" line="1677"/>
         <source>Move</source>
         <translation>Mugitu</translation>
     </message>
@@ -1331,21 +1342,21 @@ Français - Wilfried</source>
         <translation type="unfinished">Itxi Zaparoo Frontend?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1406"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1410"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1481"/>
-        <location filename="../app/MainLayout.qml" line="1530"/>
-        <location filename="../app/MainLayout.qml" line="1586"/>
-        <location filename="../app/MainLayout.qml" line="1678"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1590"/>
+        <location filename="../app/MainLayout.qml" line="1682"/>
         <source>Open</source>
         <translation>Ireki</translation>
     </message>
@@ -1354,19 +1365,19 @@ Français - Wilfried</source>
         <translation type="vanished">Irten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1462"/>
-        <location filename="../app/MainLayout.qml" line="1487"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1514"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1574"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1624"/>
-        <location filename="../app/MainLayout.qml" line="1645"/>
-        <location filename="../app/MainLayout.qml" line="1654"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1518"/>
+        <location filename="../app/MainLayout.qml" line="1548"/>
+        <location filename="../app/MainLayout.qml" line="1566"/>
+        <location filename="../app/MainLayout.qml" line="1578"/>
+        <location filename="../app/MainLayout.qml" line="1594"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1649"/>
+        <location filename="../app/MainLayout.qml" line="1658"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1717"/>
         <source>Back</source>
         <translation>Atzera</translation>
     </message>
@@ -1375,29 +1386,29 @@ Français - Wilfried</source>
         <translation type="obsolete">Orria</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1449"/>
-        <location filename="../app/MainLayout.qml" line="1484"/>
-        <location filename="../app/MainLayout.qml" line="1535"/>
-        <location filename="../app/MainLayout.qml" line="1683"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
+        <location filename="../app/MainLayout.qml" line="1488"/>
+        <location filename="../app/MainLayout.qml" line="1539"/>
+        <location filename="../app/MainLayout.qml" line="1687"/>
         <source>Options</source>
         <translation type="unfinished">Aukerak</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1315"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1494"/>
-        <location filename="../app/MainLayout.qml" line="1552"/>
-        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1319"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1498"/>
+        <location filename="../app/MainLayout.qml" line="1556"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
         <source>Retry</source>
         <translation>Berriro saiatu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1613"/>
         <source>Change</source>
         <translation>Aldatu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1619"/>
         <source>Toggle</source>
         <translation>Txandakatu</translation>
     </message>

--- a/src/ui/translations/frontend_fr.ts
+++ b/src/ui/translations/frontend_fr.ts
@@ -702,29 +702,29 @@ Français - Wilfried</translation>
         <translation type="vanished">Lancer le core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
-        <location filename="../app/Main.qml" line="2319"/>
-        <location filename="../app/Main.qml" line="2654"/>
-        <location filename="../app/Main.qml" line="2663"/>
-        <location filename="../app/Main.qml" line="3705"/>
-        <location filename="../app/Main.qml" line="3748"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2330"/>
+        <location filename="../app/Main.qml" line="2393"/>
+        <location filename="../app/Main.qml" line="2699"/>
+        <location filename="../app/Main.qml" line="3741"/>
+        <location filename="../app/Main.qml" line="3784"/>
         <source>Change launcher</source>
         <translation>Modifier le lanceur</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Remove from favorites</source>
         <translation>Retirer des favoris</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Add to favorites</source>
         <translation>Ajouter aux favoris</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2253"/>
-        <location filename="../app/Main.qml" line="2324"/>
+        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2335"/>
         <source>Write to NFC token</source>
         <translation>Écrire sur un badge NFC</translation>
     </message>
@@ -733,8 +733,8 @@ Français - Wilfried</translation>
         <translation type="vanished">QR code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2243"/>
-        <location filename="../app/Main.qml" line="2297"/>
+        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2308"/>
         <source>Launch game</source>
         <translation>Lancer le jeu</translation>
     </message>
@@ -743,118 +743,118 @@ Français - Wilfried</translation>
         <translation type="vanished">Aller à...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1063"/>
-        <location filename="../app/Main.qml" line="3381"/>
-        <location filename="../app/Main.qml" line="3428"/>
-        <location filename="../app/Main.qml" line="3438"/>
+        <location filename="../app/Main.qml" line="1070"/>
+        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3464"/>
+        <location filename="../app/Main.qml" line="3474"/>
         <source>View</source>
         <translation>Afficher</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4812"/>
+        <location filename="../app/Main.qml" line="4848"/>
         <source>Loading systems…</source>
         <translation>Chargement des systèmes…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4819"/>
+        <location filename="../app/Main.qml" line="4855"/>
         <source>Loading favorites…</source>
         <translation>Chargement des favoris…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4814"/>
+        <location filename="../app/Main.qml" line="4850"/>
         <source>Loading games…</source>
         <translation>Chargement des jeux…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2207"/>
+        <location filename="../app/Main.qml" line="2183"/>
+        <location filename="../app/Main.qml" line="2218"/>
         <source>Update media database</source>
         <translation>Mettre à jour la base de données média</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2175"/>
-        <location filename="../app/Main.qml" line="2210"/>
+        <location filename="../app/Main.qml" line="2186"/>
+        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
         <translation>Scraper les métadonnées</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Unhide</source>
         <translation>Afficher</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1056"/>
+        <location filename="../app/Main.qml" line="1063"/>
         <source>Settings</source>
         <translation type="unfinished">Réglages</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2089"/>
+        <location filename="../app/Main.qml" line="2096"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2153"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Hide</source>
         <translation>Masquer</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2247"/>
-        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2258"/>
+        <location filename="../app/Main.qml" line="2312"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2267"/>
-        <location filename="../app/Main.qml" line="2335"/>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2346"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Default</source>
         <translation>Par défaut</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="2378"/>
         <source>Current: %1</source>
         <translation>Actuel&#xa0;: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2151"/>
-        <location filename="../app/Main.qml" line="2202"/>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3364"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2230"/>
+        <location filename="../app/Main.qml" line="2238"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1028"/>
+        <location filename="../app/Main.qml" line="1035"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1048"/>
+        <location filename="../app/Main.qml" line="1055"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1052"/>
+        <location filename="../app/Main.qml" line="1059"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -863,290 +863,290 @@ Français - Wilfried</translation>
         <translation type="obsolete">Réglages et utilitaires</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="1067"/>
         <source>Quit</source>
         <translation type="unfinished">Quitter</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2290"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2173"/>
+        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2350"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2257"/>
-        <location filename="../app/Main.qml" line="2328"/>
+        <location filename="../app/Main.qml" line="2268"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2461"/>
         <source>Move</source>
         <translation type="unfinished">Déplacer</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2638"/>
+        <location filename="../app/Main.qml" line="2667"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
-        <location filename="../app/Main.qml" line="3007"/>
-        <location filename="../app/Main.qml" line="3029"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3095"/>
+        <location filename="../app/Main.qml" line="1032"/>
+        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3131"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3062"/>
+        <location filename="../app/Main.qml" line="3098"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3099"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3101"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3068"/>
+        <location filename="../app/Main.qml" line="3104"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3105"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3107"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3072"/>
+        <location filename="../app/Main.qml" line="3108"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3074"/>
+        <location filename="../app/Main.qml" line="3110"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3111"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3077"/>
+        <location filename="../app/Main.qml" line="3113"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3078"/>
+        <location filename="../app/Main.qml" line="3114"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3080"/>
+        <location filename="../app/Main.qml" line="3116"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3084"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3120"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3122"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3087"/>
+        <location filename="../app/Main.qml" line="3123"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3125"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3090"/>
+        <location filename="../app/Main.qml" line="3126"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3092"/>
+        <location filename="../app/Main.qml" line="3128"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3129"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3217"/>
+        <location filename="../app/Main.qml" line="3253"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3233"/>
+        <location filename="../app/Main.qml" line="3269"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3242"/>
+        <location filename="../app/Main.qml" line="3278"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3307"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3406"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3396"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3432"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoris</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3428"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
-        <location filename="../app/Main.qml" line="3425"/>
+        <location filename="../app/Main.qml" line="3415"/>
+        <location filename="../app/Main.qml" line="3461"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="3436"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3409"/>
+        <location filename="../app/Main.qml" line="3445"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3413"/>
-        <location filename="../app/Main.qml" line="3435"/>
+        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3489"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3485"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3456"/>
+        <location filename="../app/Main.qml" line="3492"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3475"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3511"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3479"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,24 +1155,24 @@ Français - Wilfried</translation>
         <translation type="vanished">Enregistrement du lanceur</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3672"/>
+        <location filename="../app/Main.qml" line="3708"/>
         <source>Saving…</source>
         <translation>Enregistrement…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3083"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3119"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Launcher update failed</source>
         <translation>Échec de la mise à jour du lanceur</translation>
     </message>
@@ -1181,11 +1181,11 @@ Français - Wilfried</translation>
         <translation type="vanished">Erreur&#xa0;: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
-        <location filename="../app/Main.qml" line="3282"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Retry</source>
         <translation>Réessayer</translation>
     </message>
@@ -1194,22 +1194,22 @@ Français - Wilfried</translation>
         <translation type="vanished">Annuler</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4816"/>
+        <location filename="../app/Main.qml" line="4852"/>
         <source>Loading game…</source>
         <translation>Chargement du jeu…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4821"/>
+        <location filename="../app/Main.qml" line="4857"/>
         <source>Loading recently played…</source>
         <translation>Chargement des jeux récents…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4823"/>
+        <location filename="../app/Main.qml" line="4859"/>
         <source>Loading settings…</source>
         <translation>Chargement des réglages…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4825"/>
+        <location filename="../app/Main.qml" line="4861"/>
         <source>Loading…</source>
         <translation>Chargement…</translation>
     </message>
@@ -1259,7 +1259,7 @@ Français - Wilfried</translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Select</source>
         <translation>Sélectionner</translation>
     </message>
@@ -1275,8 +1275,8 @@ Français - Wilfried</translation>
     <message>
         <location filename="../app/MainLayout.qml" line="1290"/>
         <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1371"/>
-        <location filename="../app/MainLayout.qml" line="1414"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
@@ -1291,12 +1291,17 @@ Français - Wilfried</translation>
         <translation>J&apos;ai compris</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
+        <source>Saving…</source>
+        <translation type="unfinished">Enregistrement…</translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="1389"/>
         <source>Adjust</source>
         <translation>Ajuster</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
         <source>Save</source>
         <translation>Enregistrer</translation>
     </message>
@@ -1305,28 +1310,28 @@ Français - Wilfried</translation>
         <translation type="vanished">Démarrer</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1645"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Scroll</source>
         <translation>Défiler</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1457"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1468"/>
+        <location filename="../app/MainLayout.qml" line="1555"/>
+        <location filename="../app/MainLayout.qml" line="1573"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1724"/>
         <source>View</source>
         <translation>Afficher</translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1480"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1585"/>
-        <location filename="../app/MainLayout.qml" line="1604"/>
-        <location filename="../app/MainLayout.qml" line="1677"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1454"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1540"/>
+        <location filename="../app/MainLayout.qml" line="1596"/>
+        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Move</source>
         <translation>Déplacer</translation>
     </message>
@@ -1361,21 +1366,21 @@ Français - Wilfried</translation>
         <translation>Quitter Zaparoo Frontend&#xa0;?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1417"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1485"/>
-        <location filename="../app/MainLayout.qml" line="1534"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1682"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1601"/>
+        <location filename="../app/MainLayout.qml" line="1693"/>
         <source>Open</source>
         <translation>Ouvrir</translation>
     </message>
@@ -1384,46 +1389,46 @@ Français - Wilfried</translation>
         <translation type="vanished">Quitter</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1466"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1477"/>
         <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1518"/>
-        <location filename="../app/MainLayout.qml" line="1548"/>
-        <location filename="../app/MainLayout.qml" line="1566"/>
-        <location filename="../app/MainLayout.qml" line="1578"/>
-        <location filename="../app/MainLayout.qml" line="1594"/>
-        <location filename="../app/MainLayout.qml" line="1628"/>
-        <location filename="../app/MainLayout.qml" line="1649"/>
-        <location filename="../app/MainLayout.qml" line="1658"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
-        <location filename="../app/MainLayout.qml" line="1717"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1559"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1589"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1639"/>
+        <location filename="../app/MainLayout.qml" line="1660"/>
+        <location filename="../app/MainLayout.qml" line="1669"/>
+        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1728"/>
         <source>Back</source>
         <translation>Retour</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1488"/>
-        <location filename="../app/MainLayout.qml" line="1539"/>
-        <location filename="../app/MainLayout.qml" line="1687"/>
+        <location filename="../app/MainLayout.qml" line="1464"/>
+        <location filename="../app/MainLayout.qml" line="1499"/>
+        <location filename="../app/MainLayout.qml" line="1550"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
         <source>Options</source>
         <translation>Options</translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1556"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1567"/>
+        <location filename="../app/MainLayout.qml" line="1716"/>
         <source>Retry</source>
         <translation>Réessayer</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1613"/>
+        <location filename="../app/MainLayout.qml" line="1624"/>
         <source>Change</source>
         <translation>Modifier</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1619"/>
+        <location filename="../app/MainLayout.qml" line="1630"/>
         <source>Toggle</source>
         <translation>Basculer</translation>
     </message>

--- a/src/ui/translations/frontend_fr.ts
+++ b/src/ui/translations/frontend_fr.ts
@@ -509,7 +509,7 @@ Français - Wilfried</translation>
 <context>
     <name>HubScreen</name>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>Resume: %1</source>
         <translation>Reprendre&#xa0;: %1</translation>
     </message>
@@ -543,18 +543,18 @@ Français - Wilfried</translation>
         <translation>Autres</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
-        <location filename="../screens/HubScreen.qml" line="1288"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="1305"/>
         <source>Resume</source>
         <translation>Reprendre</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>No recent games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="303"/>
         <source>Favorites</source>
         <translation>Favoris</translation>
     </message>
@@ -563,12 +563,12 @@ Français - Wilfried</translation>
         <translation type="vanished">Joués récemment</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>Update</source>
         <translation>Mise à jour</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>No internet connection</source>
         <translation type="unfinished"></translation>
     </message>
@@ -577,22 +577,22 @@ Français - Wilfried</translation>
         <translation type="vanished">Réglages et utilitaires</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="352"/>
+        <location filename="../screens/HubScreen.qml" line="355"/>
         <source>Not available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="309"/>
+        <location filename="../screens/HubScreen.qml" line="312"/>
         <source>Settings</source>
         <translation>Réglages</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="302"/>
+        <location filename="../screens/HubScreen.qml" line="305"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1591"/>
+        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Aucun système disponible. Lancez Mettre à jour la base de données média depuis les Réglages.</translation>
     </message>
@@ -702,24 +702,29 @@ Français - Wilfried</translation>
         <translation type="vanished">Lancer le core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2563"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2319"/>
+        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2663"/>
+        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3748"/>
         <source>Change launcher</source>
         <translation>Modifier le lanceur</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Remove from favorites</source>
         <translation>Retirer des favoris</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Add to favorites</source>
         <translation>Ajouter aux favoris</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2281"/>
+        <location filename="../app/Main.qml" line="2253"/>
+        <location filename="../app/Main.qml" line="2324"/>
         <source>Write to NFC token</source>
         <translation>Écrire sur un badge NFC</translation>
     </message>
@@ -728,8 +733,8 @@ Français - Wilfried</translation>
         <translation type="vanished">QR code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2243"/>
+        <location filename="../app/Main.qml" line="2297"/>
         <source>Launch game</source>
         <translation>Lancer le jeu</translation>
     </message>
@@ -738,118 +743,118 @@ Français - Wilfried</translation>
         <translation type="vanished">Aller à...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
-        <location filename="../app/Main.qml" line="3281"/>
-        <location filename="../app/Main.qml" line="3328"/>
-        <location filename="../app/Main.qml" line="3338"/>
+        <location filename="../app/Main.qml" line="1063"/>
+        <location filename="../app/Main.qml" line="3381"/>
+        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3438"/>
         <source>View</source>
         <translation>Afficher</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4603"/>
+        <location filename="../app/Main.qml" line="4812"/>
         <source>Loading systems…</source>
         <translation>Chargement des systèmes…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4610"/>
+        <location filename="../app/Main.qml" line="4819"/>
         <source>Loading favorites…</source>
         <translation>Chargement des favoris…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4605"/>
+        <location filename="../app/Main.qml" line="4814"/>
         <source>Loading games…</source>
         <translation>Chargement des jeux…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2207"/>
         <source>Update media database</source>
         <translation>Mettre à jour la base de données média</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2145"/>
-        <location filename="../app/Main.qml" line="2180"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2210"/>
         <source>Scrape metadata</source>
         <translation>Scraper les métadonnées</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2166"/>
         <source>Unhide</source>
         <translation>Afficher</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1053"/>
+        <location filename="../app/Main.qml" line="1056"/>
         <source>Settings</source>
         <translation type="unfinished">Réglages</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2076"/>
+        <location filename="../app/Main.qml" line="2089"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2142"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Hide</source>
         <translation>Masquer</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2217"/>
-        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2247"/>
+        <location filename="../app/Main.qml" line="2301"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2237"/>
-        <location filename="../app/Main.qml" line="2292"/>
-        <location filename="../app/Main.qml" line="2333"/>
+        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3371"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Default</source>
         <translation>Par défaut</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="2367"/>
         <source>Current: %1</source>
         <translation>Actuel&#xa0;: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2122"/>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2189"/>
-        <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="3264"/>
+        <location filename="../app/Main.qml" line="2151"/>
+        <location filename="../app/Main.qml" line="2202"/>
+        <location filename="../app/Main.qml" line="2219"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3364"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1028"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1045"/>
+        <location filename="../app/Main.qml" line="1048"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1049"/>
+        <location filename="../app/Main.qml" line="1052"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -858,311 +863,316 @@ Français - Wilfried</translation>
         <translation type="obsolete">Réglages et utilitaires</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1057"/>
+        <location filename="../app/Main.qml" line="1060"/>
         <source>Quit</source>
         <translation type="unfinished">Quitter</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2241"/>
-        <location filename="../app/Main.qml" line="2260"/>
-        <location filename="../app/Main.qml" line="2296"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2290"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="2285"/>
+        <location filename="../app/Main.qml" line="2257"/>
+        <location filename="../app/Main.qml" line="2328"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2360"/>
+        <location filename="../app/Main.qml" line="2438"/>
         <source>Move</source>
         <translation type="unfinished">Déplacer</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2638"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
-        <location filename="../app/Main.qml" line="2907"/>
-        <location filename="../app/Main.qml" line="2929"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="3007"/>
+        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <source>Change launcher: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3053"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2962"/>
+        <location filename="../app/Main.qml" line="3062"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2963"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2965"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2968"/>
+        <location filename="../app/Main.qml" line="3068"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2969"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2971"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2972"/>
+        <location filename="../app/Main.qml" line="3072"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2974"/>
+        <location filename="../app/Main.qml" line="3074"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2975"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2977"/>
+        <location filename="../app/Main.qml" line="3077"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2978"/>
+        <location filename="../app/Main.qml" line="3078"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2980"/>
+        <location filename="../app/Main.qml" line="3080"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2981"/>
+        <location filename="../app/Main.qml" line="3081"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2984"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3084"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2986"/>
+        <location filename="../app/Main.qml" line="3086"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2987"/>
+        <location filename="../app/Main.qml" line="3087"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2989"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2990"/>
+        <location filename="../app/Main.qml" line="3090"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2992"/>
+        <location filename="../app/Main.qml" line="3092"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3217"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3233"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3142"/>
+        <location filename="../app/Main.qml" line="3242"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3271"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3256"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3370"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3296"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3396"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoris</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3292"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
-        <location filename="../app/Main.qml" line="3325"/>
+        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3425"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3309"/>
+        <location filename="../app/Main.qml" line="3409"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3313"/>
-        <location filename="../app/Main.qml" line="3335"/>
+        <location filename="../app/Main.qml" line="3413"/>
+        <location filename="../app/Main.qml" line="3435"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3317"/>
+        <location filename="../app/Main.qml" line="3417"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3353"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3349"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3449"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3456"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3375"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3475"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3479"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3556"/>
-        <location filename="../app/Main.qml" line="3574"/>
         <source>Saving launcher</source>
-        <translation>Enregistrement du lanceur</translation>
+        <translation type="vanished">Enregistrement du lanceur</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3560"/>
-        <location filename="../app/Main.qml" line="3577"/>
+        <location filename="../app/Main.qml" line="3672"/>
         <source>Saving…</source>
         <translation>Enregistrement…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2983"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3083"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Launcher update failed</source>
         <translation>Échec de la mise à jour du lanceur</translation>
     </message>
@@ -1171,10 +1181,11 @@ Français - Wilfried</translation>
         <translation type="vanished">Erreur&#xa0;: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
-        <location filename="../app/Main.qml" line="3182"/>
-        <location filename="../app/Main.qml" line="3590"/>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Retry</source>
         <translation>Réessayer</translation>
     </message>
@@ -1183,22 +1194,22 @@ Français - Wilfried</translation>
         <translation type="vanished">Annuler</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4607"/>
+        <location filename="../app/Main.qml" line="4816"/>
         <source>Loading game…</source>
         <translation>Chargement du jeu…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4612"/>
+        <location filename="../app/Main.qml" line="4821"/>
         <source>Loading recently played…</source>
         <translation>Chargement des jeux récents…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4614"/>
+        <location filename="../app/Main.qml" line="4823"/>
         <source>Loading settings…</source>
         <translation>Chargement des réglages…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4616"/>
+        <location filename="../app/Main.qml" line="4825"/>
         <source>Loading…</source>
         <translation>Chargement…</translation>
     </message>
@@ -1227,7 +1238,7 @@ Français - Wilfried</translation>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
         <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
@@ -1247,45 +1258,45 @@ Français - Wilfried</translation>
         <translation>Êtes-vous sûr de vouloir quitter&#xa0;?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1279"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
         <source>Select</source>
         <translation>Sélectionner</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1293"/>
-        <location filename="../app/MainLayout.qml" line="1308"/>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1345"/>
+        <location filename="../app/MainLayout.qml" line="1283"/>
+        <location filename="../app/MainLayout.qml" line="1297"/>
+        <location filename="../app/MainLayout.qml" line="1312"/>
+        <location filename="../app/MainLayout.qml" line="1323"/>
+        <location filename="../app/MainLayout.qml" line="1349"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1326"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1290"/>
+        <location filename="../app/MainLayout.qml" line="1330"/>
+        <location filename="../app/MainLayout.qml" line="1371"/>
+        <location filename="../app/MainLayout.qml" line="1414"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1304"/>
+        <location filename="../app/MainLayout.qml" line="1308"/>
         <source>Done</source>
         <translation>Terminé</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1334"/>
+        <location filename="../app/MainLayout.qml" line="1338"/>
         <source>I understand</source>
         <translation>J&apos;ai compris</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Adjust</source>
         <translation>Ajuster</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
         <source>Save</source>
         <translation>Enregistrer</translation>
     </message>
@@ -1294,28 +1305,28 @@ Français - Wilfried</translation>
         <translation type="vanished">Démarrer</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1641"/>
+        <location filename="../app/MainLayout.qml" line="1645"/>
         <source>Scroll</source>
         <translation>Défiler</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1558"/>
-        <location filename="../app/MainLayout.qml" line="1690"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1544"/>
+        <location filename="../app/MainLayout.qml" line="1562"/>
+        <location filename="../app/MainLayout.qml" line="1694"/>
+        <location filename="../app/MainLayout.qml" line="1713"/>
         <source>View</source>
         <translation>Afficher</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1271"/>
-        <location filename="../app/MainLayout.qml" line="1359"/>
-        <location filename="../app/MainLayout.qml" line="1439"/>
-        <location filename="../app/MainLayout.qml" line="1476"/>
-        <location filename="../app/MainLayout.qml" line="1525"/>
-        <location filename="../app/MainLayout.qml" line="1581"/>
-        <location filename="../app/MainLayout.qml" line="1600"/>
-        <location filename="../app/MainLayout.qml" line="1673"/>
+        <location filename="../app/MainLayout.qml" line="1275"/>
+        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1443"/>
+        <location filename="../app/MainLayout.qml" line="1480"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1585"/>
+        <location filename="../app/MainLayout.qml" line="1604"/>
+        <location filename="../app/MainLayout.qml" line="1677"/>
         <source>Move</source>
         <translation>Déplacer</translation>
     </message>
@@ -1350,21 +1361,21 @@ Français - Wilfried</translation>
         <translation>Quitter Zaparoo Frontend&#xa0;?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1406"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1410"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1481"/>
-        <location filename="../app/MainLayout.qml" line="1530"/>
-        <location filename="../app/MainLayout.qml" line="1586"/>
-        <location filename="../app/MainLayout.qml" line="1678"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1590"/>
+        <location filename="../app/MainLayout.qml" line="1682"/>
         <source>Open</source>
         <translation>Ouvrir</translation>
     </message>
@@ -1373,46 +1384,46 @@ Français - Wilfried</translation>
         <translation type="vanished">Quitter</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1462"/>
-        <location filename="../app/MainLayout.qml" line="1487"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1514"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1574"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1624"/>
-        <location filename="../app/MainLayout.qml" line="1645"/>
-        <location filename="../app/MainLayout.qml" line="1654"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1518"/>
+        <location filename="../app/MainLayout.qml" line="1548"/>
+        <location filename="../app/MainLayout.qml" line="1566"/>
+        <location filename="../app/MainLayout.qml" line="1578"/>
+        <location filename="../app/MainLayout.qml" line="1594"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1649"/>
+        <location filename="../app/MainLayout.qml" line="1658"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1717"/>
         <source>Back</source>
         <translation>Retour</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1449"/>
-        <location filename="../app/MainLayout.qml" line="1484"/>
-        <location filename="../app/MainLayout.qml" line="1535"/>
-        <location filename="../app/MainLayout.qml" line="1683"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
+        <location filename="../app/MainLayout.qml" line="1488"/>
+        <location filename="../app/MainLayout.qml" line="1539"/>
+        <location filename="../app/MainLayout.qml" line="1687"/>
         <source>Options</source>
         <translation>Options</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1315"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1494"/>
-        <location filename="../app/MainLayout.qml" line="1552"/>
-        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1319"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1498"/>
+        <location filename="../app/MainLayout.qml" line="1556"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
         <source>Retry</source>
         <translation>Réessayer</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1613"/>
         <source>Change</source>
         <translation>Modifier</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1619"/>
         <source>Toggle</source>
         <translation>Basculer</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -519,23 +519,23 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
-        <location filename="../screens/HubScreen.qml" line="1288"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="1305"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>No recent games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>Resume: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="303"/>
         <source>Favorites</source>
         <translation>מועדפים</translation>
     </message>
@@ -544,32 +544,32 @@ Français - Wilfried</source>
         <translation type="vanished">שוחקו לאחרונה</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>No internet connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="352"/>
+        <location filename="../screens/HubScreen.qml" line="355"/>
         <source>Not available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="309"/>
+        <location filename="../screens/HubScreen.qml" line="312"/>
         <source>Settings</source>
         <translation>הגדרות</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="302"/>
+        <location filename="../screens/HubScreen.qml" line="305"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1591"/>
+        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>אין מערכות זמינות. הפעילו &quot;עדכון מסד נתוני מדיה&quot; מההגדרות.</translation>
     </message>
@@ -675,81 +675,86 @@ Français - Wilfried</source>
         <translation type="vanished">הפעל את הליבה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2563"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2319"/>
+        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2663"/>
+        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3748"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2207"/>
         <source>Update media database</source>
         <translation type="unfinished">עדכון מסד נתוני המדיה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2145"/>
-        <location filename="../app/Main.qml" line="2180"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2210"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">איסוף מטא-נתונים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2166"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1053"/>
+        <location filename="../app/Main.qml" line="1056"/>
         <source>Settings</source>
         <translation type="unfinished">הגדרות</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2076"/>
+        <location filename="../app/Main.qml" line="2089"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2142"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2243"/>
+        <location filename="../app/Main.qml" line="2297"/>
         <source>Launch game</source>
         <translation>הפעל משחק</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2217"/>
-        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2247"/>
+        <location filename="../app/Main.qml" line="2301"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2237"/>
-        <location filename="../app/Main.qml" line="2292"/>
-        <location filename="../app/Main.qml" line="2333"/>
+        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Remove from favorites</source>
         <translation>הסר מהמועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Add to favorites</source>
         <translation>הוסף למועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2281"/>
+        <location filename="../app/Main.qml" line="2253"/>
+        <location filename="../app/Main.qml" line="2324"/>
         <source>Write to NFC token</source>
         <translation>כתוב לטוקן NFC</translation>
     </message>
@@ -758,369 +763,371 @@ Français - Wilfried</source>
         <translation type="vanished">קוד QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3371"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Default</source>
         <translation type="unfinished">ברירת מחדל</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="2367"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2122"/>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2189"/>
-        <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="3264"/>
+        <location filename="../app/Main.qml" line="2151"/>
+        <location filename="../app/Main.qml" line="2202"/>
+        <location filename="../app/Main.qml" line="2219"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3364"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3296"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3396"/>
         <source>Favorites</source>
         <translation type="unfinished">מועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
-        <location filename="../app/Main.qml" line="3281"/>
-        <location filename="../app/Main.qml" line="3328"/>
-        <location filename="../app/Main.qml" line="3338"/>
+        <location filename="../app/Main.qml" line="1063"/>
+        <location filename="../app/Main.qml" line="3381"/>
+        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3438"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3309"/>
+        <location filename="../app/Main.qml" line="3409"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3370"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3375"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3475"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3292"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3479"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1028"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1045"/>
+        <location filename="../app/Main.qml" line="1048"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1049"/>
+        <location filename="../app/Main.qml" line="1052"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1057"/>
+        <location filename="../app/Main.qml" line="1060"/>
         <source>Quit</source>
         <translation type="unfinished">יציאה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2241"/>
-        <location filename="../app/Main.qml" line="2260"/>
-        <location filename="../app/Main.qml" line="2296"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2290"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="2285"/>
+        <location filename="../app/Main.qml" line="2257"/>
+        <location filename="../app/Main.qml" line="2328"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2360"/>
+        <location filename="../app/Main.qml" line="2438"/>
         <source>Move</source>
         <translation type="unfinished">הזזה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2638"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
-        <location filename="../app/Main.qml" line="2907"/>
-        <location filename="../app/Main.qml" line="2929"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="3007"/>
+        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>OK</source>
         <translation type="unfinished">אישור</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <source>Change launcher: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3053"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2962"/>
+        <location filename="../app/Main.qml" line="3062"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2963"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2965"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2968"/>
+        <location filename="../app/Main.qml" line="3068"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2969"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2971"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2972"/>
+        <location filename="../app/Main.qml" line="3072"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2974"/>
+        <location filename="../app/Main.qml" line="3074"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2975"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2977"/>
+        <location filename="../app/Main.qml" line="3077"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2978"/>
+        <location filename="../app/Main.qml" line="3078"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2980"/>
+        <location filename="../app/Main.qml" line="3080"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2981"/>
+        <location filename="../app/Main.qml" line="3081"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2984"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3084"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2986"/>
+        <location filename="../app/Main.qml" line="3086"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2987"/>
+        <location filename="../app/Main.qml" line="3087"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2989"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2990"/>
+        <location filename="../app/Main.qml" line="3090"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2992"/>
+        <location filename="../app/Main.qml" line="3092"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3217"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3233"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3142"/>
+        <location filename="../app/Main.qml" line="3242"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3271"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3256"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
-        <location filename="../app/Main.qml" line="3325"/>
+        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3425"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3313"/>
-        <location filename="../app/Main.qml" line="3335"/>
+        <location filename="../app/Main.qml" line="3413"/>
+        <location filename="../app/Main.qml" line="3435"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3317"/>
+        <location filename="../app/Main.qml" line="3417"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3353"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3349"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3449"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3456"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3556"/>
-        <location filename="../app/Main.qml" line="3574"/>
-        <source>Saving launcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3560"/>
-        <location filename="../app/Main.qml" line="3577"/>
+        <location filename="../app/Main.qml" line="3672"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2983"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3083"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
-        <location filename="../app/Main.qml" line="3182"/>
-        <location filename="../app/Main.qml" line="3590"/>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Retry</source>
         <translation type="unfinished">נסה שוב</translation>
     </message>
@@ -1129,37 +1136,37 @@ Français - Wilfried</source>
         <translation type="obsolete">ביטול</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4603"/>
+        <location filename="../app/Main.qml" line="4812"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4605"/>
+        <location filename="../app/Main.qml" line="4814"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4607"/>
+        <location filename="../app/Main.qml" line="4816"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4610"/>
+        <location filename="../app/Main.qml" line="4819"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4612"/>
+        <location filename="../app/Main.qml" line="4821"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4614"/>
+        <location filename="../app/Main.qml" line="4823"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4616"/>
+        <location filename="../app/Main.qml" line="4825"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>
@@ -1213,7 +1220,7 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
         <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
         <source>OK</source>
         <translation type="unfinished">אישור</translation>
     </message>
@@ -1238,76 +1245,76 @@ Français - Wilfried</source>
         <translation>האם אתה בטוח שברצונך לצאת?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1271"/>
-        <location filename="../app/MainLayout.qml" line="1359"/>
-        <location filename="../app/MainLayout.qml" line="1439"/>
-        <location filename="../app/MainLayout.qml" line="1476"/>
-        <location filename="../app/MainLayout.qml" line="1525"/>
-        <location filename="../app/MainLayout.qml" line="1581"/>
-        <location filename="../app/MainLayout.qml" line="1600"/>
-        <location filename="../app/MainLayout.qml" line="1673"/>
+        <location filename="../app/MainLayout.qml" line="1275"/>
+        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1443"/>
+        <location filename="../app/MainLayout.qml" line="1480"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1585"/>
+        <location filename="../app/MainLayout.qml" line="1604"/>
+        <location filename="../app/MainLayout.qml" line="1677"/>
         <source>Move</source>
         <translation>הזזה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1279"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
         <source>Select</source>
         <translation>בחירה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1293"/>
-        <location filename="../app/MainLayout.qml" line="1308"/>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1345"/>
+        <location filename="../app/MainLayout.qml" line="1283"/>
+        <location filename="../app/MainLayout.qml" line="1297"/>
+        <location filename="../app/MainLayout.qml" line="1312"/>
+        <location filename="../app/MainLayout.qml" line="1323"/>
+        <location filename="../app/MainLayout.qml" line="1349"/>
         <source>Close</source>
         <translation>סגור</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1326"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1290"/>
+        <location filename="../app/MainLayout.qml" line="1330"/>
+        <location filename="../app/MainLayout.qml" line="1371"/>
+        <location filename="../app/MainLayout.qml" line="1414"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1304"/>
+        <location filename="../app/MainLayout.qml" line="1308"/>
         <source>Done</source>
         <translation>הושלם</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1315"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1494"/>
-        <location filename="../app/MainLayout.qml" line="1552"/>
-        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1319"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1498"/>
+        <location filename="../app/MainLayout.qml" line="1556"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
         <source>Retry</source>
         <translation>נסה שוב</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1334"/>
+        <location filename="../app/MainLayout.qml" line="1338"/>
         <source>I understand</source>
         <translation>הבנתי</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1406"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1410"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1316,11 +1323,11 @@ Français - Wilfried</source>
         <translation type="vanished">התחל</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1481"/>
-        <location filename="../app/MainLayout.qml" line="1530"/>
-        <location filename="../app/MainLayout.qml" line="1586"/>
-        <location filename="../app/MainLayout.qml" line="1678"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1590"/>
+        <location filename="../app/MainLayout.qml" line="1682"/>
         <source>Open</source>
         <translation>פתח</translation>
     </message>
@@ -1329,28 +1336,28 @@ Français - Wilfried</source>
         <translation type="vanished">יציאה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1462"/>
-        <location filename="../app/MainLayout.qml" line="1487"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1514"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1574"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1624"/>
-        <location filename="../app/MainLayout.qml" line="1645"/>
-        <location filename="../app/MainLayout.qml" line="1654"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1518"/>
+        <location filename="../app/MainLayout.qml" line="1548"/>
+        <location filename="../app/MainLayout.qml" line="1566"/>
+        <location filename="../app/MainLayout.qml" line="1578"/>
+        <location filename="../app/MainLayout.qml" line="1594"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1649"/>
+        <location filename="../app/MainLayout.qml" line="1658"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1717"/>
         <source>Back</source>
         <translation>חזרה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1558"/>
-        <location filename="../app/MainLayout.qml" line="1690"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1544"/>
+        <location filename="../app/MainLayout.qml" line="1562"/>
+        <location filename="../app/MainLayout.qml" line="1694"/>
+        <location filename="../app/MainLayout.qml" line="1713"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1359,25 +1366,25 @@ Français - Wilfried</source>
         <translation type="vanished">עמוד</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1449"/>
-        <location filename="../app/MainLayout.qml" line="1484"/>
-        <location filename="../app/MainLayout.qml" line="1535"/>
-        <location filename="../app/MainLayout.qml" line="1683"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
+        <location filename="../app/MainLayout.qml" line="1488"/>
+        <location filename="../app/MainLayout.qml" line="1539"/>
+        <location filename="../app/MainLayout.qml" line="1687"/>
         <source>Options</source>
         <translation>אפשרויות</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1613"/>
         <source>Change</source>
         <translation>שינוי</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1619"/>
         <source>Toggle</source>
         <translation>החלף</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1641"/>
+        <location filename="../app/MainLayout.qml" line="1645"/>
         <source>Scroll</source>
         <translation>גלילה</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -675,86 +675,86 @@ Français - Wilfried</source>
         <translation type="vanished">הפעל את הליבה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
-        <location filename="../app/Main.qml" line="2319"/>
-        <location filename="../app/Main.qml" line="2654"/>
-        <location filename="../app/Main.qml" line="2663"/>
-        <location filename="../app/Main.qml" line="3705"/>
-        <location filename="../app/Main.qml" line="3748"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2330"/>
+        <location filename="../app/Main.qml" line="2393"/>
+        <location filename="../app/Main.qml" line="2699"/>
+        <location filename="../app/Main.qml" line="3741"/>
+        <location filename="../app/Main.qml" line="3784"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2207"/>
+        <location filename="../app/Main.qml" line="2183"/>
+        <location filename="../app/Main.qml" line="2218"/>
         <source>Update media database</source>
         <translation type="unfinished">עדכון מסד נתוני המדיה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2175"/>
-        <location filename="../app/Main.qml" line="2210"/>
+        <location filename="../app/Main.qml" line="2186"/>
+        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">איסוף מטא-נתונים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1056"/>
+        <location filename="../app/Main.qml" line="1063"/>
         <source>Settings</source>
         <translation type="unfinished">הגדרות</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2089"/>
+        <location filename="../app/Main.qml" line="2096"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2153"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2243"/>
-        <location filename="../app/Main.qml" line="2297"/>
+        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2308"/>
         <source>Launch game</source>
         <translation>הפעל משחק</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2247"/>
-        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2258"/>
+        <location filename="../app/Main.qml" line="2312"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2267"/>
-        <location filename="../app/Main.qml" line="2335"/>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2346"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Remove from favorites</source>
         <translation>הסר מהמועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Add to favorites</source>
         <translation>הוסף למועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2253"/>
-        <location filename="../app/Main.qml" line="2324"/>
+        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2335"/>
         <source>Write to NFC token</source>
         <translation>כתוב לטוקן NFC</translation>
     </message>
@@ -763,371 +763,371 @@ Français - Wilfried</source>
         <translation type="vanished">קוד QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Default</source>
         <translation type="unfinished">ברירת מחדל</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="2378"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2151"/>
-        <location filename="../app/Main.qml" line="2202"/>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3364"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2230"/>
+        <location filename="../app/Main.qml" line="2238"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3396"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3432"/>
         <source>Favorites</source>
         <translation type="unfinished">מועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1063"/>
-        <location filename="../app/Main.qml" line="3381"/>
-        <location filename="../app/Main.qml" line="3428"/>
-        <location filename="../app/Main.qml" line="3438"/>
+        <location filename="../app/Main.qml" line="1070"/>
+        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3464"/>
+        <location filename="../app/Main.qml" line="3474"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3409"/>
+        <location filename="../app/Main.qml" line="3445"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3406"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3475"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3511"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3428"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3479"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="3436"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1028"/>
+        <location filename="../app/Main.qml" line="1035"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1048"/>
+        <location filename="../app/Main.qml" line="1055"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1052"/>
+        <location filename="../app/Main.qml" line="1059"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="1067"/>
         <source>Quit</source>
         <translation type="unfinished">יציאה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2290"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2173"/>
+        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2350"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2257"/>
-        <location filename="../app/Main.qml" line="2328"/>
+        <location filename="../app/Main.qml" line="2268"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2461"/>
         <source>Move</source>
         <translation type="unfinished">הזזה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2638"/>
+        <location filename="../app/Main.qml" line="2667"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
-        <location filename="../app/Main.qml" line="3007"/>
-        <location filename="../app/Main.qml" line="3029"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3095"/>
+        <location filename="../app/Main.qml" line="1032"/>
+        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3131"/>
         <source>OK</source>
         <translation type="unfinished">אישור</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3062"/>
+        <location filename="../app/Main.qml" line="3098"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3099"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3101"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3068"/>
+        <location filename="../app/Main.qml" line="3104"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3105"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3107"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3072"/>
+        <location filename="../app/Main.qml" line="3108"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3074"/>
+        <location filename="../app/Main.qml" line="3110"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3111"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3077"/>
+        <location filename="../app/Main.qml" line="3113"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3078"/>
+        <location filename="../app/Main.qml" line="3114"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3080"/>
+        <location filename="../app/Main.qml" line="3116"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3084"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3120"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3122"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3087"/>
+        <location filename="../app/Main.qml" line="3123"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3125"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3090"/>
+        <location filename="../app/Main.qml" line="3126"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3092"/>
+        <location filename="../app/Main.qml" line="3128"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3129"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3217"/>
+        <location filename="../app/Main.qml" line="3253"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3233"/>
+        <location filename="../app/Main.qml" line="3269"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3242"/>
+        <location filename="../app/Main.qml" line="3278"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3307"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
-        <location filename="../app/Main.qml" line="3425"/>
+        <location filename="../app/Main.qml" line="3415"/>
+        <location filename="../app/Main.qml" line="3461"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3413"/>
-        <location filename="../app/Main.qml" line="3435"/>
+        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3489"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3485"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3456"/>
+        <location filename="../app/Main.qml" line="3492"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3672"/>
+        <location filename="../app/Main.qml" line="3708"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3083"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3119"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
-        <location filename="../app/Main.qml" line="3282"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Retry</source>
         <translation type="unfinished">נסה שוב</translation>
     </message>
@@ -1136,37 +1136,37 @@ Français - Wilfried</source>
         <translation type="obsolete">ביטול</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4812"/>
+        <location filename="../app/Main.qml" line="4848"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4814"/>
+        <location filename="../app/Main.qml" line="4850"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4816"/>
+        <location filename="../app/Main.qml" line="4852"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4819"/>
+        <location filename="../app/Main.qml" line="4855"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4821"/>
+        <location filename="../app/Main.qml" line="4857"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4823"/>
+        <location filename="../app/Main.qml" line="4859"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4825"/>
+        <location filename="../app/Main.qml" line="4861"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>
@@ -1246,19 +1246,19 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1480"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1585"/>
-        <location filename="../app/MainLayout.qml" line="1604"/>
-        <location filename="../app/MainLayout.qml" line="1677"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1454"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1540"/>
+        <location filename="../app/MainLayout.qml" line="1596"/>
+        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Move</source>
         <translation>הזזה</translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Select</source>
         <translation>בחירה</translation>
     </message>
@@ -1274,8 +1274,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="1290"/>
         <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1371"/>
-        <location filename="../app/MainLayout.qml" line="1414"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
@@ -1286,10 +1286,10 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1556"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1567"/>
+        <location filename="../app/MainLayout.qml" line="1716"/>
         <source>Retry</source>
         <translation>נסה שוב</translation>
     </message>
@@ -1299,22 +1299,27 @@ Français - Wilfried</source>
         <translation>הבנתי</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
+        <source>Saving…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="1389"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1417"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1323,11 +1328,11 @@ Français - Wilfried</source>
         <translation type="vanished">התחל</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1485"/>
-        <location filename="../app/MainLayout.qml" line="1534"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1682"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1601"/>
+        <location filename="../app/MainLayout.qml" line="1693"/>
         <source>Open</source>
         <translation>פתח</translation>
     </message>
@@ -1336,28 +1341,28 @@ Français - Wilfried</source>
         <translation type="vanished">יציאה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1466"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1477"/>
         <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1518"/>
-        <location filename="../app/MainLayout.qml" line="1548"/>
-        <location filename="../app/MainLayout.qml" line="1566"/>
-        <location filename="../app/MainLayout.qml" line="1578"/>
-        <location filename="../app/MainLayout.qml" line="1594"/>
-        <location filename="../app/MainLayout.qml" line="1628"/>
-        <location filename="../app/MainLayout.qml" line="1649"/>
-        <location filename="../app/MainLayout.qml" line="1658"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
-        <location filename="../app/MainLayout.qml" line="1717"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1559"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1589"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1639"/>
+        <location filename="../app/MainLayout.qml" line="1660"/>
+        <location filename="../app/MainLayout.qml" line="1669"/>
+        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1728"/>
         <source>Back</source>
         <translation>חזרה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1457"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1468"/>
+        <location filename="../app/MainLayout.qml" line="1555"/>
+        <location filename="../app/MainLayout.qml" line="1573"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1724"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1366,25 +1371,25 @@ Français - Wilfried</source>
         <translation type="vanished">עמוד</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1488"/>
-        <location filename="../app/MainLayout.qml" line="1539"/>
-        <location filename="../app/MainLayout.qml" line="1687"/>
+        <location filename="../app/MainLayout.qml" line="1464"/>
+        <location filename="../app/MainLayout.qml" line="1499"/>
+        <location filename="../app/MainLayout.qml" line="1550"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
         <source>Options</source>
         <translation>אפשרויות</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1613"/>
+        <location filename="../app/MainLayout.qml" line="1624"/>
         <source>Change</source>
         <translation>שינוי</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1619"/>
+        <location filename="../app/MainLayout.qml" line="1630"/>
         <source>Toggle</source>
         <translation>החלף</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1645"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Scroll</source>
         <translation>גלילה</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -519,23 +519,23 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
-        <location filename="../screens/HubScreen.qml" line="1288"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="1305"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>No recent games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>Resume: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="303"/>
         <source>Favorites</source>
         <translation>पसंदीदा</translation>
     </message>
@@ -544,32 +544,32 @@ Français - Wilfried</source>
         <translation type="vanished">हाल ही में खेले गए</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>No internet connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="352"/>
+        <location filename="../screens/HubScreen.qml" line="355"/>
         <source>Not available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="309"/>
+        <location filename="../screens/HubScreen.qml" line="312"/>
         <source>Settings</source>
         <translation>सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="302"/>
+        <location filename="../screens/HubScreen.qml" line="305"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1591"/>
+        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>कोई सिस्टम उपलब्ध नहीं है। सेटिंग्स से मीडिया डेटाबेस अपडेट चलाएँ।</translation>
     </message>
@@ -675,81 +675,86 @@ Français - Wilfried</source>
         <translation type="vanished">कोर चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2563"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2319"/>
+        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2663"/>
+        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3748"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2207"/>
         <source>Update media database</source>
         <translation type="unfinished">मीडिया डेटाबेस अपडेट करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2145"/>
-        <location filename="../app/Main.qml" line="2180"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2210"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">मेटाडेटा स्क्रैप करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2166"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1053"/>
+        <location filename="../app/Main.qml" line="1056"/>
         <source>Settings</source>
         <translation type="unfinished">सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2076"/>
+        <location filename="../app/Main.qml" line="2089"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2142"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2243"/>
+        <location filename="../app/Main.qml" line="2297"/>
         <source>Launch game</source>
         <translation>गेम चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2217"/>
-        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2247"/>
+        <location filename="../app/Main.qml" line="2301"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2237"/>
-        <location filename="../app/Main.qml" line="2292"/>
-        <location filename="../app/Main.qml" line="2333"/>
+        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Remove from favorites</source>
         <translation>पसंदीदा से हटाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Add to favorites</source>
         <translation>पसंदीदा में जोड़ें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2281"/>
+        <location filename="../app/Main.qml" line="2253"/>
+        <location filename="../app/Main.qml" line="2324"/>
         <source>Write to NFC token</source>
         <translation>NFC टोकन पर लिखें</translation>
     </message>
@@ -758,369 +763,371 @@ Français - Wilfried</source>
         <translation type="vanished">QR कोड</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3371"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Default</source>
         <translation type="unfinished">डिफ़ॉल्ट</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="2367"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2122"/>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2189"/>
-        <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="3264"/>
+        <location filename="../app/Main.qml" line="2151"/>
+        <location filename="../app/Main.qml" line="2202"/>
+        <location filename="../app/Main.qml" line="2219"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3364"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3296"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3396"/>
         <source>Favorites</source>
         <translation type="unfinished">पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
-        <location filename="../app/Main.qml" line="3281"/>
-        <location filename="../app/Main.qml" line="3328"/>
-        <location filename="../app/Main.qml" line="3338"/>
+        <location filename="../app/Main.qml" line="1063"/>
+        <location filename="../app/Main.qml" line="3381"/>
+        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3438"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3309"/>
+        <location filename="../app/Main.qml" line="3409"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3370"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3375"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3475"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3292"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3479"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1028"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1045"/>
+        <location filename="../app/Main.qml" line="1048"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1049"/>
+        <location filename="../app/Main.qml" line="1052"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1057"/>
+        <location filename="../app/Main.qml" line="1060"/>
         <source>Quit</source>
         <translation type="unfinished">बंद करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2241"/>
-        <location filename="../app/Main.qml" line="2260"/>
-        <location filename="../app/Main.qml" line="2296"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2290"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="2285"/>
+        <location filename="../app/Main.qml" line="2257"/>
+        <location filename="../app/Main.qml" line="2328"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2360"/>
+        <location filename="../app/Main.qml" line="2438"/>
         <source>Move</source>
         <translation type="unfinished">स्थानांतरित करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2638"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
-        <location filename="../app/Main.qml" line="2907"/>
-        <location filename="../app/Main.qml" line="2929"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="3007"/>
+        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>OK</source>
         <translation type="unfinished">ठीक है</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <source>Change launcher: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3053"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2962"/>
+        <location filename="../app/Main.qml" line="3062"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2963"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2965"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2968"/>
+        <location filename="../app/Main.qml" line="3068"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2969"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2971"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2972"/>
+        <location filename="../app/Main.qml" line="3072"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2974"/>
+        <location filename="../app/Main.qml" line="3074"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2975"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2977"/>
+        <location filename="../app/Main.qml" line="3077"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2978"/>
+        <location filename="../app/Main.qml" line="3078"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2980"/>
+        <location filename="../app/Main.qml" line="3080"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2981"/>
+        <location filename="../app/Main.qml" line="3081"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2984"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3084"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2986"/>
+        <location filename="../app/Main.qml" line="3086"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2987"/>
+        <location filename="../app/Main.qml" line="3087"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2989"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2990"/>
+        <location filename="../app/Main.qml" line="3090"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2992"/>
+        <location filename="../app/Main.qml" line="3092"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3217"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3233"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3142"/>
+        <location filename="../app/Main.qml" line="3242"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3271"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3256"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
-        <location filename="../app/Main.qml" line="3325"/>
+        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3425"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3313"/>
-        <location filename="../app/Main.qml" line="3335"/>
+        <location filename="../app/Main.qml" line="3413"/>
+        <location filename="../app/Main.qml" line="3435"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3317"/>
+        <location filename="../app/Main.qml" line="3417"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3353"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3349"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3449"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3456"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3556"/>
-        <location filename="../app/Main.qml" line="3574"/>
-        <source>Saving launcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3560"/>
-        <location filename="../app/Main.qml" line="3577"/>
+        <location filename="../app/Main.qml" line="3672"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2983"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3083"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
-        <location filename="../app/Main.qml" line="3182"/>
-        <location filename="../app/Main.qml" line="3590"/>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Retry</source>
         <translation type="unfinished">फिर से प्रयास करें</translation>
     </message>
@@ -1129,37 +1136,37 @@ Français - Wilfried</source>
         <translation type="obsolete">रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4603"/>
+        <location filename="../app/Main.qml" line="4812"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4605"/>
+        <location filename="../app/Main.qml" line="4814"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4607"/>
+        <location filename="../app/Main.qml" line="4816"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4610"/>
+        <location filename="../app/Main.qml" line="4819"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4612"/>
+        <location filename="../app/Main.qml" line="4821"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4614"/>
+        <location filename="../app/Main.qml" line="4823"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4616"/>
+        <location filename="../app/Main.qml" line="4825"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>
@@ -1213,7 +1220,7 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
         <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
         <source>OK</source>
         <translation type="unfinished">ठीक है</translation>
     </message>
@@ -1238,76 +1245,76 @@ Français - Wilfried</source>
         <translation>क्या आप वाकई बाहर निकलना चाहते हैं?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1271"/>
-        <location filename="../app/MainLayout.qml" line="1359"/>
-        <location filename="../app/MainLayout.qml" line="1439"/>
-        <location filename="../app/MainLayout.qml" line="1476"/>
-        <location filename="../app/MainLayout.qml" line="1525"/>
-        <location filename="../app/MainLayout.qml" line="1581"/>
-        <location filename="../app/MainLayout.qml" line="1600"/>
-        <location filename="../app/MainLayout.qml" line="1673"/>
+        <location filename="../app/MainLayout.qml" line="1275"/>
+        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1443"/>
+        <location filename="../app/MainLayout.qml" line="1480"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1585"/>
+        <location filename="../app/MainLayout.qml" line="1604"/>
+        <location filename="../app/MainLayout.qml" line="1677"/>
         <source>Move</source>
         <translation>स्थानांतरित करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1279"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
         <source>Select</source>
         <translation>चुनें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1293"/>
-        <location filename="../app/MainLayout.qml" line="1308"/>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1345"/>
+        <location filename="../app/MainLayout.qml" line="1283"/>
+        <location filename="../app/MainLayout.qml" line="1297"/>
+        <location filename="../app/MainLayout.qml" line="1312"/>
+        <location filename="../app/MainLayout.qml" line="1323"/>
+        <location filename="../app/MainLayout.qml" line="1349"/>
         <source>Close</source>
         <translation>बंद करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1326"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1290"/>
+        <location filename="../app/MainLayout.qml" line="1330"/>
+        <location filename="../app/MainLayout.qml" line="1371"/>
+        <location filename="../app/MainLayout.qml" line="1414"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1304"/>
+        <location filename="../app/MainLayout.qml" line="1308"/>
         <source>Done</source>
         <translation>पूरा</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1315"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1494"/>
-        <location filename="../app/MainLayout.qml" line="1552"/>
-        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1319"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1498"/>
+        <location filename="../app/MainLayout.qml" line="1556"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
         <source>Retry</source>
         <translation>फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1334"/>
+        <location filename="../app/MainLayout.qml" line="1338"/>
         <source>I understand</source>
         <translation>मैं समझ गया</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1406"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1410"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1316,11 +1323,11 @@ Français - Wilfried</source>
         <translation type="vanished">शुरू करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1481"/>
-        <location filename="../app/MainLayout.qml" line="1530"/>
-        <location filename="../app/MainLayout.qml" line="1586"/>
-        <location filename="../app/MainLayout.qml" line="1678"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1590"/>
+        <location filename="../app/MainLayout.qml" line="1682"/>
         <source>Open</source>
         <translation>खोलें</translation>
     </message>
@@ -1329,28 +1336,28 @@ Français - Wilfried</source>
         <translation type="vanished">बंद करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1462"/>
-        <location filename="../app/MainLayout.qml" line="1487"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1514"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1574"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1624"/>
-        <location filename="../app/MainLayout.qml" line="1645"/>
-        <location filename="../app/MainLayout.qml" line="1654"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1518"/>
+        <location filename="../app/MainLayout.qml" line="1548"/>
+        <location filename="../app/MainLayout.qml" line="1566"/>
+        <location filename="../app/MainLayout.qml" line="1578"/>
+        <location filename="../app/MainLayout.qml" line="1594"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1649"/>
+        <location filename="../app/MainLayout.qml" line="1658"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1717"/>
         <source>Back</source>
         <translation>वापस</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1558"/>
-        <location filename="../app/MainLayout.qml" line="1690"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1544"/>
+        <location filename="../app/MainLayout.qml" line="1562"/>
+        <location filename="../app/MainLayout.qml" line="1694"/>
+        <location filename="../app/MainLayout.qml" line="1713"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1359,25 +1366,25 @@ Français - Wilfried</source>
         <translation type="vanished">पृष्ठ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1449"/>
-        <location filename="../app/MainLayout.qml" line="1484"/>
-        <location filename="../app/MainLayout.qml" line="1535"/>
-        <location filename="../app/MainLayout.qml" line="1683"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
+        <location filename="../app/MainLayout.qml" line="1488"/>
+        <location filename="../app/MainLayout.qml" line="1539"/>
+        <location filename="../app/MainLayout.qml" line="1687"/>
         <source>Options</source>
         <translation>विकल्प</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1613"/>
         <source>Change</source>
         <translation>बदलें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1619"/>
         <source>Toggle</source>
         <translation>टॉगल</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1641"/>
+        <location filename="../app/MainLayout.qml" line="1645"/>
         <source>Scroll</source>
         <translation>स्क्रॉल</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -675,86 +675,86 @@ Français - Wilfried</source>
         <translation type="vanished">कोर चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
-        <location filename="../app/Main.qml" line="2319"/>
-        <location filename="../app/Main.qml" line="2654"/>
-        <location filename="../app/Main.qml" line="2663"/>
-        <location filename="../app/Main.qml" line="3705"/>
-        <location filename="../app/Main.qml" line="3748"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2330"/>
+        <location filename="../app/Main.qml" line="2393"/>
+        <location filename="../app/Main.qml" line="2699"/>
+        <location filename="../app/Main.qml" line="3741"/>
+        <location filename="../app/Main.qml" line="3784"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2207"/>
+        <location filename="../app/Main.qml" line="2183"/>
+        <location filename="../app/Main.qml" line="2218"/>
         <source>Update media database</source>
         <translation type="unfinished">मीडिया डेटाबेस अपडेट करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2175"/>
-        <location filename="../app/Main.qml" line="2210"/>
+        <location filename="../app/Main.qml" line="2186"/>
+        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">मेटाडेटा स्क्रैप करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1056"/>
+        <location filename="../app/Main.qml" line="1063"/>
         <source>Settings</source>
         <translation type="unfinished">सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2089"/>
+        <location filename="../app/Main.qml" line="2096"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2153"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2243"/>
-        <location filename="../app/Main.qml" line="2297"/>
+        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2308"/>
         <source>Launch game</source>
         <translation>गेम चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2247"/>
-        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2258"/>
+        <location filename="../app/Main.qml" line="2312"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2267"/>
-        <location filename="../app/Main.qml" line="2335"/>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2346"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Remove from favorites</source>
         <translation>पसंदीदा से हटाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Add to favorites</source>
         <translation>पसंदीदा में जोड़ें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2253"/>
-        <location filename="../app/Main.qml" line="2324"/>
+        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2335"/>
         <source>Write to NFC token</source>
         <translation>NFC टोकन पर लिखें</translation>
     </message>
@@ -763,371 +763,371 @@ Français - Wilfried</source>
         <translation type="vanished">QR कोड</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Default</source>
         <translation type="unfinished">डिफ़ॉल्ट</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="2378"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2151"/>
-        <location filename="../app/Main.qml" line="2202"/>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3364"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2230"/>
+        <location filename="../app/Main.qml" line="2238"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3396"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3432"/>
         <source>Favorites</source>
         <translation type="unfinished">पसंदीदा</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1063"/>
-        <location filename="../app/Main.qml" line="3381"/>
-        <location filename="../app/Main.qml" line="3428"/>
-        <location filename="../app/Main.qml" line="3438"/>
+        <location filename="../app/Main.qml" line="1070"/>
+        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3464"/>
+        <location filename="../app/Main.qml" line="3474"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3409"/>
+        <location filename="../app/Main.qml" line="3445"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3406"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3475"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3511"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3428"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3479"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="3436"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1028"/>
+        <location filename="../app/Main.qml" line="1035"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1048"/>
+        <location filename="../app/Main.qml" line="1055"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1052"/>
+        <location filename="../app/Main.qml" line="1059"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="1067"/>
         <source>Quit</source>
         <translation type="unfinished">बंद करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2290"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2173"/>
+        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2350"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2257"/>
-        <location filename="../app/Main.qml" line="2328"/>
+        <location filename="../app/Main.qml" line="2268"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2461"/>
         <source>Move</source>
         <translation type="unfinished">स्थानांतरित करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2638"/>
+        <location filename="../app/Main.qml" line="2667"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
-        <location filename="../app/Main.qml" line="3007"/>
-        <location filename="../app/Main.qml" line="3029"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3095"/>
+        <location filename="../app/Main.qml" line="1032"/>
+        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3131"/>
         <source>OK</source>
         <translation type="unfinished">ठीक है</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3062"/>
+        <location filename="../app/Main.qml" line="3098"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3099"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3101"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3068"/>
+        <location filename="../app/Main.qml" line="3104"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3105"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3107"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3072"/>
+        <location filename="../app/Main.qml" line="3108"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3074"/>
+        <location filename="../app/Main.qml" line="3110"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3111"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3077"/>
+        <location filename="../app/Main.qml" line="3113"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3078"/>
+        <location filename="../app/Main.qml" line="3114"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3080"/>
+        <location filename="../app/Main.qml" line="3116"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3084"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3120"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3122"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3087"/>
+        <location filename="../app/Main.qml" line="3123"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3125"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3090"/>
+        <location filename="../app/Main.qml" line="3126"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3092"/>
+        <location filename="../app/Main.qml" line="3128"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3129"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3217"/>
+        <location filename="../app/Main.qml" line="3253"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3233"/>
+        <location filename="../app/Main.qml" line="3269"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3242"/>
+        <location filename="../app/Main.qml" line="3278"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3307"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
-        <location filename="../app/Main.qml" line="3425"/>
+        <location filename="../app/Main.qml" line="3415"/>
+        <location filename="../app/Main.qml" line="3461"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3413"/>
-        <location filename="../app/Main.qml" line="3435"/>
+        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3489"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3485"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3456"/>
+        <location filename="../app/Main.qml" line="3492"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3672"/>
+        <location filename="../app/Main.qml" line="3708"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3083"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3119"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
-        <location filename="../app/Main.qml" line="3282"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Retry</source>
         <translation type="unfinished">फिर से प्रयास करें</translation>
     </message>
@@ -1136,37 +1136,37 @@ Français - Wilfried</source>
         <translation type="obsolete">रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4812"/>
+        <location filename="../app/Main.qml" line="4848"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4814"/>
+        <location filename="../app/Main.qml" line="4850"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4816"/>
+        <location filename="../app/Main.qml" line="4852"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4819"/>
+        <location filename="../app/Main.qml" line="4855"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4821"/>
+        <location filename="../app/Main.qml" line="4857"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4823"/>
+        <location filename="../app/Main.qml" line="4859"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4825"/>
+        <location filename="../app/Main.qml" line="4861"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>
@@ -1246,19 +1246,19 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1480"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1585"/>
-        <location filename="../app/MainLayout.qml" line="1604"/>
-        <location filename="../app/MainLayout.qml" line="1677"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1454"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1540"/>
+        <location filename="../app/MainLayout.qml" line="1596"/>
+        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Move</source>
         <translation>स्थानांतरित करें</translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Select</source>
         <translation>चुनें</translation>
     </message>
@@ -1274,8 +1274,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="1290"/>
         <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1371"/>
-        <location filename="../app/MainLayout.qml" line="1414"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
@@ -1286,10 +1286,10 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1556"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1567"/>
+        <location filename="../app/MainLayout.qml" line="1716"/>
         <source>Retry</source>
         <translation>फिर से प्रयास करें</translation>
     </message>
@@ -1299,22 +1299,27 @@ Français - Wilfried</source>
         <translation>मैं समझ गया</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
+        <source>Saving…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="1389"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1417"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1323,11 +1328,11 @@ Français - Wilfried</source>
         <translation type="vanished">शुरू करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1485"/>
-        <location filename="../app/MainLayout.qml" line="1534"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1682"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1601"/>
+        <location filename="../app/MainLayout.qml" line="1693"/>
         <source>Open</source>
         <translation>खोलें</translation>
     </message>
@@ -1336,28 +1341,28 @@ Français - Wilfried</source>
         <translation type="vanished">बंद करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1466"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1477"/>
         <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1518"/>
-        <location filename="../app/MainLayout.qml" line="1548"/>
-        <location filename="../app/MainLayout.qml" line="1566"/>
-        <location filename="../app/MainLayout.qml" line="1578"/>
-        <location filename="../app/MainLayout.qml" line="1594"/>
-        <location filename="../app/MainLayout.qml" line="1628"/>
-        <location filename="../app/MainLayout.qml" line="1649"/>
-        <location filename="../app/MainLayout.qml" line="1658"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
-        <location filename="../app/MainLayout.qml" line="1717"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1559"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1589"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1639"/>
+        <location filename="../app/MainLayout.qml" line="1660"/>
+        <location filename="../app/MainLayout.qml" line="1669"/>
+        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1728"/>
         <source>Back</source>
         <translation>वापस</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1457"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1468"/>
+        <location filename="../app/MainLayout.qml" line="1555"/>
+        <location filename="../app/MainLayout.qml" line="1573"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1724"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1366,25 +1371,25 @@ Français - Wilfried</source>
         <translation type="vanished">पृष्ठ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1488"/>
-        <location filename="../app/MainLayout.qml" line="1539"/>
-        <location filename="../app/MainLayout.qml" line="1687"/>
+        <location filename="../app/MainLayout.qml" line="1464"/>
+        <location filename="../app/MainLayout.qml" line="1499"/>
+        <location filename="../app/MainLayout.qml" line="1550"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
         <source>Options</source>
         <translation>विकल्प</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1613"/>
+        <location filename="../app/MainLayout.qml" line="1624"/>
         <source>Change</source>
         <translation>बदलें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1619"/>
+        <location filename="../app/MainLayout.qml" line="1630"/>
         <source>Toggle</source>
         <translation>टॉगल</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1645"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Scroll</source>
         <translation>स्क्रॉल</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -675,29 +675,29 @@ Français - Wilfried</source>
         <translation type="vanished">Avvia core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
-        <location filename="../app/Main.qml" line="2319"/>
-        <location filename="../app/Main.qml" line="2654"/>
-        <location filename="../app/Main.qml" line="2663"/>
-        <location filename="../app/Main.qml" line="3705"/>
-        <location filename="../app/Main.qml" line="3748"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2330"/>
+        <location filename="../app/Main.qml" line="2393"/>
+        <location filename="../app/Main.qml" line="2699"/>
+        <location filename="../app/Main.qml" line="3741"/>
+        <location filename="../app/Main.qml" line="3784"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Remove from favorites</source>
         <translation>Rimuovi dai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Add to favorites</source>
         <translation>Aggiungi ai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2253"/>
-        <location filename="../app/Main.qml" line="2324"/>
+        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2335"/>
         <source>Write to NFC token</source>
         <translation>Scrivi sul token NFC</translation>
     </message>
@@ -706,443 +706,443 @@ Français - Wilfried</source>
         <translation type="vanished">Codice QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2243"/>
-        <location filename="../app/Main.qml" line="2297"/>
+        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2308"/>
         <source>Launch game</source>
         <translation>Avvia gioco</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1063"/>
-        <location filename="../app/Main.qml" line="3381"/>
-        <location filename="../app/Main.qml" line="3428"/>
-        <location filename="../app/Main.qml" line="3438"/>
+        <location filename="../app/Main.qml" line="1070"/>
+        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3464"/>
+        <location filename="../app/Main.qml" line="3474"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4812"/>
+        <location filename="../app/Main.qml" line="4848"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4819"/>
+        <location filename="../app/Main.qml" line="4855"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4814"/>
+        <location filename="../app/Main.qml" line="4850"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2207"/>
+        <location filename="../app/Main.qml" line="2183"/>
+        <location filename="../app/Main.qml" line="2218"/>
         <source>Update media database</source>
         <translation type="unfinished">Aggiorna database multimediale</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2175"/>
-        <location filename="../app/Main.qml" line="2210"/>
+        <location filename="../app/Main.qml" line="2186"/>
+        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Recupera metadati</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1056"/>
+        <location filename="../app/Main.qml" line="1063"/>
         <source>Settings</source>
         <translation type="unfinished">Impostazioni</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2089"/>
+        <location filename="../app/Main.qml" line="2096"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2153"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2247"/>
-        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2258"/>
+        <location filename="../app/Main.qml" line="2312"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2267"/>
-        <location filename="../app/Main.qml" line="2335"/>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2346"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Default</source>
         <translation type="unfinished">Predefinito</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="2378"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2151"/>
-        <location filename="../app/Main.qml" line="2202"/>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3364"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2230"/>
+        <location filename="../app/Main.qml" line="2238"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3409"/>
+        <location filename="../app/Main.qml" line="3445"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3406"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3475"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3511"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3428"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3479"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="3436"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1028"/>
+        <location filename="../app/Main.qml" line="1035"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1048"/>
+        <location filename="../app/Main.qml" line="1055"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1052"/>
+        <location filename="../app/Main.qml" line="1059"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="1067"/>
         <source>Quit</source>
         <translation type="unfinished">Esci</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2290"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2173"/>
+        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2350"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2257"/>
-        <location filename="../app/Main.qml" line="2328"/>
+        <location filename="../app/Main.qml" line="2268"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2461"/>
         <source>Move</source>
         <translation type="unfinished">Muovi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2638"/>
+        <location filename="../app/Main.qml" line="2667"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
-        <location filename="../app/Main.qml" line="3007"/>
-        <location filename="../app/Main.qml" line="3029"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3095"/>
+        <location filename="../app/Main.qml" line="1032"/>
+        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3131"/>
         <source>OK</source>
         <translation type="unfinished">Va bene</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3062"/>
+        <location filename="../app/Main.qml" line="3098"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3099"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3101"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3068"/>
+        <location filename="../app/Main.qml" line="3104"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3105"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3107"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3072"/>
+        <location filename="../app/Main.qml" line="3108"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3074"/>
+        <location filename="../app/Main.qml" line="3110"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3111"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3077"/>
+        <location filename="../app/Main.qml" line="3113"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3078"/>
+        <location filename="../app/Main.qml" line="3114"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3080"/>
+        <location filename="../app/Main.qml" line="3116"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3084"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3120"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3122"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3087"/>
+        <location filename="../app/Main.qml" line="3123"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3125"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3090"/>
+        <location filename="../app/Main.qml" line="3126"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3092"/>
+        <location filename="../app/Main.qml" line="3128"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3129"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3217"/>
+        <location filename="../app/Main.qml" line="3253"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3233"/>
+        <location filename="../app/Main.qml" line="3269"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3242"/>
+        <location filename="../app/Main.qml" line="3278"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3307"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3396"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3432"/>
         <source>Favorites</source>
         <translation type="unfinished">Preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
-        <location filename="../app/Main.qml" line="3425"/>
+        <location filename="../app/Main.qml" line="3415"/>
+        <location filename="../app/Main.qml" line="3461"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3413"/>
-        <location filename="../app/Main.qml" line="3435"/>
+        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3489"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3485"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3456"/>
+        <location filename="../app/Main.qml" line="3492"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3672"/>
+        <location filename="../app/Main.qml" line="3708"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3083"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3119"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
-        <location filename="../app/Main.qml" line="3282"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Retry</source>
         <translation type="unfinished">Riprova</translation>
     </message>
@@ -1151,22 +1151,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Annulla</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4816"/>
+        <location filename="../app/Main.qml" line="4852"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4821"/>
+        <location filename="../app/Main.qml" line="4857"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4823"/>
+        <location filename="../app/Main.qml" line="4859"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4825"/>
+        <location filename="../app/Main.qml" line="4861"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>
@@ -1216,7 +1216,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Select</source>
         <translation>Seleziona</translation>
     </message>
@@ -1232,8 +1232,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="1290"/>
         <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1371"/>
-        <location filename="../app/MainLayout.qml" line="1414"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
@@ -1248,12 +1248,17 @@ Français - Wilfried</source>
         <translation>Ho capito</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
+        <source>Saving…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="1389"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1262,28 +1267,28 @@ Français - Wilfried</source>
         <translation type="vanished">Avvia</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1645"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Scroll</source>
         <translation>Scorri</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1457"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1468"/>
+        <location filename="../app/MainLayout.qml" line="1555"/>
+        <location filename="../app/MainLayout.qml" line="1573"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1724"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1480"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1585"/>
-        <location filename="../app/MainLayout.qml" line="1604"/>
-        <location filename="../app/MainLayout.qml" line="1677"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1454"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1540"/>
+        <location filename="../app/MainLayout.qml" line="1596"/>
+        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Move</source>
         <translation>Muovi</translation>
     </message>
@@ -1318,21 +1323,21 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1417"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1485"/>
-        <location filename="../app/MainLayout.qml" line="1534"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1682"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1601"/>
+        <location filename="../app/MainLayout.qml" line="1693"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
@@ -1341,19 +1346,19 @@ Français - Wilfried</source>
         <translation type="vanished">Esci</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1466"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1477"/>
         <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1518"/>
-        <location filename="../app/MainLayout.qml" line="1548"/>
-        <location filename="../app/MainLayout.qml" line="1566"/>
-        <location filename="../app/MainLayout.qml" line="1578"/>
-        <location filename="../app/MainLayout.qml" line="1594"/>
-        <location filename="../app/MainLayout.qml" line="1628"/>
-        <location filename="../app/MainLayout.qml" line="1649"/>
-        <location filename="../app/MainLayout.qml" line="1658"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
-        <location filename="../app/MainLayout.qml" line="1717"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1559"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1589"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1639"/>
+        <location filename="../app/MainLayout.qml" line="1660"/>
+        <location filename="../app/MainLayout.qml" line="1669"/>
+        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1728"/>
         <source>Back</source>
         <translation>Indietro</translation>
     </message>
@@ -1362,29 +1367,29 @@ Français - Wilfried</source>
         <translation type="vanished">Pagina</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1488"/>
-        <location filename="../app/MainLayout.qml" line="1539"/>
-        <location filename="../app/MainLayout.qml" line="1687"/>
+        <location filename="../app/MainLayout.qml" line="1464"/>
+        <location filename="../app/MainLayout.qml" line="1499"/>
+        <location filename="../app/MainLayout.qml" line="1550"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
         <source>Options</source>
         <translation>Opzioni</translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1556"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1567"/>
+        <location filename="../app/MainLayout.qml" line="1716"/>
         <source>Retry</source>
         <translation>Riprova</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1613"/>
+        <location filename="../app/MainLayout.qml" line="1624"/>
         <source>Change</source>
         <translation>Cambia</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1619"/>
+        <location filename="../app/MainLayout.qml" line="1630"/>
         <source>Toggle</source>
         <translation>Alterna</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -519,23 +519,23 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
-        <location filename="../screens/HubScreen.qml" line="1288"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="1305"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>No recent games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>Resume: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="303"/>
         <source>Favorites</source>
         <translation>Preferiti</translation>
     </message>
@@ -544,32 +544,32 @@ Français - Wilfried</source>
         <translation type="vanished">Giocati di recente</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>No internet connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="352"/>
+        <location filename="../screens/HubScreen.qml" line="355"/>
         <source>Not available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="309"/>
+        <location filename="../screens/HubScreen.qml" line="312"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="302"/>
+        <location filename="../screens/HubScreen.qml" line="305"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1591"/>
+        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Nessun sistema disponibile. Esegui Aggiorna database multimediale dalle Impostazioni.</translation>
     </message>
@@ -675,24 +675,29 @@ Français - Wilfried</source>
         <translation type="vanished">Avvia core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2563"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2319"/>
+        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2663"/>
+        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3748"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Remove from favorites</source>
         <translation>Rimuovi dai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Add to favorites</source>
         <translation>Aggiungi ai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2281"/>
+        <location filename="../app/Main.qml" line="2253"/>
+        <location filename="../app/Main.qml" line="2324"/>
         <source>Write to NFC token</source>
         <translation>Scrivi sul token NFC</translation>
     </message>
@@ -701,441 +706,443 @@ Français - Wilfried</source>
         <translation type="vanished">Codice QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2243"/>
+        <location filename="../app/Main.qml" line="2297"/>
         <source>Launch game</source>
         <translation>Avvia gioco</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
-        <location filename="../app/Main.qml" line="3281"/>
-        <location filename="../app/Main.qml" line="3328"/>
-        <location filename="../app/Main.qml" line="3338"/>
+        <location filename="../app/Main.qml" line="1063"/>
+        <location filename="../app/Main.qml" line="3381"/>
+        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3438"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3317"/>
+        <location filename="../app/Main.qml" line="3417"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4603"/>
+        <location filename="../app/Main.qml" line="4812"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4610"/>
+        <location filename="../app/Main.qml" line="4819"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4605"/>
+        <location filename="../app/Main.qml" line="4814"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2207"/>
         <source>Update media database</source>
         <translation type="unfinished">Aggiorna database multimediale</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2145"/>
-        <location filename="../app/Main.qml" line="2180"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2210"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Recupera metadati</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2166"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1053"/>
+        <location filename="../app/Main.qml" line="1056"/>
         <source>Settings</source>
         <translation type="unfinished">Impostazioni</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2076"/>
+        <location filename="../app/Main.qml" line="2089"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2142"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2217"/>
-        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2247"/>
+        <location filename="../app/Main.qml" line="2301"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2237"/>
-        <location filename="../app/Main.qml" line="2292"/>
-        <location filename="../app/Main.qml" line="2333"/>
+        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3371"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Default</source>
         <translation type="unfinished">Predefinito</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="2367"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2122"/>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2189"/>
-        <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="3264"/>
+        <location filename="../app/Main.qml" line="2151"/>
+        <location filename="../app/Main.qml" line="2202"/>
+        <location filename="../app/Main.qml" line="2219"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3364"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3309"/>
+        <location filename="../app/Main.qml" line="3409"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3370"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3375"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3475"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3292"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3479"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1028"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1045"/>
+        <location filename="../app/Main.qml" line="1048"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1049"/>
+        <location filename="../app/Main.qml" line="1052"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1057"/>
+        <location filename="../app/Main.qml" line="1060"/>
         <source>Quit</source>
         <translation type="unfinished">Esci</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2241"/>
-        <location filename="../app/Main.qml" line="2260"/>
-        <location filename="../app/Main.qml" line="2296"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2290"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="2285"/>
+        <location filename="../app/Main.qml" line="2257"/>
+        <location filename="../app/Main.qml" line="2328"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2360"/>
+        <location filename="../app/Main.qml" line="2438"/>
         <source>Move</source>
         <translation type="unfinished">Muovi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2638"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
-        <location filename="../app/Main.qml" line="2907"/>
-        <location filename="../app/Main.qml" line="2929"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="3007"/>
+        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>OK</source>
         <translation type="unfinished">Va bene</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <source>Change launcher: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3053"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2962"/>
+        <location filename="../app/Main.qml" line="3062"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2963"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2965"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2968"/>
+        <location filename="../app/Main.qml" line="3068"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2969"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2971"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2972"/>
+        <location filename="../app/Main.qml" line="3072"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2974"/>
+        <location filename="../app/Main.qml" line="3074"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2975"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2977"/>
+        <location filename="../app/Main.qml" line="3077"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2978"/>
+        <location filename="../app/Main.qml" line="3078"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2980"/>
+        <location filename="../app/Main.qml" line="3080"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2981"/>
+        <location filename="../app/Main.qml" line="3081"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2984"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3084"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2986"/>
+        <location filename="../app/Main.qml" line="3086"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2987"/>
+        <location filename="../app/Main.qml" line="3087"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2989"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2990"/>
+        <location filename="../app/Main.qml" line="3090"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2992"/>
+        <location filename="../app/Main.qml" line="3092"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3217"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3233"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3142"/>
+        <location filename="../app/Main.qml" line="3242"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3271"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3256"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3296"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3396"/>
         <source>Favorites</source>
         <translation type="unfinished">Preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
-        <location filename="../app/Main.qml" line="3325"/>
+        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3425"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3313"/>
-        <location filename="../app/Main.qml" line="3335"/>
+        <location filename="../app/Main.qml" line="3413"/>
+        <location filename="../app/Main.qml" line="3435"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3353"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3349"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3449"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3456"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3556"/>
-        <location filename="../app/Main.qml" line="3574"/>
-        <source>Saving launcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3560"/>
-        <location filename="../app/Main.qml" line="3577"/>
+        <location filename="../app/Main.qml" line="3672"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2983"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3083"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
-        <location filename="../app/Main.qml" line="3182"/>
-        <location filename="../app/Main.qml" line="3590"/>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Retry</source>
         <translation type="unfinished">Riprova</translation>
     </message>
@@ -1144,22 +1151,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Annulla</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4607"/>
+        <location filename="../app/Main.qml" line="4816"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4612"/>
+        <location filename="../app/Main.qml" line="4821"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4614"/>
+        <location filename="../app/Main.qml" line="4823"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4616"/>
+        <location filename="../app/Main.qml" line="4825"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>
@@ -1188,7 +1195,7 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
         <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
         <source>OK</source>
         <translation type="unfinished">Va bene</translation>
     </message>
@@ -1208,45 +1215,45 @@ Français - Wilfried</source>
         <translation>Sei sicuro di voler uscire?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1279"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
         <source>Select</source>
         <translation>Seleziona</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1293"/>
-        <location filename="../app/MainLayout.qml" line="1308"/>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1345"/>
+        <location filename="../app/MainLayout.qml" line="1283"/>
+        <location filename="../app/MainLayout.qml" line="1297"/>
+        <location filename="../app/MainLayout.qml" line="1312"/>
+        <location filename="../app/MainLayout.qml" line="1323"/>
+        <location filename="../app/MainLayout.qml" line="1349"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1326"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1290"/>
+        <location filename="../app/MainLayout.qml" line="1330"/>
+        <location filename="../app/MainLayout.qml" line="1371"/>
+        <location filename="../app/MainLayout.qml" line="1414"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1304"/>
+        <location filename="../app/MainLayout.qml" line="1308"/>
         <source>Done</source>
         <translation>Fatto</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1334"/>
+        <location filename="../app/MainLayout.qml" line="1338"/>
         <source>I understand</source>
         <translation>Ho capito</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1255,28 +1262,28 @@ Français - Wilfried</source>
         <translation type="vanished">Avvia</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1641"/>
+        <location filename="../app/MainLayout.qml" line="1645"/>
         <source>Scroll</source>
         <translation>Scorri</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1558"/>
-        <location filename="../app/MainLayout.qml" line="1690"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1544"/>
+        <location filename="../app/MainLayout.qml" line="1562"/>
+        <location filename="../app/MainLayout.qml" line="1694"/>
+        <location filename="../app/MainLayout.qml" line="1713"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1271"/>
-        <location filename="../app/MainLayout.qml" line="1359"/>
-        <location filename="../app/MainLayout.qml" line="1439"/>
-        <location filename="../app/MainLayout.qml" line="1476"/>
-        <location filename="../app/MainLayout.qml" line="1525"/>
-        <location filename="../app/MainLayout.qml" line="1581"/>
-        <location filename="../app/MainLayout.qml" line="1600"/>
-        <location filename="../app/MainLayout.qml" line="1673"/>
+        <location filename="../app/MainLayout.qml" line="1275"/>
+        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1443"/>
+        <location filename="../app/MainLayout.qml" line="1480"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1585"/>
+        <location filename="../app/MainLayout.qml" line="1604"/>
+        <location filename="../app/MainLayout.qml" line="1677"/>
         <source>Move</source>
         <translation>Muovi</translation>
     </message>
@@ -1311,21 +1318,21 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1406"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1410"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1481"/>
-        <location filename="../app/MainLayout.qml" line="1530"/>
-        <location filename="../app/MainLayout.qml" line="1586"/>
-        <location filename="../app/MainLayout.qml" line="1678"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1590"/>
+        <location filename="../app/MainLayout.qml" line="1682"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
@@ -1334,19 +1341,19 @@ Français - Wilfried</source>
         <translation type="vanished">Esci</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1462"/>
-        <location filename="../app/MainLayout.qml" line="1487"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1514"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1574"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1624"/>
-        <location filename="../app/MainLayout.qml" line="1645"/>
-        <location filename="../app/MainLayout.qml" line="1654"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1518"/>
+        <location filename="../app/MainLayout.qml" line="1548"/>
+        <location filename="../app/MainLayout.qml" line="1566"/>
+        <location filename="../app/MainLayout.qml" line="1578"/>
+        <location filename="../app/MainLayout.qml" line="1594"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1649"/>
+        <location filename="../app/MainLayout.qml" line="1658"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1717"/>
         <source>Back</source>
         <translation>Indietro</translation>
     </message>
@@ -1355,29 +1362,29 @@ Français - Wilfried</source>
         <translation type="vanished">Pagina</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1449"/>
-        <location filename="../app/MainLayout.qml" line="1484"/>
-        <location filename="../app/MainLayout.qml" line="1535"/>
-        <location filename="../app/MainLayout.qml" line="1683"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
+        <location filename="../app/MainLayout.qml" line="1488"/>
+        <location filename="../app/MainLayout.qml" line="1539"/>
+        <location filename="../app/MainLayout.qml" line="1687"/>
         <source>Options</source>
         <translation>Opzioni</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1315"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1494"/>
-        <location filename="../app/MainLayout.qml" line="1552"/>
-        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1319"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1498"/>
+        <location filename="../app/MainLayout.qml" line="1556"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
         <source>Retry</source>
         <translation>Riprova</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1613"/>
         <source>Change</source>
         <translation>Cambia</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1619"/>
         <source>Toggle</source>
         <translation>Alterna</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -517,23 +517,23 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
-        <location filename="../screens/HubScreen.qml" line="1288"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="1305"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>No recent games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>Resume: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="303"/>
         <source>Favorites</source>
         <translation>お気に入り</translation>
     </message>
@@ -542,32 +542,32 @@ Français - Wilfried</source>
         <translation type="vanished">最近プレイしたゲーム</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>No internet connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="352"/>
+        <location filename="../screens/HubScreen.qml" line="355"/>
         <source>Not available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="309"/>
+        <location filename="../screens/HubScreen.qml" line="312"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="302"/>
+        <location filename="../screens/HubScreen.qml" line="305"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1591"/>
+        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>利用可能なシステムがありません。設定からメディアデータベースの更新を実行してください。</translation>
     </message>
@@ -673,24 +673,29 @@ Français - Wilfried</source>
         <translation type="vanished">コアを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2563"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2319"/>
+        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2663"/>
+        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3748"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Remove from favorites</source>
         <translation>お気に入りから削除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Add to favorites</source>
         <translation>お気に入りに追加</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2281"/>
+        <location filename="../app/Main.qml" line="2253"/>
+        <location filename="../app/Main.qml" line="2324"/>
         <source>Write to NFC token</source>
         <translation>NFC トークンに書き込む</translation>
     </message>
@@ -699,441 +704,443 @@ Français - Wilfried</source>
         <translation type="vanished">QR コード</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2243"/>
+        <location filename="../app/Main.qml" line="2297"/>
         <source>Launch game</source>
         <translation>ゲームを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
-        <location filename="../app/Main.qml" line="3281"/>
-        <location filename="../app/Main.qml" line="3328"/>
-        <location filename="../app/Main.qml" line="3338"/>
+        <location filename="../app/Main.qml" line="1063"/>
+        <location filename="../app/Main.qml" line="3381"/>
+        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3438"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3317"/>
+        <location filename="../app/Main.qml" line="3417"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4603"/>
+        <location filename="../app/Main.qml" line="4812"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4610"/>
+        <location filename="../app/Main.qml" line="4819"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4605"/>
+        <location filename="../app/Main.qml" line="4814"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2207"/>
         <source>Update media database</source>
         <translation type="unfinished">メディアデータベースを更新</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2145"/>
-        <location filename="../app/Main.qml" line="2180"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2210"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">メタデータをスクレイピング</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2166"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1053"/>
+        <location filename="../app/Main.qml" line="1056"/>
         <source>Settings</source>
         <translation type="unfinished">設定</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2076"/>
+        <location filename="../app/Main.qml" line="2089"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2142"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2217"/>
-        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2247"/>
+        <location filename="../app/Main.qml" line="2301"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2237"/>
-        <location filename="../app/Main.qml" line="2292"/>
-        <location filename="../app/Main.qml" line="2333"/>
+        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3371"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Default</source>
         <translation type="unfinished">デフォルト</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="2367"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2122"/>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2189"/>
-        <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="3264"/>
+        <location filename="../app/Main.qml" line="2151"/>
+        <location filename="../app/Main.qml" line="2202"/>
+        <location filename="../app/Main.qml" line="2219"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3364"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3309"/>
+        <location filename="../app/Main.qml" line="3409"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3370"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3375"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3475"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3292"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3479"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1028"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1045"/>
+        <location filename="../app/Main.qml" line="1048"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1049"/>
+        <location filename="../app/Main.qml" line="1052"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1057"/>
+        <location filename="../app/Main.qml" line="1060"/>
         <source>Quit</source>
         <translation type="unfinished">終了</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2241"/>
-        <location filename="../app/Main.qml" line="2260"/>
-        <location filename="../app/Main.qml" line="2296"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2290"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="2285"/>
+        <location filename="../app/Main.qml" line="2257"/>
+        <location filename="../app/Main.qml" line="2328"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2360"/>
+        <location filename="../app/Main.qml" line="2438"/>
         <source>Move</source>
         <translation type="unfinished">移動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2638"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
-        <location filename="../app/Main.qml" line="2907"/>
-        <location filename="../app/Main.qml" line="2929"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="3007"/>
+        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>OK</source>
         <translation type="unfinished">決定</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <source>Change launcher: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3053"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2962"/>
+        <location filename="../app/Main.qml" line="3062"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2963"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2965"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2968"/>
+        <location filename="../app/Main.qml" line="3068"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2969"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2971"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2972"/>
+        <location filename="../app/Main.qml" line="3072"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2974"/>
+        <location filename="../app/Main.qml" line="3074"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2975"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2977"/>
+        <location filename="../app/Main.qml" line="3077"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2978"/>
+        <location filename="../app/Main.qml" line="3078"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2980"/>
+        <location filename="../app/Main.qml" line="3080"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2981"/>
+        <location filename="../app/Main.qml" line="3081"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2984"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3084"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2986"/>
+        <location filename="../app/Main.qml" line="3086"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2987"/>
+        <location filename="../app/Main.qml" line="3087"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2989"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2990"/>
+        <location filename="../app/Main.qml" line="3090"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2992"/>
+        <location filename="../app/Main.qml" line="3092"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3217"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3233"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3142"/>
+        <location filename="../app/Main.qml" line="3242"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3271"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3256"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3296"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3396"/>
         <source>Favorites</source>
         <translation type="unfinished">お気に入り</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
-        <location filename="../app/Main.qml" line="3325"/>
+        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3425"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3313"/>
-        <location filename="../app/Main.qml" line="3335"/>
+        <location filename="../app/Main.qml" line="3413"/>
+        <location filename="../app/Main.qml" line="3435"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3353"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3349"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3449"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3456"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3556"/>
-        <location filename="../app/Main.qml" line="3574"/>
-        <source>Saving launcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3560"/>
-        <location filename="../app/Main.qml" line="3577"/>
+        <location filename="../app/Main.qml" line="3672"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2983"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3083"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
-        <location filename="../app/Main.qml" line="3182"/>
-        <location filename="../app/Main.qml" line="3590"/>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Retry</source>
         <translation type="unfinished">再試行</translation>
     </message>
@@ -1142,22 +1149,22 @@ Français - Wilfried</source>
         <translation type="obsolete">キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4607"/>
+        <location filename="../app/Main.qml" line="4816"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4612"/>
+        <location filename="../app/Main.qml" line="4821"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4614"/>
+        <location filename="../app/Main.qml" line="4823"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4616"/>
+        <location filename="../app/Main.qml" line="4825"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>
@@ -1186,7 +1193,7 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
         <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
         <source>OK</source>
         <translation type="unfinished">決定</translation>
     </message>
@@ -1206,45 +1213,45 @@ Français - Wilfried</source>
         <translation>本当に終了しますか？</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1279"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
         <source>Select</source>
         <translation>選択</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1293"/>
-        <location filename="../app/MainLayout.qml" line="1308"/>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1345"/>
+        <location filename="../app/MainLayout.qml" line="1283"/>
+        <location filename="../app/MainLayout.qml" line="1297"/>
+        <location filename="../app/MainLayout.qml" line="1312"/>
+        <location filename="../app/MainLayout.qml" line="1323"/>
+        <location filename="../app/MainLayout.qml" line="1349"/>
         <source>Close</source>
         <translation>閉じる</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1326"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1290"/>
+        <location filename="../app/MainLayout.qml" line="1330"/>
+        <location filename="../app/MainLayout.qml" line="1371"/>
+        <location filename="../app/MainLayout.qml" line="1414"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1304"/>
+        <location filename="../app/MainLayout.qml" line="1308"/>
         <source>Done</source>
         <translation>完了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1334"/>
+        <location filename="../app/MainLayout.qml" line="1338"/>
         <source>I understand</source>
         <translation>了解しました</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1253,28 +1260,28 @@ Français - Wilfried</source>
         <translation type="vanished">開始</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1641"/>
+        <location filename="../app/MainLayout.qml" line="1645"/>
         <source>Scroll</source>
         <translation>スクロール</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1558"/>
-        <location filename="../app/MainLayout.qml" line="1690"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1544"/>
+        <location filename="../app/MainLayout.qml" line="1562"/>
+        <location filename="../app/MainLayout.qml" line="1694"/>
+        <location filename="../app/MainLayout.qml" line="1713"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1271"/>
-        <location filename="../app/MainLayout.qml" line="1359"/>
-        <location filename="../app/MainLayout.qml" line="1439"/>
-        <location filename="../app/MainLayout.qml" line="1476"/>
-        <location filename="../app/MainLayout.qml" line="1525"/>
-        <location filename="../app/MainLayout.qml" line="1581"/>
-        <location filename="../app/MainLayout.qml" line="1600"/>
-        <location filename="../app/MainLayout.qml" line="1673"/>
+        <location filename="../app/MainLayout.qml" line="1275"/>
+        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1443"/>
+        <location filename="../app/MainLayout.qml" line="1480"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1585"/>
+        <location filename="../app/MainLayout.qml" line="1604"/>
+        <location filename="../app/MainLayout.qml" line="1677"/>
         <source>Move</source>
         <translation>移動</translation>
     </message>
@@ -1309,21 +1316,21 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1406"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1410"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1481"/>
-        <location filename="../app/MainLayout.qml" line="1530"/>
-        <location filename="../app/MainLayout.qml" line="1586"/>
-        <location filename="../app/MainLayout.qml" line="1678"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1590"/>
+        <location filename="../app/MainLayout.qml" line="1682"/>
         <source>Open</source>
         <translation>開く</translation>
     </message>
@@ -1332,19 +1339,19 @@ Français - Wilfried</source>
         <translation type="vanished">終了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1462"/>
-        <location filename="../app/MainLayout.qml" line="1487"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1514"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1574"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1624"/>
-        <location filename="../app/MainLayout.qml" line="1645"/>
-        <location filename="../app/MainLayout.qml" line="1654"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1518"/>
+        <location filename="../app/MainLayout.qml" line="1548"/>
+        <location filename="../app/MainLayout.qml" line="1566"/>
+        <location filename="../app/MainLayout.qml" line="1578"/>
+        <location filename="../app/MainLayout.qml" line="1594"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1649"/>
+        <location filename="../app/MainLayout.qml" line="1658"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1717"/>
         <source>Back</source>
         <translation>戻る</translation>
     </message>
@@ -1353,29 +1360,29 @@ Français - Wilfried</source>
         <translation type="vanished">ページ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1449"/>
-        <location filename="../app/MainLayout.qml" line="1484"/>
-        <location filename="../app/MainLayout.qml" line="1535"/>
-        <location filename="../app/MainLayout.qml" line="1683"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
+        <location filename="../app/MainLayout.qml" line="1488"/>
+        <location filename="../app/MainLayout.qml" line="1539"/>
+        <location filename="../app/MainLayout.qml" line="1687"/>
         <source>Options</source>
         <translation>オプション</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1315"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1494"/>
-        <location filename="../app/MainLayout.qml" line="1552"/>
-        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1319"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1498"/>
+        <location filename="../app/MainLayout.qml" line="1556"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
         <source>Retry</source>
         <translation>再試行</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1613"/>
         <source>Change</source>
         <translation>変更</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1619"/>
         <source>Toggle</source>
         <translation>切り替え</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -673,29 +673,29 @@ Français - Wilfried</source>
         <translation type="vanished">コアを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
-        <location filename="../app/Main.qml" line="2319"/>
-        <location filename="../app/Main.qml" line="2654"/>
-        <location filename="../app/Main.qml" line="2663"/>
-        <location filename="../app/Main.qml" line="3705"/>
-        <location filename="../app/Main.qml" line="3748"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2330"/>
+        <location filename="../app/Main.qml" line="2393"/>
+        <location filename="../app/Main.qml" line="2699"/>
+        <location filename="../app/Main.qml" line="3741"/>
+        <location filename="../app/Main.qml" line="3784"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Remove from favorites</source>
         <translation>お気に入りから削除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Add to favorites</source>
         <translation>お気に入りに追加</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2253"/>
-        <location filename="../app/Main.qml" line="2324"/>
+        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2335"/>
         <source>Write to NFC token</source>
         <translation>NFC トークンに書き込む</translation>
     </message>
@@ -704,443 +704,443 @@ Français - Wilfried</source>
         <translation type="vanished">QR コード</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2243"/>
-        <location filename="../app/Main.qml" line="2297"/>
+        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2308"/>
         <source>Launch game</source>
         <translation>ゲームを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1063"/>
-        <location filename="../app/Main.qml" line="3381"/>
-        <location filename="../app/Main.qml" line="3428"/>
-        <location filename="../app/Main.qml" line="3438"/>
+        <location filename="../app/Main.qml" line="1070"/>
+        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3464"/>
+        <location filename="../app/Main.qml" line="3474"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4812"/>
+        <location filename="../app/Main.qml" line="4848"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4819"/>
+        <location filename="../app/Main.qml" line="4855"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4814"/>
+        <location filename="../app/Main.qml" line="4850"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2207"/>
+        <location filename="../app/Main.qml" line="2183"/>
+        <location filename="../app/Main.qml" line="2218"/>
         <source>Update media database</source>
         <translation type="unfinished">メディアデータベースを更新</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2175"/>
-        <location filename="../app/Main.qml" line="2210"/>
+        <location filename="../app/Main.qml" line="2186"/>
+        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">メタデータをスクレイピング</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1056"/>
+        <location filename="../app/Main.qml" line="1063"/>
         <source>Settings</source>
         <translation type="unfinished">設定</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2089"/>
+        <location filename="../app/Main.qml" line="2096"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2153"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2247"/>
-        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2258"/>
+        <location filename="../app/Main.qml" line="2312"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2267"/>
-        <location filename="../app/Main.qml" line="2335"/>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2346"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Default</source>
         <translation type="unfinished">デフォルト</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="2378"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2151"/>
-        <location filename="../app/Main.qml" line="2202"/>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3364"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2230"/>
+        <location filename="../app/Main.qml" line="2238"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3409"/>
+        <location filename="../app/Main.qml" line="3445"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3406"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3475"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3511"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3428"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3479"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="3436"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1028"/>
+        <location filename="../app/Main.qml" line="1035"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1048"/>
+        <location filename="../app/Main.qml" line="1055"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1052"/>
+        <location filename="../app/Main.qml" line="1059"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="1067"/>
         <source>Quit</source>
         <translation type="unfinished">終了</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2290"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2173"/>
+        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2350"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2257"/>
-        <location filename="../app/Main.qml" line="2328"/>
+        <location filename="../app/Main.qml" line="2268"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2461"/>
         <source>Move</source>
         <translation type="unfinished">移動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2638"/>
+        <location filename="../app/Main.qml" line="2667"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
-        <location filename="../app/Main.qml" line="3007"/>
-        <location filename="../app/Main.qml" line="3029"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3095"/>
+        <location filename="../app/Main.qml" line="1032"/>
+        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3131"/>
         <source>OK</source>
         <translation type="unfinished">決定</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3062"/>
+        <location filename="../app/Main.qml" line="3098"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3099"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3101"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3068"/>
+        <location filename="../app/Main.qml" line="3104"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3105"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3107"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3072"/>
+        <location filename="../app/Main.qml" line="3108"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3074"/>
+        <location filename="../app/Main.qml" line="3110"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3111"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3077"/>
+        <location filename="../app/Main.qml" line="3113"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3078"/>
+        <location filename="../app/Main.qml" line="3114"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3080"/>
+        <location filename="../app/Main.qml" line="3116"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3084"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3120"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3122"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3087"/>
+        <location filename="../app/Main.qml" line="3123"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3125"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3090"/>
+        <location filename="../app/Main.qml" line="3126"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3092"/>
+        <location filename="../app/Main.qml" line="3128"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3129"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3217"/>
+        <location filename="../app/Main.qml" line="3253"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3233"/>
+        <location filename="../app/Main.qml" line="3269"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3242"/>
+        <location filename="../app/Main.qml" line="3278"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3307"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3396"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3432"/>
         <source>Favorites</source>
         <translation type="unfinished">お気に入り</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
-        <location filename="../app/Main.qml" line="3425"/>
+        <location filename="../app/Main.qml" line="3415"/>
+        <location filename="../app/Main.qml" line="3461"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3413"/>
-        <location filename="../app/Main.qml" line="3435"/>
+        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3489"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3485"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3456"/>
+        <location filename="../app/Main.qml" line="3492"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3672"/>
+        <location filename="../app/Main.qml" line="3708"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3083"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3119"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
-        <location filename="../app/Main.qml" line="3282"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Retry</source>
         <translation type="unfinished">再試行</translation>
     </message>
@@ -1149,22 +1149,22 @@ Français - Wilfried</source>
         <translation type="obsolete">キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4816"/>
+        <location filename="../app/Main.qml" line="4852"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4821"/>
+        <location filename="../app/Main.qml" line="4857"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4823"/>
+        <location filename="../app/Main.qml" line="4859"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4825"/>
+        <location filename="../app/Main.qml" line="4861"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>
@@ -1214,7 +1214,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Select</source>
         <translation>選択</translation>
     </message>
@@ -1230,8 +1230,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="1290"/>
         <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1371"/>
-        <location filename="../app/MainLayout.qml" line="1414"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
@@ -1246,12 +1246,17 @@ Français - Wilfried</source>
         <translation>了解しました</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
+        <source>Saving…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="1389"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1260,28 +1265,28 @@ Français - Wilfried</source>
         <translation type="vanished">開始</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1645"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Scroll</source>
         <translation>スクロール</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1457"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1468"/>
+        <location filename="../app/MainLayout.qml" line="1555"/>
+        <location filename="../app/MainLayout.qml" line="1573"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1724"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1480"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1585"/>
-        <location filename="../app/MainLayout.qml" line="1604"/>
-        <location filename="../app/MainLayout.qml" line="1677"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1454"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1540"/>
+        <location filename="../app/MainLayout.qml" line="1596"/>
+        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Move</source>
         <translation>移動</translation>
     </message>
@@ -1316,21 +1321,21 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1417"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1485"/>
-        <location filename="../app/MainLayout.qml" line="1534"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1682"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1601"/>
+        <location filename="../app/MainLayout.qml" line="1693"/>
         <source>Open</source>
         <translation>開く</translation>
     </message>
@@ -1339,19 +1344,19 @@ Français - Wilfried</source>
         <translation type="vanished">終了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1466"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1477"/>
         <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1518"/>
-        <location filename="../app/MainLayout.qml" line="1548"/>
-        <location filename="../app/MainLayout.qml" line="1566"/>
-        <location filename="../app/MainLayout.qml" line="1578"/>
-        <location filename="../app/MainLayout.qml" line="1594"/>
-        <location filename="../app/MainLayout.qml" line="1628"/>
-        <location filename="../app/MainLayout.qml" line="1649"/>
-        <location filename="../app/MainLayout.qml" line="1658"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
-        <location filename="../app/MainLayout.qml" line="1717"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1559"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1589"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1639"/>
+        <location filename="../app/MainLayout.qml" line="1660"/>
+        <location filename="../app/MainLayout.qml" line="1669"/>
+        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1728"/>
         <source>Back</source>
         <translation>戻る</translation>
     </message>
@@ -1360,29 +1365,29 @@ Français - Wilfried</source>
         <translation type="vanished">ページ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1488"/>
-        <location filename="../app/MainLayout.qml" line="1539"/>
-        <location filename="../app/MainLayout.qml" line="1687"/>
+        <location filename="../app/MainLayout.qml" line="1464"/>
+        <location filename="../app/MainLayout.qml" line="1499"/>
+        <location filename="../app/MainLayout.qml" line="1550"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
         <source>Options</source>
         <translation>オプション</translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1556"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1567"/>
+        <location filename="../app/MainLayout.qml" line="1716"/>
         <source>Retry</source>
         <translation>再試行</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1613"/>
+        <location filename="../app/MainLayout.qml" line="1624"/>
         <source>Change</source>
         <translation>変更</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1619"/>
+        <location filename="../app/MainLayout.qml" line="1630"/>
         <source>Toggle</source>
         <translation>切り替え</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -673,86 +673,86 @@ Français - Wilfried</source>
         <translation type="vanished">코어 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
-        <location filename="../app/Main.qml" line="2319"/>
-        <location filename="../app/Main.qml" line="2654"/>
-        <location filename="../app/Main.qml" line="2663"/>
-        <location filename="../app/Main.qml" line="3705"/>
-        <location filename="../app/Main.qml" line="3748"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2330"/>
+        <location filename="../app/Main.qml" line="2393"/>
+        <location filename="../app/Main.qml" line="2699"/>
+        <location filename="../app/Main.qml" line="3741"/>
+        <location filename="../app/Main.qml" line="3784"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2207"/>
+        <location filename="../app/Main.qml" line="2183"/>
+        <location filename="../app/Main.qml" line="2218"/>
         <source>Update media database</source>
         <translation type="unfinished">미디어 데이터베이스 업데이트</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2175"/>
-        <location filename="../app/Main.qml" line="2210"/>
+        <location filename="../app/Main.qml" line="2186"/>
+        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">메타데이터 수집</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1056"/>
+        <location filename="../app/Main.qml" line="1063"/>
         <source>Settings</source>
         <translation type="unfinished">설정</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2089"/>
+        <location filename="../app/Main.qml" line="2096"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2153"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2243"/>
-        <location filename="../app/Main.qml" line="2297"/>
+        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2308"/>
         <source>Launch game</source>
         <translation>게임 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2247"/>
-        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2258"/>
+        <location filename="../app/Main.qml" line="2312"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2267"/>
-        <location filename="../app/Main.qml" line="2335"/>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2346"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Remove from favorites</source>
         <translation>즐겨찾기에서 제거</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Add to favorites</source>
         <translation>즐겨찾기에 추가</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2253"/>
-        <location filename="../app/Main.qml" line="2324"/>
+        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2335"/>
         <source>Write to NFC token</source>
         <translation>NFC 토큰에 쓰기</translation>
     </message>
@@ -761,371 +761,371 @@ Français - Wilfried</source>
         <translation type="vanished">QR 코드</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Default</source>
         <translation type="unfinished">기본값</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="2378"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2151"/>
-        <location filename="../app/Main.qml" line="2202"/>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3364"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2230"/>
+        <location filename="../app/Main.qml" line="2238"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3396"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3432"/>
         <source>Favorites</source>
         <translation type="unfinished">즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1063"/>
-        <location filename="../app/Main.qml" line="3381"/>
-        <location filename="../app/Main.qml" line="3428"/>
-        <location filename="../app/Main.qml" line="3438"/>
+        <location filename="../app/Main.qml" line="1070"/>
+        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3464"/>
+        <location filename="../app/Main.qml" line="3474"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3409"/>
+        <location filename="../app/Main.qml" line="3445"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3406"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3475"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3511"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3428"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3479"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="3436"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1028"/>
+        <location filename="../app/Main.qml" line="1035"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1048"/>
+        <location filename="../app/Main.qml" line="1055"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1052"/>
+        <location filename="../app/Main.qml" line="1059"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="1067"/>
         <source>Quit</source>
         <translation type="unfinished">종료</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2290"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2173"/>
+        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2350"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2257"/>
-        <location filename="../app/Main.qml" line="2328"/>
+        <location filename="../app/Main.qml" line="2268"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2461"/>
         <source>Move</source>
         <translation type="unfinished">이동</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2638"/>
+        <location filename="../app/Main.qml" line="2667"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
-        <location filename="../app/Main.qml" line="3007"/>
-        <location filename="../app/Main.qml" line="3029"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3095"/>
+        <location filename="../app/Main.qml" line="1032"/>
+        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3131"/>
         <source>OK</source>
         <translation type="unfinished">확인</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3062"/>
+        <location filename="../app/Main.qml" line="3098"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3099"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3101"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3068"/>
+        <location filename="../app/Main.qml" line="3104"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3105"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3107"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3072"/>
+        <location filename="../app/Main.qml" line="3108"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3074"/>
+        <location filename="../app/Main.qml" line="3110"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3111"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3077"/>
+        <location filename="../app/Main.qml" line="3113"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3078"/>
+        <location filename="../app/Main.qml" line="3114"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3080"/>
+        <location filename="../app/Main.qml" line="3116"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3084"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3120"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3122"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3087"/>
+        <location filename="../app/Main.qml" line="3123"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3125"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3090"/>
+        <location filename="../app/Main.qml" line="3126"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3092"/>
+        <location filename="../app/Main.qml" line="3128"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3129"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3217"/>
+        <location filename="../app/Main.qml" line="3253"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3233"/>
+        <location filename="../app/Main.qml" line="3269"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3242"/>
+        <location filename="../app/Main.qml" line="3278"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3307"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
-        <location filename="../app/Main.qml" line="3425"/>
+        <location filename="../app/Main.qml" line="3415"/>
+        <location filename="../app/Main.qml" line="3461"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3413"/>
-        <location filename="../app/Main.qml" line="3435"/>
+        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3489"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3485"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3456"/>
+        <location filename="../app/Main.qml" line="3492"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3672"/>
+        <location filename="../app/Main.qml" line="3708"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3083"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3119"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
-        <location filename="../app/Main.qml" line="3282"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Retry</source>
         <translation type="unfinished">다시 시도</translation>
     </message>
@@ -1134,37 +1134,37 @@ Français - Wilfried</source>
         <translation type="obsolete">취소</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4812"/>
+        <location filename="../app/Main.qml" line="4848"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4814"/>
+        <location filename="../app/Main.qml" line="4850"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4816"/>
+        <location filename="../app/Main.qml" line="4852"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4819"/>
+        <location filename="../app/Main.qml" line="4855"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4821"/>
+        <location filename="../app/Main.qml" line="4857"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4823"/>
+        <location filename="../app/Main.qml" line="4859"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4825"/>
+        <location filename="../app/Main.qml" line="4861"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>
@@ -1244,19 +1244,19 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1480"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1585"/>
-        <location filename="../app/MainLayout.qml" line="1604"/>
-        <location filename="../app/MainLayout.qml" line="1677"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1454"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1540"/>
+        <location filename="../app/MainLayout.qml" line="1596"/>
+        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Move</source>
         <translation>이동</translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Select</source>
         <translation>선택</translation>
     </message>
@@ -1272,8 +1272,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="1290"/>
         <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1371"/>
-        <location filename="../app/MainLayout.qml" line="1414"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
@@ -1284,10 +1284,10 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1556"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1567"/>
+        <location filename="../app/MainLayout.qml" line="1716"/>
         <source>Retry</source>
         <translation>다시 시도</translation>
     </message>
@@ -1297,22 +1297,27 @@ Français - Wilfried</source>
         <translation>이해했습니다</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
+        <source>Saving…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="1389"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1417"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1321,11 +1326,11 @@ Français - Wilfried</source>
         <translation type="vanished">시작</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1485"/>
-        <location filename="../app/MainLayout.qml" line="1534"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1682"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1601"/>
+        <location filename="../app/MainLayout.qml" line="1693"/>
         <source>Open</source>
         <translation>열기</translation>
     </message>
@@ -1334,28 +1339,28 @@ Français - Wilfried</source>
         <translation type="vanished">종료</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1466"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1477"/>
         <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1518"/>
-        <location filename="../app/MainLayout.qml" line="1548"/>
-        <location filename="../app/MainLayout.qml" line="1566"/>
-        <location filename="../app/MainLayout.qml" line="1578"/>
-        <location filename="../app/MainLayout.qml" line="1594"/>
-        <location filename="../app/MainLayout.qml" line="1628"/>
-        <location filename="../app/MainLayout.qml" line="1649"/>
-        <location filename="../app/MainLayout.qml" line="1658"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
-        <location filename="../app/MainLayout.qml" line="1717"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1559"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1589"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1639"/>
+        <location filename="../app/MainLayout.qml" line="1660"/>
+        <location filename="../app/MainLayout.qml" line="1669"/>
+        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1728"/>
         <source>Back</source>
         <translation>뒤로</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1457"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1468"/>
+        <location filename="../app/MainLayout.qml" line="1555"/>
+        <location filename="../app/MainLayout.qml" line="1573"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1724"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1364,25 +1369,25 @@ Français - Wilfried</source>
         <translation type="vanished">페이지</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1488"/>
-        <location filename="../app/MainLayout.qml" line="1539"/>
-        <location filename="../app/MainLayout.qml" line="1687"/>
+        <location filename="../app/MainLayout.qml" line="1464"/>
+        <location filename="../app/MainLayout.qml" line="1499"/>
+        <location filename="../app/MainLayout.qml" line="1550"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
         <source>Options</source>
         <translation>옵션</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1613"/>
+        <location filename="../app/MainLayout.qml" line="1624"/>
         <source>Change</source>
         <translation>변경</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1619"/>
+        <location filename="../app/MainLayout.qml" line="1630"/>
         <source>Toggle</source>
         <translation>전환</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1645"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Scroll</source>
         <translation>스크롤</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -517,23 +517,23 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
-        <location filename="../screens/HubScreen.qml" line="1288"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="1305"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>No recent games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>Resume: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="303"/>
         <source>Favorites</source>
         <translation>즐겨찾기</translation>
     </message>
@@ -542,32 +542,32 @@ Français - Wilfried</source>
         <translation type="vanished">최근 플레이</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>No internet connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="352"/>
+        <location filename="../screens/HubScreen.qml" line="355"/>
         <source>Not available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="309"/>
+        <location filename="../screens/HubScreen.qml" line="312"/>
         <source>Settings</source>
         <translation>설정</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="302"/>
+        <location filename="../screens/HubScreen.qml" line="305"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1591"/>
+        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>사용 가능한 시스템이 없습니다. 설정에서 미디어 데이터베이스 업데이트를 실행하세요.</translation>
     </message>
@@ -673,81 +673,86 @@ Français - Wilfried</source>
         <translation type="vanished">코어 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2563"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2319"/>
+        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2663"/>
+        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3748"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2207"/>
         <source>Update media database</source>
         <translation type="unfinished">미디어 데이터베이스 업데이트</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2145"/>
-        <location filename="../app/Main.qml" line="2180"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2210"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">메타데이터 수집</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2166"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1053"/>
+        <location filename="../app/Main.qml" line="1056"/>
         <source>Settings</source>
         <translation type="unfinished">설정</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2076"/>
+        <location filename="../app/Main.qml" line="2089"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2142"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2243"/>
+        <location filename="../app/Main.qml" line="2297"/>
         <source>Launch game</source>
         <translation>게임 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2217"/>
-        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2247"/>
+        <location filename="../app/Main.qml" line="2301"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2237"/>
-        <location filename="../app/Main.qml" line="2292"/>
-        <location filename="../app/Main.qml" line="2333"/>
+        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Remove from favorites</source>
         <translation>즐겨찾기에서 제거</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Add to favorites</source>
         <translation>즐겨찾기에 추가</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2281"/>
+        <location filename="../app/Main.qml" line="2253"/>
+        <location filename="../app/Main.qml" line="2324"/>
         <source>Write to NFC token</source>
         <translation>NFC 토큰에 쓰기</translation>
     </message>
@@ -756,369 +761,371 @@ Français - Wilfried</source>
         <translation type="vanished">QR 코드</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3371"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Default</source>
         <translation type="unfinished">기본값</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="2367"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2122"/>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2189"/>
-        <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="3264"/>
+        <location filename="../app/Main.qml" line="2151"/>
+        <location filename="../app/Main.qml" line="2202"/>
+        <location filename="../app/Main.qml" line="2219"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3364"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3296"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3396"/>
         <source>Favorites</source>
         <translation type="unfinished">즐겨찾기</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
-        <location filename="../app/Main.qml" line="3281"/>
-        <location filename="../app/Main.qml" line="3328"/>
-        <location filename="../app/Main.qml" line="3338"/>
+        <location filename="../app/Main.qml" line="1063"/>
+        <location filename="../app/Main.qml" line="3381"/>
+        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3438"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3309"/>
+        <location filename="../app/Main.qml" line="3409"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3370"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3375"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3475"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3292"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3479"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1028"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1045"/>
+        <location filename="../app/Main.qml" line="1048"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1049"/>
+        <location filename="../app/Main.qml" line="1052"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1057"/>
+        <location filename="../app/Main.qml" line="1060"/>
         <source>Quit</source>
         <translation type="unfinished">종료</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2241"/>
-        <location filename="../app/Main.qml" line="2260"/>
-        <location filename="../app/Main.qml" line="2296"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2290"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="2285"/>
+        <location filename="../app/Main.qml" line="2257"/>
+        <location filename="../app/Main.qml" line="2328"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2360"/>
+        <location filename="../app/Main.qml" line="2438"/>
         <source>Move</source>
         <translation type="unfinished">이동</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2638"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
-        <location filename="../app/Main.qml" line="2907"/>
-        <location filename="../app/Main.qml" line="2929"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="3007"/>
+        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>OK</source>
         <translation type="unfinished">확인</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <source>Change launcher: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3053"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2962"/>
+        <location filename="../app/Main.qml" line="3062"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2963"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2965"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2968"/>
+        <location filename="../app/Main.qml" line="3068"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2969"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2971"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2972"/>
+        <location filename="../app/Main.qml" line="3072"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2974"/>
+        <location filename="../app/Main.qml" line="3074"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2975"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2977"/>
+        <location filename="../app/Main.qml" line="3077"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2978"/>
+        <location filename="../app/Main.qml" line="3078"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2980"/>
+        <location filename="../app/Main.qml" line="3080"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2981"/>
+        <location filename="../app/Main.qml" line="3081"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2984"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3084"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2986"/>
+        <location filename="../app/Main.qml" line="3086"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2987"/>
+        <location filename="../app/Main.qml" line="3087"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2989"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2990"/>
+        <location filename="../app/Main.qml" line="3090"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2992"/>
+        <location filename="../app/Main.qml" line="3092"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3217"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3233"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3142"/>
+        <location filename="../app/Main.qml" line="3242"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3271"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3256"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
-        <location filename="../app/Main.qml" line="3325"/>
+        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3425"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3313"/>
-        <location filename="../app/Main.qml" line="3335"/>
+        <location filename="../app/Main.qml" line="3413"/>
+        <location filename="../app/Main.qml" line="3435"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3317"/>
+        <location filename="../app/Main.qml" line="3417"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3353"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3349"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3449"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3456"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3556"/>
-        <location filename="../app/Main.qml" line="3574"/>
-        <source>Saving launcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3560"/>
-        <location filename="../app/Main.qml" line="3577"/>
+        <location filename="../app/Main.qml" line="3672"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2983"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3083"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
-        <location filename="../app/Main.qml" line="3182"/>
-        <location filename="../app/Main.qml" line="3590"/>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Retry</source>
         <translation type="unfinished">다시 시도</translation>
     </message>
@@ -1127,37 +1134,37 @@ Français - Wilfried</source>
         <translation type="obsolete">취소</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4603"/>
+        <location filename="../app/Main.qml" line="4812"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4605"/>
+        <location filename="../app/Main.qml" line="4814"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4607"/>
+        <location filename="../app/Main.qml" line="4816"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4610"/>
+        <location filename="../app/Main.qml" line="4819"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4612"/>
+        <location filename="../app/Main.qml" line="4821"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4614"/>
+        <location filename="../app/Main.qml" line="4823"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4616"/>
+        <location filename="../app/Main.qml" line="4825"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>
@@ -1211,7 +1218,7 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
         <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
         <source>OK</source>
         <translation type="unfinished">확인</translation>
     </message>
@@ -1236,76 +1243,76 @@ Français - Wilfried</source>
         <translation>정말 종료하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1271"/>
-        <location filename="../app/MainLayout.qml" line="1359"/>
-        <location filename="../app/MainLayout.qml" line="1439"/>
-        <location filename="../app/MainLayout.qml" line="1476"/>
-        <location filename="../app/MainLayout.qml" line="1525"/>
-        <location filename="../app/MainLayout.qml" line="1581"/>
-        <location filename="../app/MainLayout.qml" line="1600"/>
-        <location filename="../app/MainLayout.qml" line="1673"/>
+        <location filename="../app/MainLayout.qml" line="1275"/>
+        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1443"/>
+        <location filename="../app/MainLayout.qml" line="1480"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1585"/>
+        <location filename="../app/MainLayout.qml" line="1604"/>
+        <location filename="../app/MainLayout.qml" line="1677"/>
         <source>Move</source>
         <translation>이동</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1279"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
         <source>Select</source>
         <translation>선택</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1293"/>
-        <location filename="../app/MainLayout.qml" line="1308"/>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1345"/>
+        <location filename="../app/MainLayout.qml" line="1283"/>
+        <location filename="../app/MainLayout.qml" line="1297"/>
+        <location filename="../app/MainLayout.qml" line="1312"/>
+        <location filename="../app/MainLayout.qml" line="1323"/>
+        <location filename="../app/MainLayout.qml" line="1349"/>
         <source>Close</source>
         <translation>닫기</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1326"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1290"/>
+        <location filename="../app/MainLayout.qml" line="1330"/>
+        <location filename="../app/MainLayout.qml" line="1371"/>
+        <location filename="../app/MainLayout.qml" line="1414"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1304"/>
+        <location filename="../app/MainLayout.qml" line="1308"/>
         <source>Done</source>
         <translation>완료</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1315"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1494"/>
-        <location filename="../app/MainLayout.qml" line="1552"/>
-        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1319"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1498"/>
+        <location filename="../app/MainLayout.qml" line="1556"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
         <source>Retry</source>
         <translation>다시 시도</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1334"/>
+        <location filename="../app/MainLayout.qml" line="1338"/>
         <source>I understand</source>
         <translation>이해했습니다</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1406"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1410"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1314,11 +1321,11 @@ Français - Wilfried</source>
         <translation type="vanished">시작</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1481"/>
-        <location filename="../app/MainLayout.qml" line="1530"/>
-        <location filename="../app/MainLayout.qml" line="1586"/>
-        <location filename="../app/MainLayout.qml" line="1678"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1590"/>
+        <location filename="../app/MainLayout.qml" line="1682"/>
         <source>Open</source>
         <translation>열기</translation>
     </message>
@@ -1327,28 +1334,28 @@ Français - Wilfried</source>
         <translation type="vanished">종료</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1462"/>
-        <location filename="../app/MainLayout.qml" line="1487"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1514"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1574"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1624"/>
-        <location filename="../app/MainLayout.qml" line="1645"/>
-        <location filename="../app/MainLayout.qml" line="1654"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1518"/>
+        <location filename="../app/MainLayout.qml" line="1548"/>
+        <location filename="../app/MainLayout.qml" line="1566"/>
+        <location filename="../app/MainLayout.qml" line="1578"/>
+        <location filename="../app/MainLayout.qml" line="1594"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1649"/>
+        <location filename="../app/MainLayout.qml" line="1658"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1717"/>
         <source>Back</source>
         <translation>뒤로</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1558"/>
-        <location filename="../app/MainLayout.qml" line="1690"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1544"/>
+        <location filename="../app/MainLayout.qml" line="1562"/>
+        <location filename="../app/MainLayout.qml" line="1694"/>
+        <location filename="../app/MainLayout.qml" line="1713"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1357,25 +1364,25 @@ Français - Wilfried</source>
         <translation type="vanished">페이지</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1449"/>
-        <location filename="../app/MainLayout.qml" line="1484"/>
-        <location filename="../app/MainLayout.qml" line="1535"/>
-        <location filename="../app/MainLayout.qml" line="1683"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
+        <location filename="../app/MainLayout.qml" line="1488"/>
+        <location filename="../app/MainLayout.qml" line="1539"/>
+        <location filename="../app/MainLayout.qml" line="1687"/>
         <source>Options</source>
         <translation>옵션</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1613"/>
         <source>Change</source>
         <translation>변경</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1619"/>
         <source>Toggle</source>
         <translation>전환</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1641"/>
+        <location filename="../app/MainLayout.qml" line="1645"/>
         <source>Scroll</source>
         <translation>스크롤</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -675,29 +675,29 @@ Français - Wilfried</source>
         <translation type="vanished">Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
-        <location filename="../app/Main.qml" line="2319"/>
-        <location filename="../app/Main.qml" line="2654"/>
-        <location filename="../app/Main.qml" line="2663"/>
-        <location filename="../app/Main.qml" line="3705"/>
-        <location filename="../app/Main.qml" line="3748"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2330"/>
+        <location filename="../app/Main.qml" line="2393"/>
+        <location filename="../app/Main.qml" line="2699"/>
+        <location filename="../app/Main.qml" line="3741"/>
+        <location filename="../app/Main.qml" line="3784"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Remove from favorites</source>
         <translation>Uit favorieten verwijderen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Add to favorites</source>
         <translation>Aan favorieten toevoegen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2253"/>
-        <location filename="../app/Main.qml" line="2324"/>
+        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2335"/>
         <source>Write to NFC token</source>
         <translation>Naar NFC-token schrijven</translation>
     </message>
@@ -706,443 +706,443 @@ Français - Wilfried</source>
         <translation type="vanished">QR-code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2243"/>
-        <location filename="../app/Main.qml" line="2297"/>
+        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2308"/>
         <source>Launch game</source>
         <translation>Game starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1063"/>
-        <location filename="../app/Main.qml" line="3381"/>
-        <location filename="../app/Main.qml" line="3428"/>
-        <location filename="../app/Main.qml" line="3438"/>
+        <location filename="../app/Main.qml" line="1070"/>
+        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3464"/>
+        <location filename="../app/Main.qml" line="3474"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4812"/>
+        <location filename="../app/Main.qml" line="4848"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4819"/>
+        <location filename="../app/Main.qml" line="4855"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4814"/>
+        <location filename="../app/Main.qml" line="4850"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2207"/>
+        <location filename="../app/Main.qml" line="2183"/>
+        <location filename="../app/Main.qml" line="2218"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediadatabase bijwerken</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2175"/>
-        <location filename="../app/Main.qml" line="2210"/>
+        <location filename="../app/Main.qml" line="2186"/>
+        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadata ophalen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1056"/>
+        <location filename="../app/Main.qml" line="1063"/>
         <source>Settings</source>
         <translation type="unfinished">Instellingen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2089"/>
+        <location filename="../app/Main.qml" line="2096"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2153"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2247"/>
-        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2258"/>
+        <location filename="../app/Main.qml" line="2312"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2267"/>
-        <location filename="../app/Main.qml" line="2335"/>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2346"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Default</source>
         <translation type="unfinished">Standaard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="2378"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2151"/>
-        <location filename="../app/Main.qml" line="2202"/>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3364"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2230"/>
+        <location filename="../app/Main.qml" line="2238"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3409"/>
+        <location filename="../app/Main.qml" line="3445"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3406"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3475"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3511"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3428"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3479"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="3436"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1028"/>
+        <location filename="../app/Main.qml" line="1035"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1048"/>
+        <location filename="../app/Main.qml" line="1055"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1052"/>
+        <location filename="../app/Main.qml" line="1059"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="1067"/>
         <source>Quit</source>
         <translation type="unfinished">Afsluiten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2290"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2173"/>
+        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2350"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2257"/>
-        <location filename="../app/Main.qml" line="2328"/>
+        <location filename="../app/Main.qml" line="2268"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2461"/>
         <source>Move</source>
         <translation type="unfinished">Bewegen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2638"/>
+        <location filename="../app/Main.qml" line="2667"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
-        <location filename="../app/Main.qml" line="3007"/>
-        <location filename="../app/Main.qml" line="3029"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3095"/>
+        <location filename="../app/Main.qml" line="1032"/>
+        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3131"/>
         <source>OK</source>
         <translation type="unfinished">Akkoord</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3062"/>
+        <location filename="../app/Main.qml" line="3098"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3099"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3101"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3068"/>
+        <location filename="../app/Main.qml" line="3104"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3105"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3107"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3072"/>
+        <location filename="../app/Main.qml" line="3108"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3074"/>
+        <location filename="../app/Main.qml" line="3110"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3111"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3077"/>
+        <location filename="../app/Main.qml" line="3113"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3078"/>
+        <location filename="../app/Main.qml" line="3114"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3080"/>
+        <location filename="../app/Main.qml" line="3116"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3084"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3120"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3122"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3087"/>
+        <location filename="../app/Main.qml" line="3123"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3125"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3090"/>
+        <location filename="../app/Main.qml" line="3126"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3092"/>
+        <location filename="../app/Main.qml" line="3128"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3129"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3217"/>
+        <location filename="../app/Main.qml" line="3253"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3233"/>
+        <location filename="../app/Main.qml" line="3269"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3242"/>
+        <location filename="../app/Main.qml" line="3278"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3307"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3396"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3432"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorieten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
-        <location filename="../app/Main.qml" line="3425"/>
+        <location filename="../app/Main.qml" line="3415"/>
+        <location filename="../app/Main.qml" line="3461"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3413"/>
-        <location filename="../app/Main.qml" line="3435"/>
+        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3489"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3485"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3456"/>
+        <location filename="../app/Main.qml" line="3492"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3672"/>
+        <location filename="../app/Main.qml" line="3708"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3083"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3119"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
-        <location filename="../app/Main.qml" line="3282"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Retry</source>
         <translation type="unfinished">Opnieuw proberen</translation>
     </message>
@@ -1151,22 +1151,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4816"/>
+        <location filename="../app/Main.qml" line="4852"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4821"/>
+        <location filename="../app/Main.qml" line="4857"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4823"/>
+        <location filename="../app/Main.qml" line="4859"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4825"/>
+        <location filename="../app/Main.qml" line="4861"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>
@@ -1216,7 +1216,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Select</source>
         <translation>Selecteren</translation>
     </message>
@@ -1232,8 +1232,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="1290"/>
         <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1371"/>
-        <location filename="../app/MainLayout.qml" line="1414"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
@@ -1248,12 +1248,17 @@ Français - Wilfried</source>
         <translation>Ik begrijp het</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
+        <source>Saving…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="1389"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1262,28 +1267,28 @@ Français - Wilfried</source>
         <translation type="vanished">Starten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1645"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Scroll</source>
         <translation>Scrollen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1457"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1468"/>
+        <location filename="../app/MainLayout.qml" line="1555"/>
+        <location filename="../app/MainLayout.qml" line="1573"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1724"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1480"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1585"/>
-        <location filename="../app/MainLayout.qml" line="1604"/>
-        <location filename="../app/MainLayout.qml" line="1677"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1454"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1540"/>
+        <location filename="../app/MainLayout.qml" line="1596"/>
+        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
@@ -1318,21 +1323,21 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1417"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1485"/>
-        <location filename="../app/MainLayout.qml" line="1534"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1682"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1601"/>
+        <location filename="../app/MainLayout.qml" line="1693"/>
         <source>Open</source>
         <translation>Openen</translation>
     </message>
@@ -1341,19 +1346,19 @@ Français - Wilfried</source>
         <translation type="vanished">Afsluiten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1466"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1477"/>
         <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1518"/>
-        <location filename="../app/MainLayout.qml" line="1548"/>
-        <location filename="../app/MainLayout.qml" line="1566"/>
-        <location filename="../app/MainLayout.qml" line="1578"/>
-        <location filename="../app/MainLayout.qml" line="1594"/>
-        <location filename="../app/MainLayout.qml" line="1628"/>
-        <location filename="../app/MainLayout.qml" line="1649"/>
-        <location filename="../app/MainLayout.qml" line="1658"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
-        <location filename="../app/MainLayout.qml" line="1717"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1559"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1589"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1639"/>
+        <location filename="../app/MainLayout.qml" line="1660"/>
+        <location filename="../app/MainLayout.qml" line="1669"/>
+        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1728"/>
         <source>Back</source>
         <translation>Terug</translation>
     </message>
@@ -1362,29 +1367,29 @@ Français - Wilfried</source>
         <translation type="vanished">Pagina</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1488"/>
-        <location filename="../app/MainLayout.qml" line="1539"/>
-        <location filename="../app/MainLayout.qml" line="1687"/>
+        <location filename="../app/MainLayout.qml" line="1464"/>
+        <location filename="../app/MainLayout.qml" line="1499"/>
+        <location filename="../app/MainLayout.qml" line="1550"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
         <source>Options</source>
         <translation>Opties</translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1556"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1567"/>
+        <location filename="../app/MainLayout.qml" line="1716"/>
         <source>Retry</source>
         <translation>Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1613"/>
+        <location filename="../app/MainLayout.qml" line="1624"/>
         <source>Change</source>
         <translation>Wijzigen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1619"/>
+        <location filename="../app/MainLayout.qml" line="1630"/>
         <source>Toggle</source>
         <translation>Schakelen</translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -519,23 +519,23 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
-        <location filename="../screens/HubScreen.qml" line="1288"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="1305"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>No recent games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>Resume: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="303"/>
         <source>Favorites</source>
         <translation>Favorieten</translation>
     </message>
@@ -544,32 +544,32 @@ Français - Wilfried</source>
         <translation type="vanished">Recent gespeeld</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>No internet connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="352"/>
+        <location filename="../screens/HubScreen.qml" line="355"/>
         <source>Not available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="309"/>
+        <location filename="../screens/HubScreen.qml" line="312"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="302"/>
+        <location filename="../screens/HubScreen.qml" line="305"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1591"/>
+        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Geen systemen beschikbaar. Voer Database bijwerken uit via Instellingen.</translation>
     </message>
@@ -675,24 +675,29 @@ Français - Wilfried</source>
         <translation type="vanished">Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2563"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2319"/>
+        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2663"/>
+        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3748"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Remove from favorites</source>
         <translation>Uit favorieten verwijderen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Add to favorites</source>
         <translation>Aan favorieten toevoegen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2281"/>
+        <location filename="../app/Main.qml" line="2253"/>
+        <location filename="../app/Main.qml" line="2324"/>
         <source>Write to NFC token</source>
         <translation>Naar NFC-token schrijven</translation>
     </message>
@@ -701,441 +706,443 @@ Français - Wilfried</source>
         <translation type="vanished">QR-code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2243"/>
+        <location filename="../app/Main.qml" line="2297"/>
         <source>Launch game</source>
         <translation>Game starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
-        <location filename="../app/Main.qml" line="3281"/>
-        <location filename="../app/Main.qml" line="3328"/>
-        <location filename="../app/Main.qml" line="3338"/>
+        <location filename="../app/Main.qml" line="1063"/>
+        <location filename="../app/Main.qml" line="3381"/>
+        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3438"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3317"/>
+        <location filename="../app/Main.qml" line="3417"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4603"/>
+        <location filename="../app/Main.qml" line="4812"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4610"/>
+        <location filename="../app/Main.qml" line="4819"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4605"/>
+        <location filename="../app/Main.qml" line="4814"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2207"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediadatabase bijwerken</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2145"/>
-        <location filename="../app/Main.qml" line="2180"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2210"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Metadata ophalen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2166"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1053"/>
+        <location filename="../app/Main.qml" line="1056"/>
         <source>Settings</source>
         <translation type="unfinished">Instellingen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2076"/>
+        <location filename="../app/Main.qml" line="2089"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2142"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2217"/>
-        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2247"/>
+        <location filename="../app/Main.qml" line="2301"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2237"/>
-        <location filename="../app/Main.qml" line="2292"/>
-        <location filename="../app/Main.qml" line="2333"/>
+        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3371"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Default</source>
         <translation type="unfinished">Standaard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="2367"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2122"/>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2189"/>
-        <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="3264"/>
+        <location filename="../app/Main.qml" line="2151"/>
+        <location filename="../app/Main.qml" line="2202"/>
+        <location filename="../app/Main.qml" line="2219"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3364"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3309"/>
+        <location filename="../app/Main.qml" line="3409"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3370"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3375"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3475"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3292"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3479"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1028"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1045"/>
+        <location filename="../app/Main.qml" line="1048"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1049"/>
+        <location filename="../app/Main.qml" line="1052"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1057"/>
+        <location filename="../app/Main.qml" line="1060"/>
         <source>Quit</source>
         <translation type="unfinished">Afsluiten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2241"/>
-        <location filename="../app/Main.qml" line="2260"/>
-        <location filename="../app/Main.qml" line="2296"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2290"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="2285"/>
+        <location filename="../app/Main.qml" line="2257"/>
+        <location filename="../app/Main.qml" line="2328"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2360"/>
+        <location filename="../app/Main.qml" line="2438"/>
         <source>Move</source>
         <translation type="unfinished">Bewegen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2638"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
-        <location filename="../app/Main.qml" line="2907"/>
-        <location filename="../app/Main.qml" line="2929"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="3007"/>
+        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>OK</source>
         <translation type="unfinished">Akkoord</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <source>Change launcher: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3053"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2962"/>
+        <location filename="../app/Main.qml" line="3062"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2963"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2965"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2968"/>
+        <location filename="../app/Main.qml" line="3068"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2969"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2971"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2972"/>
+        <location filename="../app/Main.qml" line="3072"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2974"/>
+        <location filename="../app/Main.qml" line="3074"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2975"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2977"/>
+        <location filename="../app/Main.qml" line="3077"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2978"/>
+        <location filename="../app/Main.qml" line="3078"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2980"/>
+        <location filename="../app/Main.qml" line="3080"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2981"/>
+        <location filename="../app/Main.qml" line="3081"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2984"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3084"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2986"/>
+        <location filename="../app/Main.qml" line="3086"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2987"/>
+        <location filename="../app/Main.qml" line="3087"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2989"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2990"/>
+        <location filename="../app/Main.qml" line="3090"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2992"/>
+        <location filename="../app/Main.qml" line="3092"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3217"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3233"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3142"/>
+        <location filename="../app/Main.qml" line="3242"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3271"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3256"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3296"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3396"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorieten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
-        <location filename="../app/Main.qml" line="3325"/>
+        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3425"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3313"/>
-        <location filename="../app/Main.qml" line="3335"/>
+        <location filename="../app/Main.qml" line="3413"/>
+        <location filename="../app/Main.qml" line="3435"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3353"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3349"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3449"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3456"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3556"/>
-        <location filename="../app/Main.qml" line="3574"/>
-        <source>Saving launcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3560"/>
-        <location filename="../app/Main.qml" line="3577"/>
+        <location filename="../app/Main.qml" line="3672"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2983"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3083"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
-        <location filename="../app/Main.qml" line="3182"/>
-        <location filename="../app/Main.qml" line="3590"/>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Retry</source>
         <translation type="unfinished">Opnieuw proberen</translation>
     </message>
@@ -1144,22 +1151,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4607"/>
+        <location filename="../app/Main.qml" line="4816"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4612"/>
+        <location filename="../app/Main.qml" line="4821"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4614"/>
+        <location filename="../app/Main.qml" line="4823"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4616"/>
+        <location filename="../app/Main.qml" line="4825"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>
@@ -1188,7 +1195,7 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
         <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
         <source>OK</source>
         <translation type="unfinished">Akkoord</translation>
     </message>
@@ -1208,45 +1215,45 @@ Français - Wilfried</source>
         <translation>Weet u zeker dat u wilt afsluiten?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1279"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
         <source>Select</source>
         <translation>Selecteren</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1293"/>
-        <location filename="../app/MainLayout.qml" line="1308"/>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1345"/>
+        <location filename="../app/MainLayout.qml" line="1283"/>
+        <location filename="../app/MainLayout.qml" line="1297"/>
+        <location filename="../app/MainLayout.qml" line="1312"/>
+        <location filename="../app/MainLayout.qml" line="1323"/>
+        <location filename="../app/MainLayout.qml" line="1349"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1326"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1290"/>
+        <location filename="../app/MainLayout.qml" line="1330"/>
+        <location filename="../app/MainLayout.qml" line="1371"/>
+        <location filename="../app/MainLayout.qml" line="1414"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1304"/>
+        <location filename="../app/MainLayout.qml" line="1308"/>
         <source>Done</source>
         <translation>Klaar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1334"/>
+        <location filename="../app/MainLayout.qml" line="1338"/>
         <source>I understand</source>
         <translation>Ik begrijp het</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1255,28 +1262,28 @@ Français - Wilfried</source>
         <translation type="vanished">Starten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1641"/>
+        <location filename="../app/MainLayout.qml" line="1645"/>
         <source>Scroll</source>
         <translation>Scrollen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1558"/>
-        <location filename="../app/MainLayout.qml" line="1690"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1544"/>
+        <location filename="../app/MainLayout.qml" line="1562"/>
+        <location filename="../app/MainLayout.qml" line="1694"/>
+        <location filename="../app/MainLayout.qml" line="1713"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1271"/>
-        <location filename="../app/MainLayout.qml" line="1359"/>
-        <location filename="../app/MainLayout.qml" line="1439"/>
-        <location filename="../app/MainLayout.qml" line="1476"/>
-        <location filename="../app/MainLayout.qml" line="1525"/>
-        <location filename="../app/MainLayout.qml" line="1581"/>
-        <location filename="../app/MainLayout.qml" line="1600"/>
-        <location filename="../app/MainLayout.qml" line="1673"/>
+        <location filename="../app/MainLayout.qml" line="1275"/>
+        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1443"/>
+        <location filename="../app/MainLayout.qml" line="1480"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1585"/>
+        <location filename="../app/MainLayout.qml" line="1604"/>
+        <location filename="../app/MainLayout.qml" line="1677"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
@@ -1311,21 +1318,21 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1406"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1410"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1481"/>
-        <location filename="../app/MainLayout.qml" line="1530"/>
-        <location filename="../app/MainLayout.qml" line="1586"/>
-        <location filename="../app/MainLayout.qml" line="1678"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1590"/>
+        <location filename="../app/MainLayout.qml" line="1682"/>
         <source>Open</source>
         <translation>Openen</translation>
     </message>
@@ -1334,19 +1341,19 @@ Français - Wilfried</source>
         <translation type="vanished">Afsluiten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1462"/>
-        <location filename="../app/MainLayout.qml" line="1487"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1514"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1574"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1624"/>
-        <location filename="../app/MainLayout.qml" line="1645"/>
-        <location filename="../app/MainLayout.qml" line="1654"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1518"/>
+        <location filename="../app/MainLayout.qml" line="1548"/>
+        <location filename="../app/MainLayout.qml" line="1566"/>
+        <location filename="../app/MainLayout.qml" line="1578"/>
+        <location filename="../app/MainLayout.qml" line="1594"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1649"/>
+        <location filename="../app/MainLayout.qml" line="1658"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1717"/>
         <source>Back</source>
         <translation>Terug</translation>
     </message>
@@ -1355,29 +1362,29 @@ Français - Wilfried</source>
         <translation type="vanished">Pagina</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1449"/>
-        <location filename="../app/MainLayout.qml" line="1484"/>
-        <location filename="../app/MainLayout.qml" line="1535"/>
-        <location filename="../app/MainLayout.qml" line="1683"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
+        <location filename="../app/MainLayout.qml" line="1488"/>
+        <location filename="../app/MainLayout.qml" line="1539"/>
+        <location filename="../app/MainLayout.qml" line="1687"/>
         <source>Options</source>
         <translation>Opties</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1315"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1494"/>
-        <location filename="../app/MainLayout.qml" line="1552"/>
-        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1319"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1498"/>
+        <location filename="../app/MainLayout.qml" line="1556"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
         <source>Retry</source>
         <translation>Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1613"/>
         <source>Change</source>
         <translation>Wijzigen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1619"/>
         <source>Toggle</source>
         <translation>Schakelen</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -521,23 +521,23 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
-        <location filename="../screens/HubScreen.qml" line="1288"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="1305"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>No recent games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>Resume: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="303"/>
         <source>Favorites</source>
         <translation>Favorite</translation>
     </message>
@@ -546,32 +546,32 @@ Français - Wilfried</source>
         <translation type="vanished">Recent Jucate</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>No internet connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="352"/>
+        <location filename="../screens/HubScreen.qml" line="355"/>
         <source>Not available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="309"/>
+        <location filename="../screens/HubScreen.qml" line="312"/>
         <source>Settings</source>
         <translation>Setări</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="302"/>
+        <location filename="../screens/HubScreen.qml" line="305"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1591"/>
+        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Niciun sistem disponibil. Rulați Actualizare bază de date din Setări.</translation>
     </message>
@@ -677,24 +677,29 @@ Français - Wilfried</source>
         <translation type="vanished">Lansare core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2563"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2319"/>
+        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2663"/>
+        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3748"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Remove from favorites</source>
         <translation>Elimină din favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Add to favorites</source>
         <translation>Adaugă la favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2281"/>
+        <location filename="../app/Main.qml" line="2253"/>
+        <location filename="../app/Main.qml" line="2324"/>
         <source>Write to NFC token</source>
         <translation>Scriere pe token NFC</translation>
     </message>
@@ -703,441 +708,443 @@ Français - Wilfried</source>
         <translation type="vanished">Cod QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2243"/>
+        <location filename="../app/Main.qml" line="2297"/>
         <source>Launch game</source>
         <translation>Lansare joc</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
-        <location filename="../app/Main.qml" line="3281"/>
-        <location filename="../app/Main.qml" line="3328"/>
-        <location filename="../app/Main.qml" line="3338"/>
+        <location filename="../app/Main.qml" line="1063"/>
+        <location filename="../app/Main.qml" line="3381"/>
+        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3438"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3317"/>
+        <location filename="../app/Main.qml" line="3417"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4603"/>
+        <location filename="../app/Main.qml" line="4812"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4610"/>
+        <location filename="../app/Main.qml" line="4819"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4605"/>
+        <location filename="../app/Main.qml" line="4814"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2207"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizare bază de date media</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2145"/>
-        <location filename="../app/Main.qml" line="2180"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2210"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extragere metadate</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2166"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1053"/>
+        <location filename="../app/Main.qml" line="1056"/>
         <source>Settings</source>
         <translation type="unfinished">Setări</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2076"/>
+        <location filename="../app/Main.qml" line="2089"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2142"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2217"/>
-        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2247"/>
+        <location filename="../app/Main.qml" line="2301"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2237"/>
-        <location filename="../app/Main.qml" line="2292"/>
-        <location filename="../app/Main.qml" line="2333"/>
+        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3371"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Default</source>
         <translation type="unfinished">Implicit</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="2367"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2122"/>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2189"/>
-        <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="3264"/>
+        <location filename="../app/Main.qml" line="2151"/>
+        <location filename="../app/Main.qml" line="2202"/>
+        <location filename="../app/Main.qml" line="2219"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3364"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3309"/>
+        <location filename="../app/Main.qml" line="3409"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3370"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3375"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3475"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3292"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3479"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1028"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1045"/>
+        <location filename="../app/Main.qml" line="1048"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1049"/>
+        <location filename="../app/Main.qml" line="1052"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1057"/>
+        <location filename="../app/Main.qml" line="1060"/>
         <source>Quit</source>
         <translation type="unfinished">Ieșire</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2241"/>
-        <location filename="../app/Main.qml" line="2260"/>
-        <location filename="../app/Main.qml" line="2296"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2290"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="2285"/>
+        <location filename="../app/Main.qml" line="2257"/>
+        <location filename="../app/Main.qml" line="2328"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2360"/>
+        <location filename="../app/Main.qml" line="2438"/>
         <source>Move</source>
         <translation type="unfinished">Mutare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2638"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
-        <location filename="../app/Main.qml" line="2907"/>
-        <location filename="../app/Main.qml" line="2929"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="3007"/>
+        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>OK</source>
         <translation type="unfinished">În regulă</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <source>Change launcher: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3053"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2962"/>
+        <location filename="../app/Main.qml" line="3062"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2963"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2965"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2968"/>
+        <location filename="../app/Main.qml" line="3068"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2969"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2971"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2972"/>
+        <location filename="../app/Main.qml" line="3072"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2974"/>
+        <location filename="../app/Main.qml" line="3074"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2975"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2977"/>
+        <location filename="../app/Main.qml" line="3077"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2978"/>
+        <location filename="../app/Main.qml" line="3078"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2980"/>
+        <location filename="../app/Main.qml" line="3080"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2981"/>
+        <location filename="../app/Main.qml" line="3081"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2984"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3084"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2986"/>
+        <location filename="../app/Main.qml" line="3086"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2987"/>
+        <location filename="../app/Main.qml" line="3087"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2989"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2990"/>
+        <location filename="../app/Main.qml" line="3090"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2992"/>
+        <location filename="../app/Main.qml" line="3092"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3217"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3233"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3142"/>
+        <location filename="../app/Main.qml" line="3242"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3271"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3256"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3296"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3396"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
-        <location filename="../app/Main.qml" line="3325"/>
+        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3425"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3313"/>
-        <location filename="../app/Main.qml" line="3335"/>
+        <location filename="../app/Main.qml" line="3413"/>
+        <location filename="../app/Main.qml" line="3435"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3353"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3349"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3449"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3456"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3556"/>
-        <location filename="../app/Main.qml" line="3574"/>
-        <source>Saving launcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3560"/>
-        <location filename="../app/Main.qml" line="3577"/>
+        <location filename="../app/Main.qml" line="3672"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2983"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3083"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
-        <location filename="../app/Main.qml" line="3182"/>
-        <location filename="../app/Main.qml" line="3590"/>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Retry</source>
         <translation type="unfinished">Reîncercare</translation>
     </message>
@@ -1146,22 +1153,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Anulare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4607"/>
+        <location filename="../app/Main.qml" line="4816"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4612"/>
+        <location filename="../app/Main.qml" line="4821"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4614"/>
+        <location filename="../app/Main.qml" line="4823"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4616"/>
+        <location filename="../app/Main.qml" line="4825"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>
@@ -1190,7 +1197,7 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
         <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
         <source>OK</source>
         <translation type="unfinished">În regulă</translation>
     </message>
@@ -1210,45 +1217,45 @@ Français - Wilfried</source>
         <translation>Sigur doriți să ieșiți?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1279"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
         <source>Select</source>
         <translation>Selectare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1293"/>
-        <location filename="../app/MainLayout.qml" line="1308"/>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1345"/>
+        <location filename="../app/MainLayout.qml" line="1283"/>
+        <location filename="../app/MainLayout.qml" line="1297"/>
+        <location filename="../app/MainLayout.qml" line="1312"/>
+        <location filename="../app/MainLayout.qml" line="1323"/>
+        <location filename="../app/MainLayout.qml" line="1349"/>
         <source>Close</source>
         <translation>Închidere</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1326"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1290"/>
+        <location filename="../app/MainLayout.qml" line="1330"/>
+        <location filename="../app/MainLayout.qml" line="1371"/>
+        <location filename="../app/MainLayout.qml" line="1414"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1304"/>
+        <location filename="../app/MainLayout.qml" line="1308"/>
         <source>Done</source>
         <translation>Gata</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1334"/>
+        <location filename="../app/MainLayout.qml" line="1338"/>
         <source>I understand</source>
         <translation>Am înțeles</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1257,28 +1264,28 @@ Français - Wilfried</source>
         <translation type="vanished">Pornire</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1641"/>
+        <location filename="../app/MainLayout.qml" line="1645"/>
         <source>Scroll</source>
         <translation>Derulare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1558"/>
-        <location filename="../app/MainLayout.qml" line="1690"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1544"/>
+        <location filename="../app/MainLayout.qml" line="1562"/>
+        <location filename="../app/MainLayout.qml" line="1694"/>
+        <location filename="../app/MainLayout.qml" line="1713"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1271"/>
-        <location filename="../app/MainLayout.qml" line="1359"/>
-        <location filename="../app/MainLayout.qml" line="1439"/>
-        <location filename="../app/MainLayout.qml" line="1476"/>
-        <location filename="../app/MainLayout.qml" line="1525"/>
-        <location filename="../app/MainLayout.qml" line="1581"/>
-        <location filename="../app/MainLayout.qml" line="1600"/>
-        <location filename="../app/MainLayout.qml" line="1673"/>
+        <location filename="../app/MainLayout.qml" line="1275"/>
+        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1443"/>
+        <location filename="../app/MainLayout.qml" line="1480"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1585"/>
+        <location filename="../app/MainLayout.qml" line="1604"/>
+        <location filename="../app/MainLayout.qml" line="1677"/>
         <source>Move</source>
         <translation>Mutare</translation>
     </message>
@@ -1313,21 +1320,21 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1406"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1410"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1481"/>
-        <location filename="../app/MainLayout.qml" line="1530"/>
-        <location filename="../app/MainLayout.qml" line="1586"/>
-        <location filename="../app/MainLayout.qml" line="1678"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1590"/>
+        <location filename="../app/MainLayout.qml" line="1682"/>
         <source>Open</source>
         <translation>Deschidere</translation>
     </message>
@@ -1336,19 +1343,19 @@ Français - Wilfried</source>
         <translation type="vanished">Ieșire</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1462"/>
-        <location filename="../app/MainLayout.qml" line="1487"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1514"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1574"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1624"/>
-        <location filename="../app/MainLayout.qml" line="1645"/>
-        <location filename="../app/MainLayout.qml" line="1654"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1518"/>
+        <location filename="../app/MainLayout.qml" line="1548"/>
+        <location filename="../app/MainLayout.qml" line="1566"/>
+        <location filename="../app/MainLayout.qml" line="1578"/>
+        <location filename="../app/MainLayout.qml" line="1594"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1649"/>
+        <location filename="../app/MainLayout.qml" line="1658"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1717"/>
         <source>Back</source>
         <translation>Înapoi</translation>
     </message>
@@ -1357,29 +1364,29 @@ Français - Wilfried</source>
         <translation type="vanished">Pagină</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1449"/>
-        <location filename="../app/MainLayout.qml" line="1484"/>
-        <location filename="../app/MainLayout.qml" line="1535"/>
-        <location filename="../app/MainLayout.qml" line="1683"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
+        <location filename="../app/MainLayout.qml" line="1488"/>
+        <location filename="../app/MainLayout.qml" line="1539"/>
+        <location filename="../app/MainLayout.qml" line="1687"/>
         <source>Options</source>
         <translation>Opțiuni</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1315"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1494"/>
-        <location filename="../app/MainLayout.qml" line="1552"/>
-        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1319"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1498"/>
+        <location filename="../app/MainLayout.qml" line="1556"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
         <source>Retry</source>
         <translation>Reîncercare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1613"/>
         <source>Change</source>
         <translation>Schimbare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1619"/>
         <source>Toggle</source>
         <translation>Comutare</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -677,29 +677,29 @@ Français - Wilfried</source>
         <translation type="vanished">Lansare core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
-        <location filename="../app/Main.qml" line="2319"/>
-        <location filename="../app/Main.qml" line="2654"/>
-        <location filename="../app/Main.qml" line="2663"/>
-        <location filename="../app/Main.qml" line="3705"/>
-        <location filename="../app/Main.qml" line="3748"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2330"/>
+        <location filename="../app/Main.qml" line="2393"/>
+        <location filename="../app/Main.qml" line="2699"/>
+        <location filename="../app/Main.qml" line="3741"/>
+        <location filename="../app/Main.qml" line="3784"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Remove from favorites</source>
         <translation>Elimină din favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Add to favorites</source>
         <translation>Adaugă la favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2253"/>
-        <location filename="../app/Main.qml" line="2324"/>
+        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2335"/>
         <source>Write to NFC token</source>
         <translation>Scriere pe token NFC</translation>
     </message>
@@ -708,443 +708,443 @@ Français - Wilfried</source>
         <translation type="vanished">Cod QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2243"/>
-        <location filename="../app/Main.qml" line="2297"/>
+        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2308"/>
         <source>Launch game</source>
         <translation>Lansare joc</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1063"/>
-        <location filename="../app/Main.qml" line="3381"/>
-        <location filename="../app/Main.qml" line="3428"/>
-        <location filename="../app/Main.qml" line="3438"/>
+        <location filename="../app/Main.qml" line="1070"/>
+        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3464"/>
+        <location filename="../app/Main.qml" line="3474"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4812"/>
+        <location filename="../app/Main.qml" line="4848"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4819"/>
+        <location filename="../app/Main.qml" line="4855"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4814"/>
+        <location filename="../app/Main.qml" line="4850"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2207"/>
+        <location filename="../app/Main.qml" line="2183"/>
+        <location filename="../app/Main.qml" line="2218"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizare bază de date media</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2175"/>
-        <location filename="../app/Main.qml" line="2210"/>
+        <location filename="../app/Main.qml" line="2186"/>
+        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Extragere metadate</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1056"/>
+        <location filename="../app/Main.qml" line="1063"/>
         <source>Settings</source>
         <translation type="unfinished">Setări</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2089"/>
+        <location filename="../app/Main.qml" line="2096"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2153"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2247"/>
-        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2258"/>
+        <location filename="../app/Main.qml" line="2312"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2267"/>
-        <location filename="../app/Main.qml" line="2335"/>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2346"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Default</source>
         <translation type="unfinished">Implicit</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="2378"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2151"/>
-        <location filename="../app/Main.qml" line="2202"/>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3364"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2230"/>
+        <location filename="../app/Main.qml" line="2238"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3409"/>
+        <location filename="../app/Main.qml" line="3445"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3406"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3475"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3511"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3428"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3479"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="3436"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1028"/>
+        <location filename="../app/Main.qml" line="1035"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1048"/>
+        <location filename="../app/Main.qml" line="1055"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1052"/>
+        <location filename="../app/Main.qml" line="1059"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="1067"/>
         <source>Quit</source>
         <translation type="unfinished">Ieșire</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2290"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2173"/>
+        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2350"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2257"/>
-        <location filename="../app/Main.qml" line="2328"/>
+        <location filename="../app/Main.qml" line="2268"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2461"/>
         <source>Move</source>
         <translation type="unfinished">Mutare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2638"/>
+        <location filename="../app/Main.qml" line="2667"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
-        <location filename="../app/Main.qml" line="3007"/>
-        <location filename="../app/Main.qml" line="3029"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3095"/>
+        <location filename="../app/Main.qml" line="1032"/>
+        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3131"/>
         <source>OK</source>
         <translation type="unfinished">În regulă</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3062"/>
+        <location filename="../app/Main.qml" line="3098"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3099"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3101"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3068"/>
+        <location filename="../app/Main.qml" line="3104"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3105"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3107"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3072"/>
+        <location filename="../app/Main.qml" line="3108"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3074"/>
+        <location filename="../app/Main.qml" line="3110"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3111"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3077"/>
+        <location filename="../app/Main.qml" line="3113"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3078"/>
+        <location filename="../app/Main.qml" line="3114"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3080"/>
+        <location filename="../app/Main.qml" line="3116"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3084"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3120"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3122"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3087"/>
+        <location filename="../app/Main.qml" line="3123"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3125"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3090"/>
+        <location filename="../app/Main.qml" line="3126"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3092"/>
+        <location filename="../app/Main.qml" line="3128"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3129"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3217"/>
+        <location filename="../app/Main.qml" line="3253"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3233"/>
+        <location filename="../app/Main.qml" line="3269"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3242"/>
+        <location filename="../app/Main.qml" line="3278"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3307"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3396"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3432"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
-        <location filename="../app/Main.qml" line="3425"/>
+        <location filename="../app/Main.qml" line="3415"/>
+        <location filename="../app/Main.qml" line="3461"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3413"/>
-        <location filename="../app/Main.qml" line="3435"/>
+        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3489"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3485"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3456"/>
+        <location filename="../app/Main.qml" line="3492"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3672"/>
+        <location filename="../app/Main.qml" line="3708"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3083"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3119"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
-        <location filename="../app/Main.qml" line="3282"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Retry</source>
         <translation type="unfinished">Reîncercare</translation>
     </message>
@@ -1153,22 +1153,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Anulare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4816"/>
+        <location filename="../app/Main.qml" line="4852"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4821"/>
+        <location filename="../app/Main.qml" line="4857"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4823"/>
+        <location filename="../app/Main.qml" line="4859"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4825"/>
+        <location filename="../app/Main.qml" line="4861"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>
@@ -1218,7 +1218,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Select</source>
         <translation>Selectare</translation>
     </message>
@@ -1234,8 +1234,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="1290"/>
         <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1371"/>
-        <location filename="../app/MainLayout.qml" line="1414"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
@@ -1250,12 +1250,17 @@ Français - Wilfried</source>
         <translation>Am înțeles</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
+        <source>Saving…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="1389"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1264,28 +1269,28 @@ Français - Wilfried</source>
         <translation type="vanished">Pornire</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1645"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Scroll</source>
         <translation>Derulare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1457"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1468"/>
+        <location filename="../app/MainLayout.qml" line="1555"/>
+        <location filename="../app/MainLayout.qml" line="1573"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1724"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1480"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1585"/>
-        <location filename="../app/MainLayout.qml" line="1604"/>
-        <location filename="../app/MainLayout.qml" line="1677"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1454"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1540"/>
+        <location filename="../app/MainLayout.qml" line="1596"/>
+        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Move</source>
         <translation>Mutare</translation>
     </message>
@@ -1320,21 +1325,21 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1417"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1485"/>
-        <location filename="../app/MainLayout.qml" line="1534"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1682"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1601"/>
+        <location filename="../app/MainLayout.qml" line="1693"/>
         <source>Open</source>
         <translation>Deschidere</translation>
     </message>
@@ -1343,19 +1348,19 @@ Français - Wilfried</source>
         <translation type="vanished">Ieșire</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1466"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1477"/>
         <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1518"/>
-        <location filename="../app/MainLayout.qml" line="1548"/>
-        <location filename="../app/MainLayout.qml" line="1566"/>
-        <location filename="../app/MainLayout.qml" line="1578"/>
-        <location filename="../app/MainLayout.qml" line="1594"/>
-        <location filename="../app/MainLayout.qml" line="1628"/>
-        <location filename="../app/MainLayout.qml" line="1649"/>
-        <location filename="../app/MainLayout.qml" line="1658"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
-        <location filename="../app/MainLayout.qml" line="1717"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1559"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1589"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1639"/>
+        <location filename="../app/MainLayout.qml" line="1660"/>
+        <location filename="../app/MainLayout.qml" line="1669"/>
+        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1728"/>
         <source>Back</source>
         <translation>Înapoi</translation>
     </message>
@@ -1364,29 +1369,29 @@ Français - Wilfried</source>
         <translation type="vanished">Pagină</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1488"/>
-        <location filename="../app/MainLayout.qml" line="1539"/>
-        <location filename="../app/MainLayout.qml" line="1687"/>
+        <location filename="../app/MainLayout.qml" line="1464"/>
+        <location filename="../app/MainLayout.qml" line="1499"/>
+        <location filename="../app/MainLayout.qml" line="1550"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
         <source>Options</source>
         <translation>Opțiuni</translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1556"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1567"/>
+        <location filename="../app/MainLayout.qml" line="1716"/>
         <source>Retry</source>
         <translation>Reîncercare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1613"/>
+        <location filename="../app/MainLayout.qml" line="1624"/>
         <source>Change</source>
         <translation>Schimbare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1619"/>
+        <location filename="../app/MainLayout.qml" line="1630"/>
         <source>Toggle</source>
         <translation>Comutare</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -677,29 +677,29 @@ Français - Wilfried</source>
         <translation type="vanished">Spustiť core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
-        <location filename="../app/Main.qml" line="2319"/>
-        <location filename="../app/Main.qml" line="2654"/>
-        <location filename="../app/Main.qml" line="2663"/>
-        <location filename="../app/Main.qml" line="3705"/>
-        <location filename="../app/Main.qml" line="3748"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2330"/>
+        <location filename="../app/Main.qml" line="2393"/>
+        <location filename="../app/Main.qml" line="2699"/>
+        <location filename="../app/Main.qml" line="3741"/>
+        <location filename="../app/Main.qml" line="3784"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Remove from favorites</source>
         <translation>Odstrániť z obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Add to favorites</source>
         <translation>Pridať do obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2253"/>
-        <location filename="../app/Main.qml" line="2324"/>
+        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2335"/>
         <source>Write to NFC token</source>
         <translation>Zapísať na NFC token</translation>
     </message>
@@ -708,443 +708,443 @@ Français - Wilfried</source>
         <translation type="vanished">QR kód</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2243"/>
-        <location filename="../app/Main.qml" line="2297"/>
+        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2308"/>
         <source>Launch game</source>
         <translation>Spustiť hru</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1063"/>
-        <location filename="../app/Main.qml" line="3381"/>
-        <location filename="../app/Main.qml" line="3428"/>
-        <location filename="../app/Main.qml" line="3438"/>
+        <location filename="../app/Main.qml" line="1070"/>
+        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3464"/>
+        <location filename="../app/Main.qml" line="3474"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4812"/>
+        <location filename="../app/Main.qml" line="4848"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4819"/>
+        <location filename="../app/Main.qml" line="4855"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4814"/>
+        <location filename="../app/Main.qml" line="4850"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2207"/>
+        <location filename="../app/Main.qml" line="2183"/>
+        <location filename="../app/Main.qml" line="2218"/>
         <source>Update media database</source>
         <translation type="unfinished">Aktualizovať databázu médií</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2175"/>
-        <location filename="../app/Main.qml" line="2210"/>
+        <location filename="../app/Main.qml" line="2186"/>
+        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Získať metadáta</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1056"/>
+        <location filename="../app/Main.qml" line="1063"/>
         <source>Settings</source>
         <translation type="unfinished">Nastavenia</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2089"/>
+        <location filename="../app/Main.qml" line="2096"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2153"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2247"/>
-        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2258"/>
+        <location filename="../app/Main.qml" line="2312"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2267"/>
-        <location filename="../app/Main.qml" line="2335"/>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2346"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Default</source>
         <translation type="unfinished">Predvolené</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="2378"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2151"/>
-        <location filename="../app/Main.qml" line="2202"/>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3364"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2230"/>
+        <location filename="../app/Main.qml" line="2238"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3409"/>
+        <location filename="../app/Main.qml" line="3445"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3406"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3475"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3511"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3428"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3479"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="3436"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1028"/>
+        <location filename="../app/Main.qml" line="1035"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1048"/>
+        <location filename="../app/Main.qml" line="1055"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1052"/>
+        <location filename="../app/Main.qml" line="1059"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="1067"/>
         <source>Quit</source>
         <translation type="unfinished">Ukončiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2290"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2173"/>
+        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2350"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2257"/>
-        <location filename="../app/Main.qml" line="2328"/>
+        <location filename="../app/Main.qml" line="2268"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2461"/>
         <source>Move</source>
         <translation type="unfinished">Presunúť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2638"/>
+        <location filename="../app/Main.qml" line="2667"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
-        <location filename="../app/Main.qml" line="3007"/>
-        <location filename="../app/Main.qml" line="3029"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3095"/>
+        <location filename="../app/Main.qml" line="1032"/>
+        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3131"/>
         <source>OK</source>
         <translation type="unfinished">V poriadku</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3062"/>
+        <location filename="../app/Main.qml" line="3098"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3099"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3101"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3068"/>
+        <location filename="../app/Main.qml" line="3104"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3105"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3107"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3072"/>
+        <location filename="../app/Main.qml" line="3108"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3074"/>
+        <location filename="../app/Main.qml" line="3110"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3111"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3077"/>
+        <location filename="../app/Main.qml" line="3113"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3078"/>
+        <location filename="../app/Main.qml" line="3114"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3080"/>
+        <location filename="../app/Main.qml" line="3116"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3084"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3120"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3122"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3087"/>
+        <location filename="../app/Main.qml" line="3123"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3125"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3090"/>
+        <location filename="../app/Main.qml" line="3126"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3092"/>
+        <location filename="../app/Main.qml" line="3128"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3129"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3217"/>
+        <location filename="../app/Main.qml" line="3253"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3233"/>
+        <location filename="../app/Main.qml" line="3269"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3242"/>
+        <location filename="../app/Main.qml" line="3278"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3307"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3396"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3432"/>
         <source>Favorites</source>
         <translation type="unfinished">Obľúbené</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
-        <location filename="../app/Main.qml" line="3425"/>
+        <location filename="../app/Main.qml" line="3415"/>
+        <location filename="../app/Main.qml" line="3461"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3413"/>
-        <location filename="../app/Main.qml" line="3435"/>
+        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3489"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3485"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3456"/>
+        <location filename="../app/Main.qml" line="3492"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3672"/>
+        <location filename="../app/Main.qml" line="3708"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3083"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3119"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
-        <location filename="../app/Main.qml" line="3282"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Retry</source>
         <translation type="unfinished">Skúsiť znova</translation>
     </message>
@@ -1153,22 +1153,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4816"/>
+        <location filename="../app/Main.qml" line="4852"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4821"/>
+        <location filename="../app/Main.qml" line="4857"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4823"/>
+        <location filename="../app/Main.qml" line="4859"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4825"/>
+        <location filename="../app/Main.qml" line="4861"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>
@@ -1218,7 +1218,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Select</source>
         <translation>Vybrať</translation>
     </message>
@@ -1234,8 +1234,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="1290"/>
         <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1371"/>
-        <location filename="../app/MainLayout.qml" line="1414"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
@@ -1250,12 +1250,17 @@ Français - Wilfried</source>
         <translation>Rozumiem</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
+        <source>Saving…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="1389"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1264,28 +1269,28 @@ Français - Wilfried</source>
         <translation type="vanished">Spustiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1645"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Scroll</source>
         <translation>Posúvať</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1457"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1468"/>
+        <location filename="../app/MainLayout.qml" line="1555"/>
+        <location filename="../app/MainLayout.qml" line="1573"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1724"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1480"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1585"/>
-        <location filename="../app/MainLayout.qml" line="1604"/>
-        <location filename="../app/MainLayout.qml" line="1677"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1454"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1540"/>
+        <location filename="../app/MainLayout.qml" line="1596"/>
+        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Move</source>
         <translation>Presunúť</translation>
     </message>
@@ -1320,21 +1325,21 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1417"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1485"/>
-        <location filename="../app/MainLayout.qml" line="1534"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1682"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1601"/>
+        <location filename="../app/MainLayout.qml" line="1693"/>
         <source>Open</source>
         <translation>Otvoriť</translation>
     </message>
@@ -1343,19 +1348,19 @@ Français - Wilfried</source>
         <translation type="vanished">Ukončiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1466"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1477"/>
         <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1518"/>
-        <location filename="../app/MainLayout.qml" line="1548"/>
-        <location filename="../app/MainLayout.qml" line="1566"/>
-        <location filename="../app/MainLayout.qml" line="1578"/>
-        <location filename="../app/MainLayout.qml" line="1594"/>
-        <location filename="../app/MainLayout.qml" line="1628"/>
-        <location filename="../app/MainLayout.qml" line="1649"/>
-        <location filename="../app/MainLayout.qml" line="1658"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
-        <location filename="../app/MainLayout.qml" line="1717"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1559"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1589"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1639"/>
+        <location filename="../app/MainLayout.qml" line="1660"/>
+        <location filename="../app/MainLayout.qml" line="1669"/>
+        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1728"/>
         <source>Back</source>
         <translation>Späť</translation>
     </message>
@@ -1364,29 +1369,29 @@ Français - Wilfried</source>
         <translation type="vanished">Stránka</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1488"/>
-        <location filename="../app/MainLayout.qml" line="1539"/>
-        <location filename="../app/MainLayout.qml" line="1687"/>
+        <location filename="../app/MainLayout.qml" line="1464"/>
+        <location filename="../app/MainLayout.qml" line="1499"/>
+        <location filename="../app/MainLayout.qml" line="1550"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
         <source>Options</source>
         <translation>Možnosti</translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1556"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1567"/>
+        <location filename="../app/MainLayout.qml" line="1716"/>
         <source>Retry</source>
         <translation>Skúsiť znova</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1613"/>
+        <location filename="../app/MainLayout.qml" line="1624"/>
         <source>Change</source>
         <translation>Zmeniť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1619"/>
+        <location filename="../app/MainLayout.qml" line="1630"/>
         <source>Toggle</source>
         <translation>Prepínať</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -521,23 +521,23 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
-        <location filename="../screens/HubScreen.qml" line="1288"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="1305"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>No recent games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>Resume: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="303"/>
         <source>Favorites</source>
         <translation>Obľúbené</translation>
     </message>
@@ -546,32 +546,32 @@ Français - Wilfried</source>
         <translation type="vanished">Nedávno hrané</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>No internet connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="352"/>
+        <location filename="../screens/HubScreen.qml" line="355"/>
         <source>Not available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="309"/>
+        <location filename="../screens/HubScreen.qml" line="312"/>
         <source>Settings</source>
         <translation>Nastavenia</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="302"/>
+        <location filename="../screens/HubScreen.qml" line="305"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1591"/>
+        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Žiadne systémy nie sú dostupné. Spustite Aktualizovať databázu médií v Nastaveniach.</translation>
     </message>
@@ -677,24 +677,29 @@ Français - Wilfried</source>
         <translation type="vanished">Spustiť core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2563"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2319"/>
+        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2663"/>
+        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3748"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Remove from favorites</source>
         <translation>Odstrániť z obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Add to favorites</source>
         <translation>Pridať do obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2281"/>
+        <location filename="../app/Main.qml" line="2253"/>
+        <location filename="../app/Main.qml" line="2324"/>
         <source>Write to NFC token</source>
         <translation>Zapísať na NFC token</translation>
     </message>
@@ -703,441 +708,443 @@ Français - Wilfried</source>
         <translation type="vanished">QR kód</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2243"/>
+        <location filename="../app/Main.qml" line="2297"/>
         <source>Launch game</source>
         <translation>Spustiť hru</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
-        <location filename="../app/Main.qml" line="3281"/>
-        <location filename="../app/Main.qml" line="3328"/>
-        <location filename="../app/Main.qml" line="3338"/>
+        <location filename="../app/Main.qml" line="1063"/>
+        <location filename="../app/Main.qml" line="3381"/>
+        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3438"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3317"/>
+        <location filename="../app/Main.qml" line="3417"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4603"/>
+        <location filename="../app/Main.qml" line="4812"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4610"/>
+        <location filename="../app/Main.qml" line="4819"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4605"/>
+        <location filename="../app/Main.qml" line="4814"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2207"/>
         <source>Update media database</source>
         <translation type="unfinished">Aktualizovať databázu médií</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2145"/>
-        <location filename="../app/Main.qml" line="2180"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2210"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Získať metadáta</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2166"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1053"/>
+        <location filename="../app/Main.qml" line="1056"/>
         <source>Settings</source>
         <translation type="unfinished">Nastavenia</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2076"/>
+        <location filename="../app/Main.qml" line="2089"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2142"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2217"/>
-        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2247"/>
+        <location filename="../app/Main.qml" line="2301"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2237"/>
-        <location filename="../app/Main.qml" line="2292"/>
-        <location filename="../app/Main.qml" line="2333"/>
+        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3371"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Default</source>
         <translation type="unfinished">Predvolené</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="2367"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2122"/>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2189"/>
-        <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="3264"/>
+        <location filename="../app/Main.qml" line="2151"/>
+        <location filename="../app/Main.qml" line="2202"/>
+        <location filename="../app/Main.qml" line="2219"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3364"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3309"/>
+        <location filename="../app/Main.qml" line="3409"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3370"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3375"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3475"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3292"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3479"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1028"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1045"/>
+        <location filename="../app/Main.qml" line="1048"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1049"/>
+        <location filename="../app/Main.qml" line="1052"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1057"/>
+        <location filename="../app/Main.qml" line="1060"/>
         <source>Quit</source>
         <translation type="unfinished">Ukončiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2241"/>
-        <location filename="../app/Main.qml" line="2260"/>
-        <location filename="../app/Main.qml" line="2296"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2290"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="2285"/>
+        <location filename="../app/Main.qml" line="2257"/>
+        <location filename="../app/Main.qml" line="2328"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2360"/>
+        <location filename="../app/Main.qml" line="2438"/>
         <source>Move</source>
         <translation type="unfinished">Presunúť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2638"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
-        <location filename="../app/Main.qml" line="2907"/>
-        <location filename="../app/Main.qml" line="2929"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="3007"/>
+        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>OK</source>
         <translation type="unfinished">V poriadku</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <source>Change launcher: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3053"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2962"/>
+        <location filename="../app/Main.qml" line="3062"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2963"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2965"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2968"/>
+        <location filename="../app/Main.qml" line="3068"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2969"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2971"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2972"/>
+        <location filename="../app/Main.qml" line="3072"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2974"/>
+        <location filename="../app/Main.qml" line="3074"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2975"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2977"/>
+        <location filename="../app/Main.qml" line="3077"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2978"/>
+        <location filename="../app/Main.qml" line="3078"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2980"/>
+        <location filename="../app/Main.qml" line="3080"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2981"/>
+        <location filename="../app/Main.qml" line="3081"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2984"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3084"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2986"/>
+        <location filename="../app/Main.qml" line="3086"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2987"/>
+        <location filename="../app/Main.qml" line="3087"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2989"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2990"/>
+        <location filename="../app/Main.qml" line="3090"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2992"/>
+        <location filename="../app/Main.qml" line="3092"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3217"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3233"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3142"/>
+        <location filename="../app/Main.qml" line="3242"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3271"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3256"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3296"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3396"/>
         <source>Favorites</source>
         <translation type="unfinished">Obľúbené</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
-        <location filename="../app/Main.qml" line="3325"/>
+        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3425"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3313"/>
-        <location filename="../app/Main.qml" line="3335"/>
+        <location filename="../app/Main.qml" line="3413"/>
+        <location filename="../app/Main.qml" line="3435"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3353"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3349"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3449"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3456"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3556"/>
-        <location filename="../app/Main.qml" line="3574"/>
-        <source>Saving launcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3560"/>
-        <location filename="../app/Main.qml" line="3577"/>
+        <location filename="../app/Main.qml" line="3672"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2983"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3083"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
-        <location filename="../app/Main.qml" line="3182"/>
-        <location filename="../app/Main.qml" line="3590"/>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Retry</source>
         <translation type="unfinished">Skúsiť znova</translation>
     </message>
@@ -1146,22 +1153,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4607"/>
+        <location filename="../app/Main.qml" line="4816"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4612"/>
+        <location filename="../app/Main.qml" line="4821"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4614"/>
+        <location filename="../app/Main.qml" line="4823"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4616"/>
+        <location filename="../app/Main.qml" line="4825"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>
@@ -1190,7 +1197,7 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
         <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
         <source>OK</source>
         <translation type="unfinished">V poriadku</translation>
     </message>
@@ -1210,45 +1217,45 @@ Français - Wilfried</source>
         <translation>Naozaj chcete ukončiť?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1279"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
         <source>Select</source>
         <translation>Vybrať</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1293"/>
-        <location filename="../app/MainLayout.qml" line="1308"/>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1345"/>
+        <location filename="../app/MainLayout.qml" line="1283"/>
+        <location filename="../app/MainLayout.qml" line="1297"/>
+        <location filename="../app/MainLayout.qml" line="1312"/>
+        <location filename="../app/MainLayout.qml" line="1323"/>
+        <location filename="../app/MainLayout.qml" line="1349"/>
         <source>Close</source>
         <translation>Zavrieť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1326"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1290"/>
+        <location filename="../app/MainLayout.qml" line="1330"/>
+        <location filename="../app/MainLayout.qml" line="1371"/>
+        <location filename="../app/MainLayout.qml" line="1414"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1304"/>
+        <location filename="../app/MainLayout.qml" line="1308"/>
         <source>Done</source>
         <translation>Hotovo</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1334"/>
+        <location filename="../app/MainLayout.qml" line="1338"/>
         <source>I understand</source>
         <translation>Rozumiem</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1257,28 +1264,28 @@ Français - Wilfried</source>
         <translation type="vanished">Spustiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1641"/>
+        <location filename="../app/MainLayout.qml" line="1645"/>
         <source>Scroll</source>
         <translation>Posúvať</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1558"/>
-        <location filename="../app/MainLayout.qml" line="1690"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1544"/>
+        <location filename="../app/MainLayout.qml" line="1562"/>
+        <location filename="../app/MainLayout.qml" line="1694"/>
+        <location filename="../app/MainLayout.qml" line="1713"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1271"/>
-        <location filename="../app/MainLayout.qml" line="1359"/>
-        <location filename="../app/MainLayout.qml" line="1439"/>
-        <location filename="../app/MainLayout.qml" line="1476"/>
-        <location filename="../app/MainLayout.qml" line="1525"/>
-        <location filename="../app/MainLayout.qml" line="1581"/>
-        <location filename="../app/MainLayout.qml" line="1600"/>
-        <location filename="../app/MainLayout.qml" line="1673"/>
+        <location filename="../app/MainLayout.qml" line="1275"/>
+        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1443"/>
+        <location filename="../app/MainLayout.qml" line="1480"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1585"/>
+        <location filename="../app/MainLayout.qml" line="1604"/>
+        <location filename="../app/MainLayout.qml" line="1677"/>
         <source>Move</source>
         <translation>Presunúť</translation>
     </message>
@@ -1313,21 +1320,21 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1406"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1410"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1481"/>
-        <location filename="../app/MainLayout.qml" line="1530"/>
-        <location filename="../app/MainLayout.qml" line="1586"/>
-        <location filename="../app/MainLayout.qml" line="1678"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1590"/>
+        <location filename="../app/MainLayout.qml" line="1682"/>
         <source>Open</source>
         <translation>Otvoriť</translation>
     </message>
@@ -1336,19 +1343,19 @@ Français - Wilfried</source>
         <translation type="vanished">Ukončiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1462"/>
-        <location filename="../app/MainLayout.qml" line="1487"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1514"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1574"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1624"/>
-        <location filename="../app/MainLayout.qml" line="1645"/>
-        <location filename="../app/MainLayout.qml" line="1654"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1518"/>
+        <location filename="../app/MainLayout.qml" line="1548"/>
+        <location filename="../app/MainLayout.qml" line="1566"/>
+        <location filename="../app/MainLayout.qml" line="1578"/>
+        <location filename="../app/MainLayout.qml" line="1594"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1649"/>
+        <location filename="../app/MainLayout.qml" line="1658"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1717"/>
         <source>Back</source>
         <translation>Späť</translation>
     </message>
@@ -1357,29 +1364,29 @@ Français - Wilfried</source>
         <translation type="vanished">Stránka</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1449"/>
-        <location filename="../app/MainLayout.qml" line="1484"/>
-        <location filename="../app/MainLayout.qml" line="1535"/>
-        <location filename="../app/MainLayout.qml" line="1683"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
+        <location filename="../app/MainLayout.qml" line="1488"/>
+        <location filename="../app/MainLayout.qml" line="1539"/>
+        <location filename="../app/MainLayout.qml" line="1687"/>
         <source>Options</source>
         <translation>Možnosti</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1315"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1494"/>
-        <location filename="../app/MainLayout.qml" line="1552"/>
-        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1319"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1498"/>
+        <location filename="../app/MainLayout.qml" line="1556"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
         <source>Retry</source>
         <translation>Skúsiť znova</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1613"/>
         <source>Change</source>
         <translation>Zmeniť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1619"/>
         <source>Toggle</source>
         <translation>Prepínať</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -521,23 +521,23 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
-        <location filename="../screens/HubScreen.qml" line="1288"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="1305"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>No recent games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>Resume: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="303"/>
         <source>Favorites</source>
         <translation>Вибране</translation>
     </message>
@@ -546,32 +546,32 @@ Français - Wilfried</source>
         <translation type="vanished">Нещодавно зіграні</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>No internet connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="352"/>
+        <location filename="../screens/HubScreen.qml" line="355"/>
         <source>Not available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="309"/>
+        <location filename="../screens/HubScreen.qml" line="312"/>
         <source>Settings</source>
         <translation>Налаштування</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="302"/>
+        <location filename="../screens/HubScreen.qml" line="305"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1591"/>
+        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>Немає доступних систем. Запустіть Оновлення бази даних з Налаштувань.</translation>
     </message>
@@ -677,24 +677,29 @@ Français - Wilfried</source>
         <translation type="vanished">Запустити core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2563"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2319"/>
+        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2663"/>
+        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3748"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Remove from favorites</source>
         <translation>Видалити з вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Add to favorites</source>
         <translation>Додати до вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2281"/>
+        <location filename="../app/Main.qml" line="2253"/>
+        <location filename="../app/Main.qml" line="2324"/>
         <source>Write to NFC token</source>
         <translation>Записати на NFC-токен</translation>
     </message>
@@ -703,441 +708,443 @@ Français - Wilfried</source>
         <translation type="vanished">QR-код</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2243"/>
+        <location filename="../app/Main.qml" line="2297"/>
         <source>Launch game</source>
         <translation>Запустити гру</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
-        <location filename="../app/Main.qml" line="3281"/>
-        <location filename="../app/Main.qml" line="3328"/>
-        <location filename="../app/Main.qml" line="3338"/>
+        <location filename="../app/Main.qml" line="1063"/>
+        <location filename="../app/Main.qml" line="3381"/>
+        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3438"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3317"/>
+        <location filename="../app/Main.qml" line="3417"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4603"/>
+        <location filename="../app/Main.qml" line="4812"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4610"/>
+        <location filename="../app/Main.qml" line="4819"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4605"/>
+        <location filename="../app/Main.qml" line="4814"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2207"/>
         <source>Update media database</source>
         <translation type="unfinished">Оновити базу медіа</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2145"/>
-        <location filename="../app/Main.qml" line="2180"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2210"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Отримати метадані</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2166"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1053"/>
+        <location filename="../app/Main.qml" line="1056"/>
         <source>Settings</source>
         <translation type="unfinished">Налаштування</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2076"/>
+        <location filename="../app/Main.qml" line="2089"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2142"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2217"/>
-        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2247"/>
+        <location filename="../app/Main.qml" line="2301"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2237"/>
-        <location filename="../app/Main.qml" line="2292"/>
-        <location filename="../app/Main.qml" line="2333"/>
+        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3371"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Default</source>
         <translation type="unfinished">Типовий</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="2367"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2122"/>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2189"/>
-        <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="3264"/>
+        <location filename="../app/Main.qml" line="2151"/>
+        <location filename="../app/Main.qml" line="2202"/>
+        <location filename="../app/Main.qml" line="2219"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3364"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3309"/>
+        <location filename="../app/Main.qml" line="3409"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3370"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3375"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3475"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3292"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3479"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1028"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1045"/>
+        <location filename="../app/Main.qml" line="1048"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1049"/>
+        <location filename="../app/Main.qml" line="1052"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1057"/>
+        <location filename="../app/Main.qml" line="1060"/>
         <source>Quit</source>
         <translation type="unfinished">Вийти</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2241"/>
-        <location filename="../app/Main.qml" line="2260"/>
-        <location filename="../app/Main.qml" line="2296"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2290"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="2285"/>
+        <location filename="../app/Main.qml" line="2257"/>
+        <location filename="../app/Main.qml" line="2328"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2360"/>
+        <location filename="../app/Main.qml" line="2438"/>
         <source>Move</source>
         <translation type="unfinished">Переміщення</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2638"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
-        <location filename="../app/Main.qml" line="2907"/>
-        <location filename="../app/Main.qml" line="2929"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="3007"/>
+        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>OK</source>
         <translation type="unfinished">Гаразд</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <source>Change launcher: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3053"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2962"/>
+        <location filename="../app/Main.qml" line="3062"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2963"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2965"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2968"/>
+        <location filename="../app/Main.qml" line="3068"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2969"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2971"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2972"/>
+        <location filename="../app/Main.qml" line="3072"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2974"/>
+        <location filename="../app/Main.qml" line="3074"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2975"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2977"/>
+        <location filename="../app/Main.qml" line="3077"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2978"/>
+        <location filename="../app/Main.qml" line="3078"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2980"/>
+        <location filename="../app/Main.qml" line="3080"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2981"/>
+        <location filename="../app/Main.qml" line="3081"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2984"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3084"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2986"/>
+        <location filename="../app/Main.qml" line="3086"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2987"/>
+        <location filename="../app/Main.qml" line="3087"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2989"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2990"/>
+        <location filename="../app/Main.qml" line="3090"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2992"/>
+        <location filename="../app/Main.qml" line="3092"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3217"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3233"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3142"/>
+        <location filename="../app/Main.qml" line="3242"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3271"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3256"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3296"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3396"/>
         <source>Favorites</source>
         <translation type="unfinished">Вибране</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
-        <location filename="../app/Main.qml" line="3325"/>
+        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3425"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3313"/>
-        <location filename="../app/Main.qml" line="3335"/>
+        <location filename="../app/Main.qml" line="3413"/>
+        <location filename="../app/Main.qml" line="3435"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3353"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3349"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3449"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3456"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3556"/>
-        <location filename="../app/Main.qml" line="3574"/>
-        <source>Saving launcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3560"/>
-        <location filename="../app/Main.qml" line="3577"/>
+        <location filename="../app/Main.qml" line="3672"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2983"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3083"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
-        <location filename="../app/Main.qml" line="3182"/>
-        <location filename="../app/Main.qml" line="3590"/>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Retry</source>
         <translation type="unfinished">Повторити</translation>
     </message>
@@ -1146,22 +1153,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4607"/>
+        <location filename="../app/Main.qml" line="4816"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4612"/>
+        <location filename="../app/Main.qml" line="4821"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4614"/>
+        <location filename="../app/Main.qml" line="4823"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4616"/>
+        <location filename="../app/Main.qml" line="4825"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>
@@ -1190,7 +1197,7 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
         <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
         <source>OK</source>
         <translation type="unfinished">Гаразд</translation>
     </message>
@@ -1210,45 +1217,45 @@ Français - Wilfried</source>
         <translation>Ви впевнені, що хочете вийти?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1279"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
         <source>Select</source>
         <translation>Вибрати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1293"/>
-        <location filename="../app/MainLayout.qml" line="1308"/>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1345"/>
+        <location filename="../app/MainLayout.qml" line="1283"/>
+        <location filename="../app/MainLayout.qml" line="1297"/>
+        <location filename="../app/MainLayout.qml" line="1312"/>
+        <location filename="../app/MainLayout.qml" line="1323"/>
+        <location filename="../app/MainLayout.qml" line="1349"/>
         <source>Close</source>
         <translation>Закрити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1326"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1290"/>
+        <location filename="../app/MainLayout.qml" line="1330"/>
+        <location filename="../app/MainLayout.qml" line="1371"/>
+        <location filename="../app/MainLayout.qml" line="1414"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1304"/>
+        <location filename="../app/MainLayout.qml" line="1308"/>
         <source>Done</source>
         <translation>Готово</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1334"/>
+        <location filename="../app/MainLayout.qml" line="1338"/>
         <source>I understand</source>
         <translation>Я розумію</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1257,28 +1264,28 @@ Français - Wilfried</source>
         <translation type="vanished">Почати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1641"/>
+        <location filename="../app/MainLayout.qml" line="1645"/>
         <source>Scroll</source>
         <translation>Прокрутка</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1558"/>
-        <location filename="../app/MainLayout.qml" line="1690"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1544"/>
+        <location filename="../app/MainLayout.qml" line="1562"/>
+        <location filename="../app/MainLayout.qml" line="1694"/>
+        <location filename="../app/MainLayout.qml" line="1713"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1271"/>
-        <location filename="../app/MainLayout.qml" line="1359"/>
-        <location filename="../app/MainLayout.qml" line="1439"/>
-        <location filename="../app/MainLayout.qml" line="1476"/>
-        <location filename="../app/MainLayout.qml" line="1525"/>
-        <location filename="../app/MainLayout.qml" line="1581"/>
-        <location filename="../app/MainLayout.qml" line="1600"/>
-        <location filename="../app/MainLayout.qml" line="1673"/>
+        <location filename="../app/MainLayout.qml" line="1275"/>
+        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1443"/>
+        <location filename="../app/MainLayout.qml" line="1480"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1585"/>
+        <location filename="../app/MainLayout.qml" line="1604"/>
+        <location filename="../app/MainLayout.qml" line="1677"/>
         <source>Move</source>
         <translation>Переміщення</translation>
     </message>
@@ -1313,21 +1320,21 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1406"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1410"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1481"/>
-        <location filename="../app/MainLayout.qml" line="1530"/>
-        <location filename="../app/MainLayout.qml" line="1586"/>
-        <location filename="../app/MainLayout.qml" line="1678"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1590"/>
+        <location filename="../app/MainLayout.qml" line="1682"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
@@ -1336,19 +1343,19 @@ Français - Wilfried</source>
         <translation type="vanished">Вийти</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1462"/>
-        <location filename="../app/MainLayout.qml" line="1487"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1514"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1574"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1624"/>
-        <location filename="../app/MainLayout.qml" line="1645"/>
-        <location filename="../app/MainLayout.qml" line="1654"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1518"/>
+        <location filename="../app/MainLayout.qml" line="1548"/>
+        <location filename="../app/MainLayout.qml" line="1566"/>
+        <location filename="../app/MainLayout.qml" line="1578"/>
+        <location filename="../app/MainLayout.qml" line="1594"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1649"/>
+        <location filename="../app/MainLayout.qml" line="1658"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1717"/>
         <source>Back</source>
         <translation>Назад</translation>
     </message>
@@ -1357,29 +1364,29 @@ Français - Wilfried</source>
         <translation type="vanished">Сторінка</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1449"/>
-        <location filename="../app/MainLayout.qml" line="1484"/>
-        <location filename="../app/MainLayout.qml" line="1535"/>
-        <location filename="../app/MainLayout.qml" line="1683"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
+        <location filename="../app/MainLayout.qml" line="1488"/>
+        <location filename="../app/MainLayout.qml" line="1539"/>
+        <location filename="../app/MainLayout.qml" line="1687"/>
         <source>Options</source>
         <translation>Параметри</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1315"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1494"/>
-        <location filename="../app/MainLayout.qml" line="1552"/>
-        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1319"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1498"/>
+        <location filename="../app/MainLayout.qml" line="1556"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
         <source>Retry</source>
         <translation>Повторити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1613"/>
         <source>Change</source>
         <translation>Змінити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1619"/>
         <source>Toggle</source>
         <translation>Перемкнути</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -677,29 +677,29 @@ Français - Wilfried</source>
         <translation type="vanished">Запустити core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
-        <location filename="../app/Main.qml" line="2319"/>
-        <location filename="../app/Main.qml" line="2654"/>
-        <location filename="../app/Main.qml" line="2663"/>
-        <location filename="../app/Main.qml" line="3705"/>
-        <location filename="../app/Main.qml" line="3748"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2330"/>
+        <location filename="../app/Main.qml" line="2393"/>
+        <location filename="../app/Main.qml" line="2699"/>
+        <location filename="../app/Main.qml" line="3741"/>
+        <location filename="../app/Main.qml" line="3784"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Remove from favorites</source>
         <translation>Видалити з вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Add to favorites</source>
         <translation>Додати до вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2253"/>
-        <location filename="../app/Main.qml" line="2324"/>
+        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2335"/>
         <source>Write to NFC token</source>
         <translation>Записати на NFC-токен</translation>
     </message>
@@ -708,443 +708,443 @@ Français - Wilfried</source>
         <translation type="vanished">QR-код</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2243"/>
-        <location filename="../app/Main.qml" line="2297"/>
+        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2308"/>
         <source>Launch game</source>
         <translation>Запустити гру</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1063"/>
-        <location filename="../app/Main.qml" line="3381"/>
-        <location filename="../app/Main.qml" line="3428"/>
-        <location filename="../app/Main.qml" line="3438"/>
+        <location filename="../app/Main.qml" line="1070"/>
+        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3464"/>
+        <location filename="../app/Main.qml" line="3474"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4812"/>
+        <location filename="../app/Main.qml" line="4848"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4819"/>
+        <location filename="../app/Main.qml" line="4855"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4814"/>
+        <location filename="../app/Main.qml" line="4850"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2207"/>
+        <location filename="../app/Main.qml" line="2183"/>
+        <location filename="../app/Main.qml" line="2218"/>
         <source>Update media database</source>
         <translation type="unfinished">Оновити базу медіа</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2175"/>
-        <location filename="../app/Main.qml" line="2210"/>
+        <location filename="../app/Main.qml" line="2186"/>
+        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">Отримати метадані</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1056"/>
+        <location filename="../app/Main.qml" line="1063"/>
         <source>Settings</source>
         <translation type="unfinished">Налаштування</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2089"/>
+        <location filename="../app/Main.qml" line="2096"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2153"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2247"/>
-        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2258"/>
+        <location filename="../app/Main.qml" line="2312"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2267"/>
-        <location filename="../app/Main.qml" line="2335"/>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2346"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Default</source>
         <translation type="unfinished">Типовий</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="2378"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2151"/>
-        <location filename="../app/Main.qml" line="2202"/>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3364"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2230"/>
+        <location filename="../app/Main.qml" line="2238"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3409"/>
+        <location filename="../app/Main.qml" line="3445"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3406"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3475"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3511"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3428"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3479"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="3436"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1028"/>
+        <location filename="../app/Main.qml" line="1035"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1048"/>
+        <location filename="../app/Main.qml" line="1055"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1052"/>
+        <location filename="../app/Main.qml" line="1059"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="1067"/>
         <source>Quit</source>
         <translation type="unfinished">Вийти</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2290"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2173"/>
+        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2350"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2257"/>
-        <location filename="../app/Main.qml" line="2328"/>
+        <location filename="../app/Main.qml" line="2268"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2461"/>
         <source>Move</source>
         <translation type="unfinished">Переміщення</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2638"/>
+        <location filename="../app/Main.qml" line="2667"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
-        <location filename="../app/Main.qml" line="3007"/>
-        <location filename="../app/Main.qml" line="3029"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3095"/>
+        <location filename="../app/Main.qml" line="1032"/>
+        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3131"/>
         <source>OK</source>
         <translation type="unfinished">Гаразд</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3062"/>
+        <location filename="../app/Main.qml" line="3098"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3099"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3101"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3068"/>
+        <location filename="../app/Main.qml" line="3104"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3105"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3107"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3072"/>
+        <location filename="../app/Main.qml" line="3108"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3074"/>
+        <location filename="../app/Main.qml" line="3110"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3111"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3077"/>
+        <location filename="../app/Main.qml" line="3113"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3078"/>
+        <location filename="../app/Main.qml" line="3114"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3080"/>
+        <location filename="../app/Main.qml" line="3116"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3084"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3120"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3122"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3087"/>
+        <location filename="../app/Main.qml" line="3123"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3125"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3090"/>
+        <location filename="../app/Main.qml" line="3126"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3092"/>
+        <location filename="../app/Main.qml" line="3128"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3129"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3217"/>
+        <location filename="../app/Main.qml" line="3253"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3233"/>
+        <location filename="../app/Main.qml" line="3269"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3242"/>
+        <location filename="../app/Main.qml" line="3278"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3307"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3396"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3432"/>
         <source>Favorites</source>
         <translation type="unfinished">Вибране</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
-        <location filename="../app/Main.qml" line="3425"/>
+        <location filename="../app/Main.qml" line="3415"/>
+        <location filename="../app/Main.qml" line="3461"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3413"/>
-        <location filename="../app/Main.qml" line="3435"/>
+        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3489"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3485"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3456"/>
+        <location filename="../app/Main.qml" line="3492"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3672"/>
+        <location filename="../app/Main.qml" line="3708"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3083"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3119"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
-        <location filename="../app/Main.qml" line="3282"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Retry</source>
         <translation type="unfinished">Повторити</translation>
     </message>
@@ -1153,22 +1153,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4816"/>
+        <location filename="../app/Main.qml" line="4852"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4821"/>
+        <location filename="../app/Main.qml" line="4857"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4823"/>
+        <location filename="../app/Main.qml" line="4859"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4825"/>
+        <location filename="../app/Main.qml" line="4861"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>
@@ -1218,7 +1218,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Select</source>
         <translation>Вибрати</translation>
     </message>
@@ -1234,8 +1234,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="1290"/>
         <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1371"/>
-        <location filename="../app/MainLayout.qml" line="1414"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
@@ -1250,12 +1250,17 @@ Français - Wilfried</source>
         <translation>Я розумію</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
+        <source>Saving…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="1389"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1264,28 +1269,28 @@ Français - Wilfried</source>
         <translation type="vanished">Почати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1645"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Scroll</source>
         <translation>Прокрутка</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1457"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1468"/>
+        <location filename="../app/MainLayout.qml" line="1555"/>
+        <location filename="../app/MainLayout.qml" line="1573"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1724"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1480"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1585"/>
-        <location filename="../app/MainLayout.qml" line="1604"/>
-        <location filename="../app/MainLayout.qml" line="1677"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1454"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1540"/>
+        <location filename="../app/MainLayout.qml" line="1596"/>
+        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Move</source>
         <translation>Переміщення</translation>
     </message>
@@ -1320,21 +1325,21 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1417"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1485"/>
-        <location filename="../app/MainLayout.qml" line="1534"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1682"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1601"/>
+        <location filename="../app/MainLayout.qml" line="1693"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
@@ -1343,19 +1348,19 @@ Français - Wilfried</source>
         <translation type="vanished">Вийти</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1466"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1477"/>
         <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1518"/>
-        <location filename="../app/MainLayout.qml" line="1548"/>
-        <location filename="../app/MainLayout.qml" line="1566"/>
-        <location filename="../app/MainLayout.qml" line="1578"/>
-        <location filename="../app/MainLayout.qml" line="1594"/>
-        <location filename="../app/MainLayout.qml" line="1628"/>
-        <location filename="../app/MainLayout.qml" line="1649"/>
-        <location filename="../app/MainLayout.qml" line="1658"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
-        <location filename="../app/MainLayout.qml" line="1717"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1559"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1589"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1639"/>
+        <location filename="../app/MainLayout.qml" line="1660"/>
+        <location filename="../app/MainLayout.qml" line="1669"/>
+        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1728"/>
         <source>Back</source>
         <translation>Назад</translation>
     </message>
@@ -1364,29 +1369,29 @@ Français - Wilfried</source>
         <translation type="vanished">Сторінка</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1488"/>
-        <location filename="../app/MainLayout.qml" line="1539"/>
-        <location filename="../app/MainLayout.qml" line="1687"/>
+        <location filename="../app/MainLayout.qml" line="1464"/>
+        <location filename="../app/MainLayout.qml" line="1499"/>
+        <location filename="../app/MainLayout.qml" line="1550"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
         <source>Options</source>
         <translation>Параметри</translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1556"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1567"/>
+        <location filename="../app/MainLayout.qml" line="1716"/>
         <source>Retry</source>
         <translation>Повторити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1613"/>
+        <location filename="../app/MainLayout.qml" line="1624"/>
         <source>Change</source>
         <translation>Змінити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1619"/>
+        <location filename="../app/MainLayout.qml" line="1630"/>
         <source>Toggle</source>
         <translation>Перемкнути</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -517,23 +517,23 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
-        <location filename="../screens/HubScreen.qml" line="1288"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="1305"/>
         <source>Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>No recent games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="297"/>
+        <location filename="../screens/HubScreen.qml" line="300"/>
         <source>Resume: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="300"/>
+        <location filename="../screens/HubScreen.qml" line="303"/>
         <source>Favorites</source>
         <translation>收藏</translation>
     </message>
@@ -542,32 +542,32 @@ Français - Wilfried</source>
         <translation type="vanished">最近游玩</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>Update</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="306"/>
+        <location filename="../screens/HubScreen.qml" line="309"/>
         <source>No internet connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="352"/>
+        <location filename="../screens/HubScreen.qml" line="355"/>
         <source>Not available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="309"/>
+        <location filename="../screens/HubScreen.qml" line="312"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="302"/>
+        <location filename="../screens/HubScreen.qml" line="305"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1591"/>
+        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
         <translation>没有可用系统。请在“设置”中运行“更新媒体数据库”。</translation>
     </message>
@@ -673,81 +673,86 @@ Français - Wilfried</source>
         <translation type="vanished">启动核心</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2127"/>
-        <location filename="../app/Main.qml" line="2563"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2319"/>
+        <location filename="../app/Main.qml" line="2654"/>
+        <location filename="../app/Main.qml" line="2663"/>
+        <location filename="../app/Main.qml" line="3705"/>
+        <location filename="../app/Main.qml" line="3748"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2172"/>
+        <location filename="../app/Main.qml" line="2207"/>
         <source>Update media database</source>
         <translation type="unfinished">更新媒体数据库</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2145"/>
-        <location filename="../app/Main.qml" line="2180"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2210"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">抓取元数据</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
+        <location filename="../app/Main.qml" line="2166"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1053"/>
+        <location filename="../app/Main.qml" line="1056"/>
         <source>Settings</source>
         <translation type="unfinished">设置</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2076"/>
+        <location filename="../app/Main.qml" line="2089"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2113"/>
+        <location filename="../app/Main.qml" line="2142"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2136"/>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2243"/>
+        <location filename="../app/Main.qml" line="2297"/>
         <source>Launch game</source>
         <translation>启动游戏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2217"/>
-        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2247"/>
+        <location filename="../app/Main.qml" line="2301"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2237"/>
-        <location filename="../app/Main.qml" line="2292"/>
-        <location filename="../app/Main.qml" line="2333"/>
+        <location filename="../app/Main.qml" line="2267"/>
+        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2411"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Remove from favorites</source>
         <translation>从收藏中移除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2275"/>
+        <location filename="../app/Main.qml" line="2305"/>
         <source>Add to favorites</source>
         <translation>添加到收藏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2223"/>
-        <location filename="../app/Main.qml" line="2281"/>
+        <location filename="../app/Main.qml" line="2253"/>
+        <location filename="../app/Main.qml" line="2324"/>
         <source>Write to NFC token</source>
         <translation>写入 NFC 令牌</translation>
     </message>
@@ -756,369 +761,371 @@ Français - Wilfried</source>
         <translation type="vanished">二维码</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3371"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Default</source>
         <translation type="unfinished">默认</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2559"/>
+        <location filename="../app/Main.qml" line="2367"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2122"/>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2189"/>
-        <location filename="../app/Main.qml" line="2197"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="3264"/>
+        <location filename="../app/Main.qml" line="2151"/>
+        <location filename="../app/Main.qml" line="2202"/>
+        <location filename="../app/Main.qml" line="2219"/>
+        <location filename="../app/Main.qml" line="2227"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3364"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3296"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3396"/>
         <source>Favorites</source>
         <translation type="unfinished">收藏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
-        <location filename="../app/Main.qml" line="3281"/>
-        <location filename="../app/Main.qml" line="3328"/>
-        <location filename="../app/Main.qml" line="3338"/>
+        <location filename="../app/Main.qml" line="1063"/>
+        <location filename="../app/Main.qml" line="3381"/>
+        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3438"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3309"/>
+        <location filename="../app/Main.qml" line="3409"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
+        <location filename="../app/Main.qml" line="3370"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3360"/>
-        <location filename="../app/Main.qml" line="3375"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3475"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3270"/>
-        <location filename="../app/Main.qml" line="3292"/>
+        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3479"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3300"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1028"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1045"/>
+        <location filename="../app/Main.qml" line="1048"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1049"/>
+        <location filename="../app/Main.qml" line="1052"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1057"/>
+        <location filename="../app/Main.qml" line="1060"/>
         <source>Quit</source>
         <translation type="unfinished">退出</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2241"/>
-        <location filename="../app/Main.qml" line="2260"/>
-        <location filename="../app/Main.qml" line="2296"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2271"/>
+        <location filename="../app/Main.qml" line="2290"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="2285"/>
+        <location filename="../app/Main.qml" line="2257"/>
+        <location filename="../app/Main.qml" line="2328"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2356"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2360"/>
+        <location filename="../app/Main.qml" line="2438"/>
         <source>Move</source>
         <translation type="unfinished">移动</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2543"/>
+        <location filename="../app/Main.qml" line="2638"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
+        <location filename="../app/Main.qml" line="2851"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
-        <location filename="../app/Main.qml" line="2907"/>
-        <location filename="../app/Main.qml" line="2929"/>
-        <location filename="../app/Main.qml" line="2953"/>
-        <location filename="../app/Main.qml" line="2995"/>
+        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="3007"/>
+        <location filename="../app/Main.qml" line="3029"/>
+        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3095"/>
         <source>OK</source>
         <translation type="unfinished">确定</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1022"/>
+        <location filename="../app/Main.qml" line="1025"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2953"/>
+        <location filename="../app/Main.qml" line="2121"/>
+        <location filename="../app/Main.qml" line="2157"/>
+        <source>Change launcher: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3053"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2962"/>
+        <location filename="../app/Main.qml" line="3062"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2963"/>
+        <location filename="../app/Main.qml" line="3063"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2965"/>
+        <location filename="../app/Main.qml" line="3065"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2966"/>
+        <location filename="../app/Main.qml" line="3066"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2968"/>
+        <location filename="../app/Main.qml" line="3068"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2969"/>
+        <location filename="../app/Main.qml" line="3069"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2971"/>
+        <location filename="../app/Main.qml" line="3071"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2972"/>
+        <location filename="../app/Main.qml" line="3072"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2974"/>
+        <location filename="../app/Main.qml" line="3074"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2975"/>
+        <location filename="../app/Main.qml" line="3075"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2977"/>
+        <location filename="../app/Main.qml" line="3077"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2978"/>
+        <location filename="../app/Main.qml" line="3078"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2980"/>
+        <location filename="../app/Main.qml" line="3080"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2981"/>
+        <location filename="../app/Main.qml" line="3081"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2984"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3084"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2986"/>
+        <location filename="../app/Main.qml" line="3086"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2987"/>
+        <location filename="../app/Main.qml" line="3087"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2989"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2990"/>
+        <location filename="../app/Main.qml" line="3090"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2992"/>
+        <location filename="../app/Main.qml" line="3092"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2993"/>
+        <location filename="../app/Main.qml" line="3093"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3217"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3133"/>
+        <location filename="../app/Main.qml" line="3233"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3142"/>
+        <location filename="../app/Main.qml" line="3242"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3171"/>
+        <location filename="../app/Main.qml" line="3271"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3182"/>
+        <location filename="../app/Main.qml" line="3282"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3256"/>
+        <location filename="../app/Main.qml" line="3356"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3279"/>
-        <location filename="../app/Main.qml" line="3325"/>
+        <location filename="../app/Main.qml" line="3379"/>
+        <location filename="../app/Main.qml" line="3425"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3313"/>
-        <location filename="../app/Main.qml" line="3335"/>
+        <location filename="../app/Main.qml" line="3413"/>
+        <location filename="../app/Main.qml" line="3435"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3317"/>
+        <location filename="../app/Main.qml" line="3417"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3353"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3342"/>
-        <location filename="../app/Main.qml" line="3349"/>
+        <location filename="../app/Main.qml" line="3442"/>
+        <location filename="../app/Main.qml" line="3449"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3456"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3556"/>
-        <location filename="../app/Main.qml" line="3574"/>
-        <source>Saving launcher</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3560"/>
-        <location filename="../app/Main.qml" line="3577"/>
+        <location filename="../app/Main.qml" line="3672"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2983"/>
-        <location filename="../app/Main.qml" line="3590"/>
+        <location filename="../app/Main.qml" line="3083"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2751"/>
-        <location filename="../app/Main.qml" line="3182"/>
-        <location filename="../app/Main.qml" line="3590"/>
-        <location filename="../app/Main.qml" line="3920"/>
+        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3718"/>
+        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="4119"/>
         <source>Retry</source>
         <translation type="unfinished">重试</translation>
     </message>
@@ -1127,37 +1134,37 @@ Français - Wilfried</source>
         <translation type="obsolete">取消</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4603"/>
+        <location filename="../app/Main.qml" line="4812"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4605"/>
+        <location filename="../app/Main.qml" line="4814"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4607"/>
+        <location filename="../app/Main.qml" line="4816"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4610"/>
+        <location filename="../app/Main.qml" line="4819"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4612"/>
+        <location filename="../app/Main.qml" line="4821"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4614"/>
+        <location filename="../app/Main.qml" line="4823"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4616"/>
+        <location filename="../app/Main.qml" line="4825"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>
@@ -1211,7 +1218,7 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
         <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1352"/>
+        <location filename="../app/MainLayout.qml" line="1356"/>
         <source>OK</source>
         <translation type="unfinished">确定</translation>
     </message>
@@ -1236,76 +1243,76 @@ Français - Wilfried</source>
         <translation>确定要退出吗？</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1271"/>
-        <location filename="../app/MainLayout.qml" line="1359"/>
-        <location filename="../app/MainLayout.qml" line="1439"/>
-        <location filename="../app/MainLayout.qml" line="1476"/>
-        <location filename="../app/MainLayout.qml" line="1525"/>
-        <location filename="../app/MainLayout.qml" line="1581"/>
-        <location filename="../app/MainLayout.qml" line="1600"/>
-        <location filename="../app/MainLayout.qml" line="1673"/>
+        <location filename="../app/MainLayout.qml" line="1275"/>
+        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1443"/>
+        <location filename="../app/MainLayout.qml" line="1480"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1585"/>
+        <location filename="../app/MainLayout.qml" line="1604"/>
+        <location filename="../app/MainLayout.qml" line="1677"/>
         <source>Move</source>
         <translation>移动</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
+        <location filename="../app/MainLayout.qml" line="1279"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
         <source>Select</source>
         <translation>选择</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1293"/>
-        <location filename="../app/MainLayout.qml" line="1308"/>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1345"/>
+        <location filename="../app/MainLayout.qml" line="1283"/>
+        <location filename="../app/MainLayout.qml" line="1297"/>
+        <location filename="../app/MainLayout.qml" line="1312"/>
+        <location filename="../app/MainLayout.qml" line="1323"/>
+        <location filename="../app/MainLayout.qml" line="1349"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1286"/>
-        <location filename="../app/MainLayout.qml" line="1326"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1290"/>
+        <location filename="../app/MainLayout.qml" line="1330"/>
+        <location filename="../app/MainLayout.qml" line="1371"/>
+        <location filename="../app/MainLayout.qml" line="1414"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1304"/>
+        <location filename="../app/MainLayout.qml" line="1308"/>
         <source>Done</source>
         <translation>完成</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1315"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1494"/>
-        <location filename="../app/MainLayout.qml" line="1552"/>
-        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1319"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1498"/>
+        <location filename="../app/MainLayout.qml" line="1556"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
         <source>Retry</source>
         <translation>重试</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1334"/>
+        <location filename="../app/MainLayout.qml" line="1338"/>
         <source>I understand</source>
         <translation>我明白了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1402"/>
+        <location filename="../app/MainLayout.qml" line="1406"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1410"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1314,11 +1321,11 @@ Français - Wilfried</source>
         <translation type="vanished">开始</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1481"/>
-        <location filename="../app/MainLayout.qml" line="1530"/>
-        <location filename="../app/MainLayout.qml" line="1586"/>
-        <location filename="../app/MainLayout.qml" line="1678"/>
+        <location filename="../app/MainLayout.qml" line="1447"/>
+        <location filename="../app/MainLayout.qml" line="1485"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1590"/>
+        <location filename="../app/MainLayout.qml" line="1682"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
@@ -1327,28 +1334,28 @@ Français - Wilfried</source>
         <translation type="vanished">退出</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1462"/>
-        <location filename="../app/MainLayout.qml" line="1487"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1514"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1574"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1624"/>
-        <location filename="../app/MainLayout.qml" line="1645"/>
-        <location filename="../app/MainLayout.qml" line="1654"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1466"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1502"/>
+        <location filename="../app/MainLayout.qml" line="1518"/>
+        <location filename="../app/MainLayout.qml" line="1548"/>
+        <location filename="../app/MainLayout.qml" line="1566"/>
+        <location filename="../app/MainLayout.qml" line="1578"/>
+        <location filename="../app/MainLayout.qml" line="1594"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1649"/>
+        <location filename="../app/MainLayout.qml" line="1658"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1717"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1558"/>
-        <location filename="../app/MainLayout.qml" line="1690"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
+        <location filename="../app/MainLayout.qml" line="1544"/>
+        <location filename="../app/MainLayout.qml" line="1562"/>
+        <location filename="../app/MainLayout.qml" line="1694"/>
+        <location filename="../app/MainLayout.qml" line="1713"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1357,25 +1364,25 @@ Français - Wilfried</source>
         <translation type="vanished">页面</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1449"/>
-        <location filename="../app/MainLayout.qml" line="1484"/>
-        <location filename="../app/MainLayout.qml" line="1535"/>
-        <location filename="../app/MainLayout.qml" line="1683"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
+        <location filename="../app/MainLayout.qml" line="1488"/>
+        <location filename="../app/MainLayout.qml" line="1539"/>
+        <location filename="../app/MainLayout.qml" line="1687"/>
         <source>Options</source>
         <translation>选项</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1613"/>
         <source>Change</source>
         <translation>更改</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1619"/>
         <source>Toggle</source>
         <translation>切换</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1641"/>
+        <location filename="../app/MainLayout.qml" line="1645"/>
         <source>Scroll</source>
         <translation>滚动</translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -673,86 +673,86 @@ Français - Wilfried</source>
         <translation type="vanished">启动核心</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
-        <location filename="../app/Main.qml" line="2319"/>
-        <location filename="../app/Main.qml" line="2654"/>
-        <location filename="../app/Main.qml" line="2663"/>
-        <location filename="../app/Main.qml" line="3705"/>
-        <location filename="../app/Main.qml" line="3748"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2330"/>
+        <location filename="../app/Main.qml" line="2393"/>
+        <location filename="../app/Main.qml" line="2699"/>
+        <location filename="../app/Main.qml" line="3741"/>
+        <location filename="../app/Main.qml" line="3784"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2172"/>
-        <location filename="../app/Main.qml" line="2207"/>
+        <location filename="../app/Main.qml" line="2183"/>
+        <location filename="../app/Main.qml" line="2218"/>
         <source>Update media database</source>
         <translation type="unfinished">更新媒体数据库</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2175"/>
-        <location filename="../app/Main.qml" line="2210"/>
+        <location filename="../app/Main.qml" line="2186"/>
+        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
         <translation type="unfinished">抓取元数据</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
+        <location filename="../app/Main.qml" line="2177"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1056"/>
+        <location filename="../app/Main.qml" line="1063"/>
         <source>Settings</source>
         <translation type="unfinished">设置</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2089"/>
+        <location filename="../app/Main.qml" line="2096"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2142"/>
+        <location filename="../app/Main.qml" line="2153"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2166"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2243"/>
-        <location filename="../app/Main.qml" line="2297"/>
+        <location filename="../app/Main.qml" line="2254"/>
+        <location filename="../app/Main.qml" line="2308"/>
         <source>Launch game</source>
         <translation>启动游戏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2247"/>
-        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2258"/>
+        <location filename="../app/Main.qml" line="2312"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2267"/>
-        <location filename="../app/Main.qml" line="2335"/>
-        <location filename="../app/Main.qml" line="2411"/>
+        <location filename="../app/Main.qml" line="2278"/>
+        <location filename="../app/Main.qml" line="2346"/>
+        <location filename="../app/Main.qml" line="2434"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Remove from favorites</source>
         <translation>从收藏中移除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2305"/>
+        <location filename="../app/Main.qml" line="2316"/>
         <source>Add to favorites</source>
         <translation>添加到收藏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2253"/>
-        <location filename="../app/Main.qml" line="2324"/>
+        <location filename="../app/Main.qml" line="2264"/>
+        <location filename="../app/Main.qml" line="2335"/>
         <source>Write to NFC token</source>
         <translation>写入 NFC 令牌</translation>
     </message>
@@ -761,371 +761,371 @@ Français - Wilfried</source>
         <translation type="vanished">二维码</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Default</source>
         <translation type="unfinished">默认</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2367"/>
+        <location filename="../app/Main.qml" line="2378"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2151"/>
-        <location filename="../app/Main.qml" line="2202"/>
-        <location filename="../app/Main.qml" line="2219"/>
-        <location filename="../app/Main.qml" line="2227"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3364"/>
+        <location filename="../app/Main.qml" line="2162"/>
+        <location filename="../app/Main.qml" line="2213"/>
+        <location filename="../app/Main.qml" line="2230"/>
+        <location filename="../app/Main.qml" line="2238"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3400"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3396"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3432"/>
         <source>Favorites</source>
         <translation type="unfinished">收藏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1063"/>
-        <location filename="../app/Main.qml" line="3381"/>
-        <location filename="../app/Main.qml" line="3428"/>
-        <location filename="../app/Main.qml" line="3438"/>
+        <location filename="../app/Main.qml" line="1070"/>
+        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3464"/>
+        <location filename="../app/Main.qml" line="3474"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3409"/>
+        <location filename="../app/Main.qml" line="3445"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
+        <location filename="../app/Main.qml" line="3406"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3460"/>
-        <location filename="../app/Main.qml" line="3475"/>
+        <location filename="../app/Main.qml" line="3496"/>
+        <location filename="../app/Main.qml" line="3511"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3370"/>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3428"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3479"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="3436"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1028"/>
+        <location filename="../app/Main.qml" line="1035"/>
         <source>Add item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1048"/>
+        <location filename="../app/Main.qml" line="1055"/>
         <source>Add item…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1052"/>
+        <location filename="../app/Main.qml" line="1059"/>
         <source>Reset layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1060"/>
+        <location filename="../app/Main.qml" line="1067"/>
         <source>Quit</source>
         <translation type="unfinished">退出</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2271"/>
-        <location filename="../app/Main.qml" line="2290"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2173"/>
+        <location filename="../app/Main.qml" line="2282"/>
+        <location filename="../app/Main.qml" line="2301"/>
+        <location filename="../app/Main.qml" line="2350"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2257"/>
-        <location filename="../app/Main.qml" line="2328"/>
+        <location filename="../app/Main.qml" line="2268"/>
+        <location filename="../app/Main.qml" line="2339"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2457"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2438"/>
+        <location filename="../app/Main.qml" line="2461"/>
         <source>Move</source>
         <translation type="unfinished">移动</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2638"/>
+        <location filename="../app/Main.qml" line="2667"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
+        <location filename="../app/Main.qml" line="2887"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
-        <location filename="../app/Main.qml" line="3007"/>
-        <location filename="../app/Main.qml" line="3029"/>
-        <location filename="../app/Main.qml" line="3053"/>
-        <location filename="../app/Main.qml" line="3095"/>
+        <location filename="../app/Main.qml" line="1032"/>
+        <location filename="../app/Main.qml" line="3043"/>
+        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3131"/>
         <source>OK</source>
         <translation type="unfinished">确定</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>Nothing left to add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="1025"/>
+        <location filename="../app/Main.qml" line="1032"/>
         <source>All categories and actions are already on the Hub. To add a game or system, open its Options menu and choose &quot;Add to Hub&quot;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2121"/>
-        <location filename="../app/Main.qml" line="2157"/>
+        <location filename="../app/Main.qml" line="2132"/>
+        <location filename="../app/Main.qml" line="2168"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3053"/>
+        <location filename="../app/Main.qml" line="3089"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3062"/>
+        <location filename="../app/Main.qml" line="3098"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3063"/>
+        <location filename="../app/Main.qml" line="3099"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3065"/>
+        <location filename="../app/Main.qml" line="3101"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3066"/>
+        <location filename="../app/Main.qml" line="3102"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3068"/>
+        <location filename="../app/Main.qml" line="3104"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3069"/>
+        <location filename="../app/Main.qml" line="3105"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3071"/>
+        <location filename="../app/Main.qml" line="3107"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3072"/>
+        <location filename="../app/Main.qml" line="3108"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3074"/>
+        <location filename="../app/Main.qml" line="3110"/>
         <source>Metadata scrape failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3075"/>
+        <location filename="../app/Main.qml" line="3111"/>
         <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3077"/>
+        <location filename="../app/Main.qml" line="3113"/>
         <source>Scraper list unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3078"/>
+        <location filename="../app/Main.qml" line="3114"/>
         <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3080"/>
+        <location filename="../app/Main.qml" line="3116"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3081"/>
+        <location filename="../app/Main.qml" line="3117"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3084"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3120"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3122"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3087"/>
+        <location filename="../app/Main.qml" line="3123"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="3125"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3090"/>
+        <location filename="../app/Main.qml" line="3126"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3092"/>
+        <location filename="../app/Main.qml" line="3128"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3093"/>
+        <location filename="../app/Main.qml" line="3129"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3217"/>
+        <location filename="../app/Main.qml" line="3253"/>
         <source>Scraper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3233"/>
+        <location filename="../app/Main.qml" line="3269"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3242"/>
+        <location filename="../app/Main.qml" line="3278"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3271"/>
+        <location filename="../app/Main.qml" line="3307"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3282"/>
+        <location filename="../app/Main.qml" line="3318"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3356"/>
+        <location filename="../app/Main.qml" line="3392"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3379"/>
-        <location filename="../app/Main.qml" line="3425"/>
+        <location filename="../app/Main.qml" line="3415"/>
+        <location filename="../app/Main.qml" line="3461"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3413"/>
-        <location filename="../app/Main.qml" line="3435"/>
+        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3471"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3417"/>
+        <location filename="../app/Main.qml" line="3453"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3489"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3442"/>
-        <location filename="../app/Main.qml" line="3449"/>
+        <location filename="../app/Main.qml" line="3478"/>
+        <location filename="../app/Main.qml" line="3485"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3456"/>
+        <location filename="../app/Main.qml" line="3492"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3672"/>
+        <location filename="../app/Main.qml" line="3708"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3083"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
+        <location filename="../app/Main.qml" line="3119"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2851"/>
-        <location filename="../app/Main.qml" line="3282"/>
-        <location filename="../app/Main.qml" line="3718"/>
-        <location filename="../app/Main.qml" line="3763"/>
-        <location filename="../app/Main.qml" line="4119"/>
+        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3754"/>
+        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="4155"/>
         <source>Retry</source>
         <translation type="unfinished">重试</translation>
     </message>
@@ -1134,37 +1134,37 @@ Français - Wilfried</source>
         <translation type="obsolete">取消</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4812"/>
+        <location filename="../app/Main.qml" line="4848"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4814"/>
+        <location filename="../app/Main.qml" line="4850"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4816"/>
+        <location filename="../app/Main.qml" line="4852"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4819"/>
+        <location filename="../app/Main.qml" line="4855"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4821"/>
+        <location filename="../app/Main.qml" line="4857"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4823"/>
+        <location filename="../app/Main.qml" line="4859"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4825"/>
+        <location filename="../app/Main.qml" line="4861"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>
@@ -1244,19 +1244,19 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1363"/>
-        <location filename="../app/MainLayout.qml" line="1443"/>
-        <location filename="../app/MainLayout.qml" line="1480"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1585"/>
-        <location filename="../app/MainLayout.qml" line="1604"/>
-        <location filename="../app/MainLayout.qml" line="1677"/>
+        <location filename="../app/MainLayout.qml" line="1374"/>
+        <location filename="../app/MainLayout.qml" line="1454"/>
+        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1540"/>
+        <location filename="../app/MainLayout.qml" line="1596"/>
+        <location filename="../app/MainLayout.qml" line="1615"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Move</source>
         <translation>移动</translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1378"/>
         <source>Select</source>
         <translation>选择</translation>
     </message>
@@ -1272,8 +1272,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../app/MainLayout.qml" line="1290"/>
         <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1371"/>
-        <location filename="../app/MainLayout.qml" line="1414"/>
+        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
@@ -1284,10 +1284,10 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1498"/>
-        <location filename="../app/MainLayout.qml" line="1556"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1567"/>
+        <location filename="../app/MainLayout.qml" line="1716"/>
         <source>Retry</source>
         <translation>重试</translation>
     </message>
@@ -1297,22 +1297,27 @@ Français - Wilfried</source>
         <translation>我明白了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1367"/>
+        <source>Saving…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/MainLayout.qml" line="1389"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1382"/>
+        <location filename="../app/MainLayout.qml" line="1393"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1406"/>
+        <location filename="../app/MainLayout.qml" line="1417"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1410"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1321,11 +1326,11 @@ Français - Wilfried</source>
         <translation type="vanished">开始</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1447"/>
-        <location filename="../app/MainLayout.qml" line="1485"/>
-        <location filename="../app/MainLayout.qml" line="1534"/>
-        <location filename="../app/MainLayout.qml" line="1590"/>
-        <location filename="../app/MainLayout.qml" line="1682"/>
+        <location filename="../app/MainLayout.qml" line="1458"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1601"/>
+        <location filename="../app/MainLayout.qml" line="1693"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
@@ -1334,28 +1339,28 @@ Français - Wilfried</source>
         <translation type="vanished">退出</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1466"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
+        <location filename="../app/MainLayout.qml" line="1477"/>
         <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1518"/>
-        <location filename="../app/MainLayout.qml" line="1548"/>
-        <location filename="../app/MainLayout.qml" line="1566"/>
-        <location filename="../app/MainLayout.qml" line="1578"/>
-        <location filename="../app/MainLayout.qml" line="1594"/>
-        <location filename="../app/MainLayout.qml" line="1628"/>
-        <location filename="../app/MainLayout.qml" line="1649"/>
-        <location filename="../app/MainLayout.qml" line="1658"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
-        <location filename="../app/MainLayout.qml" line="1717"/>
+        <location filename="../app/MainLayout.qml" line="1513"/>
+        <location filename="../app/MainLayout.qml" line="1529"/>
+        <location filename="../app/MainLayout.qml" line="1559"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1589"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1639"/>
+        <location filename="../app/MainLayout.qml" line="1660"/>
+        <location filename="../app/MainLayout.qml" line="1669"/>
+        <location filename="../app/MainLayout.qml" line="1709"/>
+        <location filename="../app/MainLayout.qml" line="1728"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1457"/>
-        <location filename="../app/MainLayout.qml" line="1544"/>
-        <location filename="../app/MainLayout.qml" line="1562"/>
-        <location filename="../app/MainLayout.qml" line="1694"/>
-        <location filename="../app/MainLayout.qml" line="1713"/>
+        <location filename="../app/MainLayout.qml" line="1468"/>
+        <location filename="../app/MainLayout.qml" line="1555"/>
+        <location filename="../app/MainLayout.qml" line="1573"/>
+        <location filename="../app/MainLayout.qml" line="1705"/>
+        <location filename="../app/MainLayout.qml" line="1724"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1364,25 +1369,25 @@ Français - Wilfried</source>
         <translation type="vanished">页面</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1453"/>
-        <location filename="../app/MainLayout.qml" line="1488"/>
-        <location filename="../app/MainLayout.qml" line="1539"/>
-        <location filename="../app/MainLayout.qml" line="1687"/>
+        <location filename="../app/MainLayout.qml" line="1464"/>
+        <location filename="../app/MainLayout.qml" line="1499"/>
+        <location filename="../app/MainLayout.qml" line="1550"/>
+        <location filename="../app/MainLayout.qml" line="1698"/>
         <source>Options</source>
         <translation>选项</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1613"/>
+        <location filename="../app/MainLayout.qml" line="1624"/>
         <source>Change</source>
         <translation>更改</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1619"/>
+        <location filename="../app/MainLayout.qml" line="1630"/>
         <source>Toggle</source>
         <translation>切换</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1645"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Scroll</source>
         <translation>滚动</translation>
     </message>

--- a/tests/ui/tst_list_picker_modal.qml
+++ b/tests/ui/tst_list_picker_modal.qml
@@ -70,6 +70,7 @@ TestCase {
         picker.entries = [];
         picker.initialId = "";
         picker.currentIndex = 0;
+        picker.locked = false;
         acceptedSpy.clear();
         closeSpy.clear();
     }
@@ -204,6 +205,23 @@ TestCase {
         picker.handleAction("page_menu");
         compare(closeSpy.count, 0);
         compare(picker.open, true);
+    }
+
+    // `locked` disables each row's own MouseArea (hover-to-focus and
+    // click-to-accept both live on it) -- the keyboard/gamepad path is a
+    // separate concern owned by the consumer not forwarding handleAction()
+    // at all while locked (Main.qml's modalListPicker routing branch), not
+    // by this component.
+    function test_locked_disables_row_mouse_area(): void {
+        picker.entries = _entries(3);
+        picker.open = true;
+        const row = findChild(picker, "listPickerRow-1");
+        const mouseArea = findChild(row, "listPickerRowMouseArea");
+        compare(mouseArea.enabled, true);
+        picker.locked = true;
+        compare(mouseArea.enabled, false);
+        picker.locked = false;
+        compare(mouseArea.enabled, true);
     }
 
     function test_reopen_recomputes_initial_index(): void {


### PR DESCRIPTION
## Summary

Closes #390. Adds a per-game launcher override, closing the gap between Core's existing `media.meta`/`media.meta.update` support and the frontend's system-scoped-only launcher UI.

- New `Browse.GameLauncherOverride` singleton: one-row cache-checked `media.meta` fetch on context-menu open, `media.meta.update` to set/clear.
- Games' "Change launcher" context-menu entry shows the current non-default launcher inline; Systems' entry gets the same treatment for free from already-loaded `SystemDefault`s. No grid/tile/system-list indicator (would need a batch fetch across a whole page — deliberately out of scope).
- Saving state keeps the full picker list visible and relabels only the picked row to "Saving…" (delayed 300ms, matching `MainLayout.loadingIndicatorDelayMs`/`ScreenStateOverlay.loadingDelayMs`) instead of collapsing to one row; input (focus/cancel/resubmit, both mouse and keyboard) is locked while a save is pending.
- Mock Core gained a `media.meta.update` handler so this is testable via `just mock-core` + `just run-dev`.

Also fixes an unrelated bug found along the way: **HubScreen tiles could get stuck permanently pressed.** `GamesScreen`/`MediaListScreen` already release their push-in press cue after a launch that doesn't navigate away (e.g. a failed launch, or a launcher that stays on the page); `HubScreen` never had the equivalent release for its two "stays put" accept kinds (a raw ZapScript shortcut, or a launch-only virtual system) — so a failed launch (e.g. Core disconnected) left the tile stuck pressed with nothing to ever release it.

## Test plan

- [x] `just build` — clean, both crates + all changed QML AOT-compile without warnings
- [x] `just test` — 783/783 (full QML QuickTest suite + `cargo nextest run --workspace`, including a new `test_locked_disables_row_mouse_area` regression test)
- [x] `just lint` — clean (fmt, clippy, cargo-deny, clang-format, clang-tidy, qmllint, translations, baked-icons)
- [x] Manual: `just mock-core` + `just run-dev` — set/clear a per-game override, verified the context-menu label updates immediately and persists across reopening

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-game launcher selection and overrides.
  * Added a “Change launcher” option to game context menus when multiple launchers are available.
  * Added support for clearing overrides and displaying the current launcher.

* **Bug Fixes**
  * Prevented launcher changes during saving to avoid conflicting selections.
  * Improved saving feedback while retaining the full launcher list.
  * Fixed Hub tile animations after launching certain shortcuts.

* **Tests**
  * Added coverage for launcher overrides, validation, clearing, and picker locking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->