### PR TITLE
feat(library): rename metadata action and teach the empty states

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -114,4 +114,4 @@ The CLA Assistant Lite bot will record your signature in
 `.github/contributors/signatures.json`. You only need to sign once;
 future pull requests will be recognized automatically.
 
-Questions? Email [legal@zaparoo.org](mailto:legal@zaparoo.org).
+Questions? Email [legal@zaparoo.com](mailto:legal@zaparoo.com).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,4 +104,4 @@ first.
 
 - Architecture or design questions: open a GitHub Discussion or issue so the
   answer is searchable later.
-- CLA or licensing: [legal@zaparoo.org](mailto:legal@zaparoo.org).
+- CLA or licensing: [legal@zaparoo.com](mailto:legal@zaparoo.com).

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ for the details.
 Copyright 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 Source available under the [PolyForm Noncommercial License 1.0.0](COPYING).
 Non-commercial use only. For commercial licensing, contact
-[legal@zaparoo.org](mailto:legal@zaparoo.org).
+[legal@zaparoo.com](mailto:legal@zaparoo.com).
 
 Third-party components:
 
 - **Qt framework**: LGPLv3. Dynamically linked on desktop builds; statically
   linked on MiSTer ARM32. Object files for re-linking against a modified Qt
   are available on request at
-  [legal@zaparoo.org](mailto:legal@zaparoo.org).
+  [legal@zaparoo.com](mailto:legal@zaparoo.com).
   See [`src/LICENSES/Qt-LGPL-NOTICE.txt`](src/LICENSES/Qt-LGPL-NOTICE.txt)
   and [`src/LICENSES/LGPLv3.txt`](src/LICENSES/LGPLv3.txt).
 - **zaparoo-update**: optional third-party update integration, separately owned

--- a/docs/content-style.md
+++ b/docs/content-style.md
@@ -35,14 +35,17 @@ to "list commands in frequency-of-use order." On a six-button controller
 press, so getting the top of the list right matters more here than on a
 mouse-driven desktop menu.
 
-## Menu size cap
+## Menu size
 
-**3–8 entries per `ContextMenu`.** GNOME's HIG allows 3–12, but
-`ContextMenu.qml` has no scroll or clip safety margin built for that many
-rows on a 240p panel (see `docs/style.md` → "ContextMenu chrome" for the
-enforced backstop). A menu that would grow past 8 needs consolidation —
-fold two related actions into one, or move a rarely-used one into
-Settings — not a scrollbar.
+There is no fixed entry cap. `ContextMenu` navigation wraps, so the last
+entry is one press up from the first, and `rowViewport` scrolls to keep the
+selection reachable when the panel can't fit every row. Ordering matters more
+than length: put the primary action first so the common case stays a single
+press.
+
+Judge a menu by whether it still fits without scrolling at 240p, not by a
+row count. Scrolling hides entries, and a hidden entry is an undiscoverable
+one.
 
 ## Capitalization
 
@@ -134,7 +137,8 @@ lengthening a menu row further.
 1. Where does it fall in the ordering rule above — primary, frequent,
    organizational, or maintenance?
 2. Which glossary term applies? Don't introduce a new synonym.
-3. Does adding it push the menu past 8 entries? If so, consolidate first.
+3. Does the menu still fit without scrolling at 240p? If not, consider
+   consolidating rather than relying on the scroll.
 4. Is it wrapped in `qsTr()`? (Three menu strings shipped without it in
    the past — see `docs/translations.md`.)
 5. Sentence case, no trailing period, ellipsis only if it needs more

--- a/docs/style.md
+++ b/docs/style.md
@@ -1056,13 +1056,13 @@ Panel uses `bgPanel` + `radiusMd`, no border. Rows are inverse-video —
 surface — see "Two registers" and "Inverse-video rows" above. Panel vertical
 padding is independent from radius.
 
-**3-8 entries maximum** (see `docs/content-style.md`'s menu-ordering and
-menu-size rules for the content-side reasoning). The `Column` painting rows
-has no scroll of its own; `panelHeight` clamps to the window's usable area
-and the panel carries `clip: true` as a shipped-build safety net, but a
-menu that reaches the cap should be consolidated, not left to rely on that
-clip. `ContextMenu.qml` also logs a `console.warn` in development when
-`entries.length` exceeds the cap.
+**No fixed entry cap** (see `docs/content-style.md`'s menu-ordering and
+menu-size rules for the content-side reasoning). `rowViewport` scrolls to keep
+the focused row in view once `_fullContentHeight` exceeds `panelHeight`, and
+`move()` wraps, so the last entry is one press up from the first. `panelHeight`
+clamps to the window's usable area and the panel carries `clip: true` as a
+shipped-build safety net. Judge a menu by whether it still fits without
+scrolling at 240p: a scrolled-past entry is an undiscoverable one.
 
 Row labels center the `Text` item itself (`Sizing.center(parent.width,
 _textWidth)`), per the integer-pixel rule below — never

--- a/rust/mock-core/src/fixtures.rs
+++ b/rust/mock-core/src/fixtures.rs
@@ -63,6 +63,23 @@ pub fn launchers_response() -> Value {
     })
 }
 
+/// Mirrors Core's `scrapers` result (`ScrapersResult` / `ScraperInfo`).
+/// Without this the Source picker in the Get metadata modal is always
+/// empty against mock-core and `refresh_scrapers` errors into the
+/// "Source list unavailable" modal, so the whole metadata flow is
+/// untestable off-device.
+///
+/// `supportedSystems` is left empty, which Core uses to mean "no
+/// restriction" -- the frontend only reads `id` and `name` today.
+pub fn scrapers_response() -> Value {
+    json!({
+        "scrapers": [
+            { "id": "gamelist.xml", "name": "gamelist.xml", "supportedSystems": [] },
+            { "id": "screenscraper", "name": "ScreenScraper", "supportedSystems": [] }
+        ]
+    })
+}
+
 pub fn settings_response() -> Value {
     let defaults = system_defaults()
         .lock()

--- a/rust/mock-core/src/handler.rs
+++ b/rust/mock-core/src/handler.rs
@@ -63,6 +63,7 @@ pub fn dispatch(text: &str, notifier: &Notifier) -> String {
     let outcome: Option<Result<Value, String>> = match req.method.as_str() {
         "systems" => Some(Ok(fixtures::systems_response(&req.params))),
         "launchers" => Some(Ok(fixtures::launchers_response())),
+        "scrapers" => Some(Ok(fixtures::scrapers_response())),
         "settings" => Some(Ok(fixtures::settings_response())),
         "settings.update" => Some(Ok(fixtures::settings_update_response(&req.params))),
         "media.search" => Some(Ok(fixtures::media_search_response(&req.params))),

--- a/rust/zaparoo-core/src/systems_catalog.rs
+++ b/rust/zaparoo-core/src/systems_catalog.rs
@@ -23,8 +23,8 @@ impl CatalogData {
     /// launchables feature, a device with no `media.db` still returns
     /// these, so "is the catalog empty?" no longer answers "are there
     /// indexed games?". This count does: it ignores launchables and only
-    /// tallies real, indexed systems. The first-run scan prompt gates on
-    /// it (see `Main.qml` → `_maybeOpenFirstRunIndex`).
+    /// tallies real, indexed systems. The first-run background index
+    /// gates on it (see `Main.qml` → `_shouldStartFirstRunIndex`).
     pub fn indexed_count(&self) -> usize {
         self.systems
             .iter()

--- a/src/LICENSES/Qt-LGPL-NOTICE.txt
+++ b/src/LICENSES/Qt-LGPL-NOTICE.txt
@@ -30,7 +30,7 @@ In accordance with the LGPLv3:
      practical shared-library story). To re-link this application against
      a modified Qt, the Minimal Corresponding Source — that is, the
      application's compiled object files — is available on request at
-     legal@zaparoo.org, per LGPLv3 §4(d)(1).
+     legal@zaparoo.com, per LGPLv3 §4(d)(1).
 
 2. Release artifact procedure for static Qt builds:
    - Keep the exact Qt version and toolchain tag used for the release.
@@ -39,7 +39,7 @@ In accordance with the LGPLv3:
      to re-link the frontend with a modified Qt build.
    - Ship COPYING, LGPLv3.txt, this notice, and all files under src/LICENSES/
      with release bundles.
-   - Fulfil object-file requests through legal@zaparoo.org for as long as the
+   - Fulfil object-file requests through legal@zaparoo.com for as long as the
      corresponding binary is distributed.
 
 3. The complete source code for Qt is available at:
@@ -71,4 +71,4 @@ obtained from:
 2. Qt download page: https://www.qt.io/download-open-source
 
 Alternatively, you may request a copy of the Qt source code by contacting
-legal@zaparoo.org.
+legal@zaparoo.com.

--- a/src/ui/app/Main.qml
+++ b/src/ui/app/Main.qml
@@ -1954,11 +1954,13 @@ MainLayout {
             if (actionId === "uploadLog")
                 root.openLogUploadModal();
             else if (actionId === "runScraper")
-                root.openScrapeSetupModal();
+                root.openScrapeSetupModal(root._systemScopeAll);
             else if (actionId === "updateMediaDb")
                 root.openIndexSetupModal();
             else if (actionId === "aboutLicense")
                 root._navigateToAbout();
+            else if (actionId === "documentation")
+                root.openDocumentationQrModal();
             else if (actionId === "crtEnable" || actionId === "crtDisable")
                 root.stageCrtToggle(actionId === "crtEnable");
             else if (actionId === "debugLoggingEnable" || actionId === "debugLoggingDisable")
@@ -2183,7 +2185,7 @@ MainLayout {
                     label: qsTr("Update media database")
                 }, {
                     id: "scrape_system",
-                    label: qsTr("Scrape metadata")
+                    label: qsTr("Get metadata")
                 });
             }
             return entries;
@@ -2218,7 +2220,7 @@ MainLayout {
                     label: qsTr("Update media database")
                 }, {
                     id: "scrape_category",
-                    label: qsTr("Scrape metadata")
+                    label: qsTr("Get metadata")
                 });
             }
             return entries;
@@ -2281,6 +2283,15 @@ MainLayout {
                 id: "add_to_hub",
                 label: qsTr("Add to Hub")
             });
+            // Maintenance last, per docs/content-style.md's ordering rule.
+            // A coverless game is the moment a user goes looking for
+            // artwork, and this is the menu they open to look -- see the
+            // scrape_game dispatch for why it scopes to the system.
+            if (!(Browse.MediaStatus.indexing || Browse.MediaStatus.optimizing || Browse.MediaStatus.scraping))
+                entries.push({
+                    id: "scrape_game",
+                    label: qsTr("Get metadata")
+                });
             return entries;
         }
         if (owner === "games" || owner === "favorites") {
@@ -2349,6 +2360,12 @@ MainLayout {
                 id: "add_to_hub",
                 label: qsTr("Add to Hub")
             });
+            // See the "recents" branch above.
+            if (!(Browse.MediaStatus.indexing || Browse.MediaStatus.optimizing || Browse.MediaStatus.scraping))
+                entries.push({
+                    id: "scrape_game",
+                    label: qsTr("Get metadata")
+                });
             return entries;
         }
         return [];
@@ -2724,7 +2741,7 @@ MainLayout {
         } else if (id === "scrape_system") {
             const systemId = Browse.SystemsModel.system_id_at(targetIndex);
             if (systemId !== "")
-                Browse.MediaStatus.start_scrape_for_system(systemId);
+                root.openScrapeSetupModal(systemId);
         } else if (id === "toggle_hide_system") {
             const systemId = Browse.SystemsModel.system_id_at(targetIndex);
             if (systemId !== "") {
@@ -2743,11 +2760,17 @@ MainLayout {
             }
         } else if (id === "scrape_category") {
             const categoryName = Browse.CategoriesModel.category_at(targetIndex);
-            if (categoryName !== "") {
-                const systemIds = Browse.SystemsModel.system_ids_for_category(categoryName);
-                if (systemIds.length > 0)
-                    Browse.MediaStatus.start_scrape_for_systems(systemIds);
-            }
+            if (categoryName !== "")
+                root.openScrapeSetupModal("cat:" + categoryName);
+        } else if (id === "scrape_game") {
+            // Core scrapes by system, not by game (MediaScrapeParams is
+            // `{ scraperId, systems, force }`), so the best we can scope
+            // to today is the game's own system. Routing through the
+            // setup modal means that wider scope is visible in the
+            // Systems row instead of happening silently. Narrows to the
+            // game once Core grows a media/path filter.
+            const gameSystemId = owner === "favorites" ? Browse.FavoritesModel.system_id_at(targetIndex) : (owner === "recents" ? Browse.RecentsModel.system_id_at(targetIndex) : Browse.GamesModel.system_id_at(targetIndex));
+            root.openScrapeSetupModal(gameSystemId !== "" ? gameSystemId : root._systemScopeAll);
         } else if (id === "launch_game") {
             if (owner === "favorites")
                 Browse.FavoritesModel.launch_at(targetIndex);
@@ -2781,7 +2804,7 @@ MainLayout {
             if (text !== "") {
                 Browse.QrCode.generate(root._buildQrPayload(text));
                 if (Browse.QrCode.size > 0)
-                    root.openQrCodeModal();
+                    root.openQrCodeModal(qsTr("Write with App"), qsTr("Scan this code with the Zaparoo App to write this game to a Zaparoo token."), "");
             }
         } else if (id === "discover_unavailable" || id === "discover_loading") {
             return;
@@ -2896,11 +2919,31 @@ MainLayout {
         }
     }
 
-    function openQrCodeModal(): void {
+    // Callers own the payload: generate into the shared Browse.QrCode slot
+    // and check `size > 0` first, then pass the copy that describes what
+    // was generated. `urlText` is the readable fallback for a web
+    // destination — a QR is not scannable at 240p over composite, so
+    // anywhere the code points at a page the URL has to be legible too.
+    function openQrCodeModal(title: string, instruction: string, urlText: string): void {
+        root.qrCodeModalTitle = title;
+        root.qrCodeModalInstruction = instruction;
+        root.qrCodeModalUrlText = urlText;
         root._requestModal(root.modalQrCode);
         root.qrCodeModalVisible = true;
         if (ScreenManager.topModal !== root.modalQrCode)
             ScreenManager.pushModal(root.modalQrCode);
+    }
+
+    // Docs pointer from Settings > About. Deep-links the Frontend guide
+    // rather than the site root, per the "link where it promises to go"
+    // rule; the scrape modal carries its own narrower link to the
+    // artwork page.
+    readonly property string _docsUrl: "https://zaparoo.org/docs/frontend/"
+
+    function openDocumentationQrModal(): void {
+        Browse.QrCode.generate(root._docsUrl);
+        if (Browse.QrCode.size > 0)
+            root.openQrCodeModal(qsTr("Documentation"), qsTr("Scan this code to open the Zaparoo Frontend guide on your phone."), "zaparoo.org/docs/frontend");
     }
 
     function closeQrCodeModal(): void {
@@ -3107,11 +3150,11 @@ MainLayout {
             title = qsTr("Media update failed");
             body = qsTr("Could not start the media database update. Check Zaparoo Core and try again.");
         } else if (kind === "media_scrape") {
-            title = qsTr("Metadata scrape failed");
-            body = qsTr("Could not start metadata scraping. Check Zaparoo Core and try again.");
+            title = qsTr("Get metadata failed");
+            body = qsTr("Could not start getting metadata. Check Zaparoo Core and try again.");
         } else if (kind === "media_scrapers") {
-            title = qsTr("Scraper list unavailable");
-            body = qsTr("Could not load the list of scrapers. Check Zaparoo Core and try again.");
+            title = qsTr("Source list unavailable");
+            body = qsTr("Could not load the list of metadata sources. Check Zaparoo Core and try again.");
         } else if (kind === "media_cancel") {
             title = qsTr("Cancel failed");
             body = qsTr("Could not cancel the media operation. Check Zaparoo Core and try again.");
@@ -3192,13 +3235,24 @@ MainLayout {
             ScreenManager.popModal();
     }
 
-    // Scrape setup modal lifecycle (round 10). Triggered from the
-    // Settings "Scrape metadata" action when idle; the modal fetches the
-    // scraper list on open via `Browse.MediaStatus.refresh_scrapers()`
-    // and owns its own scraper-choice/re-scrape-toggle state until Start.
-    function openScrapeSetupModal(): void {
+    // "Get metadata" setup modal lifecycle. Every entry point routes here
+    // — the Settings > Library row and the system/category/game
+    // context-menu entries — so the chosen source, scope and replace flag
+    // are always the user's rather than hardcoded. `scope` uses the same
+    // "*"/"cat:<Category>"/<system id> sentinel as
+    // `_buildSystemScopeEntries`; a context-menu caller passes the thing
+    // it was invoked on so the modal opens pre-scoped and the Systems row
+    // shows exactly what is about to run. The modal fetches the source
+    // list on open via `Browse.MediaStatus.refresh_scrapers()`.
+    function openScrapeSetupModal(scope: string): void {
         Browse.MediaStatus.refresh_scrapers();
+        // `_requestModal` activates the Loader, and a sourceComponent
+        // Loader instantiates synchronously, so the item exists by the
+        // next line even on the very first open. Seed the scope before
+        // flipping `visible`, since `onOpenChanged` is what reads it.
         root._requestModal(root.modalScrapeSetup);
+        if (root.scrapeSetupModal !== null)
+            root.scrapeSetupModal.initialSystemScope = scope !== "" ? scope : root._systemScopeAll;
         root.scrapeSetupModalVisible = true;
         if (ScreenManager.topModal !== root.modalScrapeSetup)
             ScreenManager.pushModal(root.modalScrapeSetup);
@@ -3250,7 +3304,7 @@ MainLayout {
                 id: ids[i],
                 label: names[i] !== undefined && names[i] !== "" ? names[i] : ids[i]
             });
-        root.openListPickerModal(qsTr("Scraper"), entries, root.scrapeSetupModal.selectedScraperId, "scraperChoice");
+        root.openListPickerModal(qsTr("Source"), entries, root.scrapeSetupModal.selectedScraperId, "scraperChoice");
     }
 
     onRequestScraperPicker: root.openScraperChoicePicker()

--- a/src/ui/app/MainLayout.qml
+++ b/src/ui/app/MainLayout.qml
@@ -391,6 +391,12 @@ ApplicationWindow {
     property string actionErrorButtonLabel: qsTr("OK")
     property bool randomFailedModalVisible: false
     property bool gameInfoModalVisible: false
+    // QR modal wording, set by Main.qml before opening. The shared
+    // Browse.QrCode singleton is a single slot, so the payload and the
+    // copy describing it are always set together at the call site.
+    property string qrCodeModalTitle: ""
+    property string qrCodeModalInstruction: ""
+    property string qrCodeModalUrlText: ""
     property bool logUploadModalVisible: false
     property bool scrapeSetupModalVisible: false
     property bool indexSetupModalVisible: false
@@ -985,6 +991,9 @@ ApplicationWindow {
                     QrCodeModal {
                         anchors.fill: parent
                         open: root.qrCodeModalVisible
+                        title: root.qrCodeModalTitle
+                        instructionText: root.qrCodeModalInstruction
+                        urlText: root.qrCodeModalUrlText
                     }
                 }
             }
@@ -1382,6 +1391,29 @@ ApplicationWindow {
                                 label: qsTr("Cancel")
                             }
                         ];
+                    // Below the list-picker branch above deliberately: both
+                    // setup modals stay mounted while their nested picker
+                    // is open, so the picker's own row has to win first.
+                    // Without this branch the bar fell through to the
+                    // Settings screen underneath and advertised its rows
+                    // while a modal owned input.
+                    if (root.indexSetupModalVisible || root.scrapeSetupModalVisible) {
+                        const setupModal = root.indexSetupModalVisible ? root.indexSetupModal : root.scrapeSetupModal;
+                        return [
+                            {
+                                button: "Dpad",
+                                label: qsTr("Move")
+                            },
+                            {
+                                button: "ButtonA",
+                                label: setupModal !== null ? setupModal.focusedActionLabel : qsTr("Select")
+                            },
+                            {
+                                button: "ButtonB",
+                                label: qsTr("Back")
+                            }
+                        ];
+                    }
                     if (root.crtCalibrationModalVisible)
                         return [
                             {

--- a/src/ui/components/CommercialNoticeModal.qml
+++ b/src/ui/components/CommercialNoticeModal.qml
@@ -113,7 +113,7 @@ Item {
 
             Text {
                 width: parent.width
-                text: qsTr("Contact: legal@zaparoo.org")
+                text: qsTr("Contact: legal@zaparoo.com")
                 font.family: Theme.fontUi
                 font.pixelSize: Sizing.fontBody
                 color: Theme.textLabel

--- a/src/ui/components/ContextMenu.qml
+++ b/src/ui/components/ContextMenu.qml
@@ -70,11 +70,9 @@ Item {
     // True once the entry count needs more room than the anchor position
     // leaves on screen -- the viewport below scrolls to keep
     // `currentIndex` in view rather than silently stranding rows past
-    // `panel`'s clipped edge (docs/content-style.md's 3-8 cap is a
-    // development-time backstop for the menus this app authors itself;
-    // "Discover alt. versions" is a data-driven list -- up to
-    // MAX_ALT_RESULTS in alternate_versions.rs -- that routinely exceeds
-    // it for arcade sets with many known revisions).
+    // `panel`'s clipped edge. Both app-authored menus and data-driven ones
+    // ("Discover alt. versions" lists up to MAX_ALT_RESULTS from
+    // alternate_versions.rs) rely on this.
     readonly property bool _scrollable: _fullContentHeight > panelHeight
     readonly property bool _fitsRight: anchorRect.x + anchorRect.width + gap + panelWidth <= width - margin
     readonly property bool _fitsLeft: anchorRect.x - gap - panelWidth >= margin
@@ -109,13 +107,6 @@ Item {
         }
     }
 
-    // docs/content-style.md's menu-size cap: 3-8 entries, for menus this
-    // app authors itself -- still worth flagging past that even though
-    // `rowViewport` below now scrolls to keep the selection reachable,
-    // since it's a signal the menu should be consolidated rather than
-    // relied on to scroll routinely.
-    readonly property int _maxRecommendedEntries: 8
-
     onEntriesChanged: {
         // Callers can swap `entries` on an already-open menu (the
         // "Discover alt. versions" submenu replaces the main list in
@@ -129,8 +120,6 @@ Item {
         }
         if (menu.currentIndex >= menu.entries.length)
             currentIndex = menu.entries.length - 1;
-        if (menu.entries.length > menu._maxRecommendedEntries)
-            console.warn("ContextMenu: " + menu.entries.length + " entries exceeds the " + menu._maxRecommendedEntries + "-entry cap in docs/content-style.md — consolidate this menu");
     }
 
     // `Math.max(advanceWidth, boundingRect.width)` plus `Sizing.stroke(2)`
@@ -359,19 +348,19 @@ Item {
         height: menu.panelHeight
         color: Theme.bgPanel
         radius: menu.panelRadius
-        // Safety net for a menu that exceeds `_maxRecommendedEntries` in a
-        // shipped build: rows past `panelHeight` are cut off cleanly
-        // instead of painting past the panel's rounded corners. Menus
-        // within the documented 3-8 cap never reach this edge.
+        // Safety net for a menu taller than the space the anchor leaves:
+        // rows past `panelHeight` are cut off cleanly instead of painting
+        // past the panel's rounded corners. A menu that fits never reaches
+        // this edge.
         clip: true
 
         // Non-interactive (key navigation drives contentY, not dragging)
         // scrolling viewport -- see `_scrollCurrentIntoView()` above. Only
         // engages once `_scrollable`; below that `rowColumn.height` fits
         // inside `rowViewport` and contentY stays pinned at 0, so this is
-        // visually identical to the old plain-Column layout for every
-        // menu within the documented 3-8 cap. Mirrors
-        // ListPickerModal.qml's `viewport`/`rowColumn` construction.
+        // visually identical to a plain-Column layout for any menu that
+        // fits. Mirrors ListPickerModal.qml's `viewport`/`rowColumn`
+        // construction.
         Flickable {
             id: rowViewport
 

--- a/src/ui/components/IndexSetupModal.qml
+++ b/src/ui/components/IndexSetupModal.qml
@@ -38,6 +38,12 @@ Item {
     readonly property int _rowSystems: 0
     readonly property int _rowStart: 1
 
+    // Accept-button verb for the help bar, mirroring SettingsScreen's
+    // `focusedActionLabel`. The bar describes the press, not the feature,
+    // so it names what A does to the focused row rather than repeating
+    // the modal's title.
+    readonly property string focusedActionLabel: modal.currentIndex === modal._rowStart ? qsTr("Start") : qsTr("Change")
+
     // Same display convention as ScrapeSetupModal's identical property —
     // see Main.qml's `_buildSystemScopeEntries` for the sentinel scheme.
     readonly property string _selectedSystemScopeName: {

--- a/src/ui/components/ListPickerModal.qml
+++ b/src/ui/components/ListPickerModal.qml
@@ -127,7 +127,23 @@ Item {
     readonly property int _swatchGap: Sizing.pctW(0.6)
     readonly property int _swatchLabelGap: Sizing.pctW(2)
     readonly property int _swatchBandWidth: modal._hasSwatchPreview ? 3 * modal._swatchBoxSize + 2 * modal._swatchGap : 0
-    readonly property int _desiredPanelWidth: Math.max(modal._widestEntryLabelWidth + (modal._hasSwatchPreview ? modal._swatchBandWidth + modal._swatchLabelGap : 0) + 2 * modal._rowHorizontalPadding, modal._titleWidth) + 2 * modal._contentHorizontalMargin
+    // Breathing room between the widest row's text box and the width the row
+    // actually has, deliberately generous rather than a pixel-exact fit.
+    //
+    // `_widestEntryLabelWidth` and the row's own `_textWidth` below apply the
+    // *same* `Sizing.stroke(2)` hinting allowance, so they cancel: without a
+    // term here the widest entry is handed exactly its measured width and not
+    // one pixel more, and `Text` elides it wherever the hinted integer glyph
+    // advances paint wider than `advanceWidth()`'s fractional, unhinted total.
+    // Chasing that difference exactly is a losing game -- it varies by font
+    // build, weight synthesis and hinting, so a panel tuned until one label
+    // fits just truncates the next label someone adds. An em and a half of
+    // slack scales with the text being measured (the error scales with glyph
+    // size, not with the screen) and costs a slightly wider panel, which is
+    // the cheap side of this trade: a picker is a list of names, and a name
+    // that reads in full matters more than a snug panel.
+    readonly property int _labelClearance: Sizing.px(Sizing.fontBody * 1.5)
+    readonly property int _desiredPanelWidth: Math.max(modal._widestEntryLabelWidth + (modal._hasSwatchPreview ? modal._swatchBandWidth + modal._swatchLabelGap : 0) + 2 * modal._rowHorizontalPadding, modal._titleWidth) + 2 * modal._contentHorizontalMargin + modal._labelClearance
     // Degenerate-case floor only, matching Modal.qml's own floor.
     readonly property int _minPanelWidth: Sizing.pctW(30)
 

--- a/src/ui/components/QrCodeModal.qml
+++ b/src/ui/components/QrCodeModal.qml
@@ -7,10 +7,21 @@ import QtQuick
 import Zaparoo.Theme
 import Zaparoo.Ui
 
+// Generic "scan this code" surface. The caller owns the payload (it must
+// call `Browse.QrCode.generate()` and check `size > 0` before opening,
+// since that singleton is a single shared slot) and supplies the wording,
+// so the same chrome serves both writing a token and pointing at the
+// documentation. Defaults reproduce the original token-write copy.
 Item {
     id: root
 
     property bool open: false
+    property string title: qsTr("Write with App")
+    property string instructionText: qsTr("Scan this code with the Zaparoo App to write this game to a Zaparoo token.")
+    // Optional plain-text URL under the matrix. A QR is unscannable at
+    // 240p over composite, so anywhere the destination is a web page the
+    // readable URL is the real affordance and the code is the shortcut.
+    property string urlText: ""
 
     visible: root.open
     z: 300
@@ -20,7 +31,7 @@ Item {
 
         open: root.open
         kind: "shell"
-        title: qsTr("Write with App")
+        title: root.title
         panelMaxWidth: Sizing.pctH(105)
 
         Column {
@@ -40,7 +51,7 @@ Item {
 
                 x: Sizing.center(parent.width, width)
                 width: Math.min(parent.width, Sizing.px(instructionsMetrics.advanceWidth))
-                text: qsTr("Scan this code with the Zaparoo App to write this game to a Zaparoo token.")
+                text: root.instructionText
                 font.family: Theme.fontUi
                 font.pixelSize: Sizing.fontCaption
                 color: Theme.textPrimary
@@ -52,6 +63,18 @@ Item {
             QrMatrix {
                 anchors.horizontalCenter: parent.horizontalCenter
                 maxQrPixels: Math.min(Sizing.pctW(36), Sizing.pctH(48))
+            }
+
+            Text {
+                width: parent.width
+                visible: root.urlText !== ""
+                text: root.urlText
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontSmall
+                color: Theme.textLabel
+                horizontalAlignment: Text.AlignHCenter
+                wrapMode: Text.WrapAnywhere
+                renderType: Text.NativeRendering
             }
         }
     }

--- a/src/ui/components/ScrapeSetupModal.qml
+++ b/src/ui/components/ScrapeSetupModal.qml
@@ -13,21 +13,32 @@ import Zaparoo.Browse as Browse
 // suppress the compiler category file-wide.
 // qmllint disable compiler
 
-// Round 10 — scrape setup modal. Opened from the Settings "Scrape
-// metadata" row when idle (replacing a direct, hardcoded-scraper start).
+// "Get metadata" setup modal. Every entry point routes here — the
+// Settings > Library row, and the system/category/game context-menu
+// entries, which previously bypassed this modal and started a scrape
+// with a hardcoded "gamelist.xml" scraper and `force: false`. Callers
+// pre-scope via `initialSystemScope` before opening, so a game-level
+// entry that currently scrapes the containing system shows that scope
+// in the Systems row rather than quietly doing more than it claims.
+//
 // Scoped down from the Zaparoo TUI's `showScrapeSetup` equivalent
-// (`pkg/ui/tui/generatedb.go`): scraper choice + system scope + re-scrape
+// (`pkg/ui/tui/generatedb.go`): source choice + system scope + replace
 // toggle + Start, dropping the TUI's per-system multi-select widget in
 // favor of the same flat "All systems / All <Category> systems / one
-// system" picker Round 11 gave `IndexSetupModal` — the per-system/
-// per-category `scrape_system`/`scrape_category` context-menu entries
-// still cover a targeted single-system run and stay on the hardcoded
-// "gamelist.xml" scraper untouched by this modal.
+// system" picker `IndexSetupModal` uses.
 //
-// Four keyboard-navigable rows (`currentIndex` 0-3): Scraper (opens a
+// Naming: entry points say "Get metadata" because the mechanism is a
+// property of the chosen source, not of the action. Inside, once a
+// source is picked, the button can be accurate — today every built-in
+// source imports local files, so it reads "Start import". When real
+// network scrapers land the verb becomes conditional on the source,
+// resolved on the frontend as a presentation concern; Core needs no
+// kind field on `ScraperInfo` for that.
+//
+// Four keyboard-navigable rows (`currentIndex` 0-3): Source (opens a
 // nested ListPickerModal via Main.qml — see `requestScraperPicker`),
 // Systems (opens the same nested picker via `requestSystemScopePicker`),
-// Re-scrape existing (inline toggle), Start scrape (action). Chrome comes
+// Replace existing (inline toggle), Start import (action). Chrome comes
 // from the shared `Modal` shell, same as LogUploadModal.
 Item {
     id: modal
@@ -41,6 +52,11 @@ Item {
     // sentinel convention as IndexSetupModal — see Main.qml's
     // `_systemScopeAll`/`_buildSystemScopeEntries`.
     property string selectedSystemScope: "*"
+    // Scope the modal opens with. Main.qml sets this before opening so a
+    // context-menu entry lands pre-scoped to the system or category it
+    // was invoked from; the Settings row leaves it at "*". Read once in
+    // `onOpenChanged` so the user can still widen or narrow it afterwards.
+    property string initialSystemScope: "*"
     property bool rescrapeExisting: false
     property int currentIndex: 0
     property bool _pressed: false
@@ -49,6 +65,12 @@ Item {
     readonly property int _rowSystems: 1
     readonly property int _rowToggle: 2
     readonly property int _rowStart: 3
+
+    // Accept-button verb for the help bar, mirroring SettingsScreen's
+    // `focusedActionLabel`. The bar describes the press, not the feature,
+    // so it names what A does to the focused row rather than repeating
+    // the modal's title.
+    readonly property string focusedActionLabel: modal.currentIndex === modal._rowStart ? qsTr("Start") : (modal.currentIndex === modal._rowToggle ? qsTr("Toggle") : qsTr("Change"))
 
     readonly property string _selectedScraperName: {
         const ids = Browse.MediaStatus.scraper_ids;
@@ -89,7 +111,7 @@ Item {
             return;
         }
         modal.currentIndex = modal._rowScraper;
-        modal.selectedSystemScope = "*";
+        modal.selectedSystemScope = modal.initialSystemScope !== "" ? modal.initialSystemScope : "*";
         modal.rescrapeExisting = false;
         modal._pressed = false;
     }
@@ -168,12 +190,42 @@ Item {
 
         open: modal.open
         kind: "shell"
-        title: qsTr("Scrape metadata")
+        title: qsTr("Get metadata")
         panelMaxWidth: Sizing.pctH(110)
 
         Column {
             width: parent.width
             spacing: Sizing.pctH(1.5)
+
+            // The single most-misunderstood fact about this feature, put
+            // where the user is about to act on it. zaparoo.org's
+            // troubleshooting page has to state it three separate times,
+            // which is what it costs to leave it unsaid here. The URL is
+            // text rather than a QR because this panel already carries
+            // four rows and a QR large enough to scan from a couch would
+            // not fit at 240p; Settings > About carries the scannable
+            // code.
+            Text {
+                width: parent.width
+                text: qsTr("Zaparoo imports artwork and details from files you already have. It does not download them.")
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontCaption
+                color: Theme.textLabel
+                wrapMode: Text.WordWrap
+                horizontalAlignment: Text.AlignHCenter
+                renderType: Text.NativeRendering
+            }
+
+            Text {
+                width: parent.width
+                text: "zaparoo.org/docs/frontend/scraping"
+                font.family: Theme.fontUi
+                font.pixelSize: Sizing.fontCaption
+                color: Theme.textPrimary
+                wrapMode: Text.WrapAnywhere
+                horizontalAlignment: Text.AlignHCenter
+                renderType: Text.NativeRendering
+            }
 
             Item {
                 width: parent.width
@@ -182,7 +234,7 @@ Item {
 
                 LoadingIndicator {
                     anchors.centerIn: parent
-                    text: qsTr("Loading scrapers…")
+                    text: qsTr("Loading sources…")
                 }
             }
 
@@ -193,7 +245,7 @@ Item {
 
                 SettingsField {
                     width: parent.width
-                    label: qsTr("Scraper")
+                    label: qsTr("Source")
                     value: modal._selectedScraperName
                     control: "picker"
                     isFocused: modal.currentIndex === modal._rowScraper
@@ -219,7 +271,7 @@ Item {
 
                 SettingsField {
                     width: parent.width
-                    label: qsTr("Re-scrape existing")
+                    label: qsTr("Replace existing")
                     value: ""
                     control: "toggle"
                     checked: modal.rescrapeExisting
@@ -233,7 +285,7 @@ Item {
 
                 SettingsField {
                     width: parent.width
-                    label: qsTr("Start scrape")
+                    label: qsTr("Start import")
                     value: ""
                     control: "action"
                     isFocused: modal.currentIndex === modal._rowStart

--- a/src/ui/components/ScrapeSetupModal.qml
+++ b/src/ui/components/ScrapeSetupModal.qml
@@ -197,31 +197,19 @@ Item {
             width: parent.width
             spacing: Sizing.pctH(1.5)
 
-            // The single most-misunderstood fact about this feature, put
-            // where the user is about to act on it. zaparoo.org's
-            // troubleshooting page has to state it three separate times,
-            // which is what it costs to leave it unsaid here. The URL is
-            // text rather than a QR because this panel already carries
-            // four rows and a QR large enough to scan from a couch would
-            // not fit at 240p; Settings > About carries the scannable
-            // code.
+            // Labeled pointer rather than a paragraph explaining what the
+            // sources do: the panel already carries four rows, and at 240p
+            // every line above them is a line the Start row can't have. The
+            // label is what makes a bare URL readable as a destination.
+            // Text rather than a QR because a code large enough to scan
+            // from a couch would not fit here; Settings > About carries the
+            // scannable one.
             Text {
                 width: parent.width
-                text: qsTr("Zaparoo imports artwork and details from files you already have. It does not download them.")
+                text: qsTr("Documentation: %1").arg("zaparoo.org/docs/frontend/scraping")
                 font.family: Theme.fontUi
                 font.pixelSize: Sizing.fontCaption
                 color: Theme.textLabel
-                wrapMode: Text.WordWrap
-                horizontalAlignment: Text.AlignHCenter
-                renderType: Text.NativeRendering
-            }
-
-            Text {
-                width: parent.width
-                text: "zaparoo.org/docs/frontend/scraping"
-                font.family: Theme.fontUi
-                font.pixelSize: Sizing.fontCaption
-                color: Theme.textPrimary
                 wrapMode: Text.WrapAnywhere
                 horizontalAlignment: Text.AlignHCenter
                 renderType: Text.NativeRendering

--- a/src/ui/components/ScreenStateOverlay.qml
+++ b/src/ui/components/ScreenStateOverlay.qml
@@ -27,6 +27,12 @@ Item {
     property string errorMessage: ""
     property int count: 0
     property string emptyText: qsTr("Nothing here")
+    // Optional second line for the empty state, mirroring `errorText`'s
+    // role for errors. Carbon's empty-state anatomy is title plus a body
+    // that names the next step; a caller that has nothing useful to add
+    // leaves this empty and the detail line stays hidden, exactly as
+    // before this property existed.
+    property string emptyDetailText: ""
     property string loadingText: qsTr("Loading…")
     property string errorText: qsTr("Check Zaparoo Core and try again.")
     property int loadingDelayMs: 300
@@ -86,14 +92,22 @@ Item {
             font.family: Theme.fontUi
             font.pixelSize: Sizing.fontSection
             color: Theme.textPrimary
+            wrapMode: Text.WordWrap
             horizontalAlignment: Text.AlignHCenter
+            // Shares the detail line's measure below. Without a width this
+            // laid out at natural width, so a long title ran off-screen
+            // rather than wrapping -- the Hub's old single-line empty text
+            // overflowed a 320px 240p frame outright.
+            width: Sizing.px(overlay.width * 0.7)
             renderType: Text.NativeRendering
         }
 
         Text {
+            readonly property string _detail: overlay.viewState === "error" ? overlay.errorText : (overlay.viewState === "empty" ? overlay.emptyDetailText : "")
+
             anchors.horizontalCenter: parent.horizontalCenter
-            visible: overlay.viewState === "error" && overlay.errorText !== ""
-            text: overlay.errorText
+            visible: _detail !== ""
+            text: _detail
             font.family: Theme.fontUi
             font.pixelSize: Sizing.fontCaption
             color: Theme.textPrimary

--- a/src/ui/components/StatusLine.qml
+++ b/src/ui/components/StatusLine.qml
@@ -102,8 +102,8 @@ Item {
             return Browse.MediaStatus.current_step_display !== "" ? qsTr("Optimizing database: %1").arg(Browse.MediaStatus.current_step_display) : qsTr("Optimizing database…");
         // Scraping is the only remaining `_taskActive` branch.
         if (Browse.MediaStatus.scrape_paused)
-            return qsTr("Scraping paused: game running");
-        return Browse.MediaStatus.scrape_current_step_display !== "" ? qsTr("Scraping: %1").arg(Browse.MediaStatus.scrape_current_step_display) : qsTr("Scraping…");
+            return qsTr("Importing paused: game running");
+        return Browse.MediaStatus.scrape_current_step_display !== "" ? qsTr("Importing: %1").arg(Browse.MediaStatus.scrape_current_step_display) : qsTr("Importing…");
     }
     readonly property bool _taskPaused: Browse.MediaStatus.indexing ? Browse.MediaStatus.paused : Browse.MediaStatus.scrape_paused
     // Optimize/vacuum has no step count Core reports -- one cell marches
@@ -156,7 +156,7 @@ Item {
             root._terminalMessage = "";
             terminalMessageTimer.stop();
         } else if (root._scrapeWasBusy && !root._scrapeBusy) {
-            root._terminalMessage = Browse.MediaStatus.scrape_state === "failed" ? qsTr("Scrape failed: %1").arg(Browse.MediaStatus.scrape_error) : qsTr("Scraped %1 of %2").arg(Format.count(Browse.MediaStatus.scrape_matched)).arg(Format.count(Browse.MediaStatus.scrape_total));
+            root._terminalMessage = Browse.MediaStatus.scrape_state === "failed" ? qsTr("Import failed: %1").arg(Browse.MediaStatus.scrape_error) : qsTr("Imported %1 of %2").arg(Format.count(Browse.MediaStatus.scrape_matched)).arg(Format.count(Browse.MediaStatus.scrape_total));
             terminalMessageTimer.restart();
         }
         root._scrapeWasBusy = root._scrapeBusy;

--- a/src/ui/screens/AboutScreen.qml
+++ b/src/ui/screens/AboutScreen.qml
@@ -209,7 +209,7 @@ Item {
                     width: parent.width
                     horizontalAlignment: Text.AlignHCenter
                     wrapMode: Text.Wrap
-                    text: qsTr("Commercial licensing: legal@zaparoo.org")
+                    text: qsTr("Commercial licensing: legal@zaparoo.com")
                     color: Theme.textPrimary
                     font.family: Theme.fontUi
                     font.pixelSize: Sizing.fontBody

--- a/src/ui/screens/HubScreen.qml
+++ b/src/ui/screens/HubScreen.qml
@@ -1595,7 +1595,7 @@ Item {
 
     // CategoriesModel has no `loading` qproperty — the catalog is
     // fetched eagerly via bind_to_endpoint!. The brief cold-launch
-    // window where count===0 surfaces as "No categories" is acceptable
+    // window where count===0 surfaces as the empty state is acceptable
     // per the "Loading is brief" locked decision in MVP_PLAN.md.
     ScreenStateOverlay {
         x: pagedGrid.x + Sizing.center(pagedGrid.width, width)
@@ -1606,6 +1606,13 @@ Item {
         loading: false
         errorMessage: Browse.CategoriesModel.error_message ?? ""
         count: Browse.CategoriesModel.loaded ? Browse.CategoriesModel.count : 1
-        emptyText: qsTr("No systems available. Run Update media database from Settings.")
+        // Indexing is background work that starts on its own, so on a first
+        // run this overlay is the only thing on screen until the first
+        // category lands. Saying "nothing here, go fix it" during a scan
+        // that is already running reads as a failure report. Name the
+        // operation the Settings row uses so the first thing a new user
+        // reads teaches the name of the thing they'll later go looking for.
+        emptyText: Browse.MediaStatus.indexing ? qsTr("Updating the media database") : qsTr("No games found yet")
+        emptyDetailText: Browse.MediaStatus.indexing ? qsTr("Your games appear here as Core finds them.") : qsTr("Update media database in Settings > Library.")
     }
 }

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -488,7 +488,7 @@ Item {
     function _fieldControl(id: string): string {
         if (id === "mouseEnabled" || id === "showHidden" || id === "showOriginalFilenames" || id === "debugLogging" || id === "reduceMotion" || id === "crtEnabled" || id === "swapConfirmCancel" || id === "swapOptionsView")
             return "toggle";
-        if (id === "aboutLicense" || id === "pageAppearance" || id === "pageDisplayInterface" || id === "pageLanguage" || id === "pageControlsInput" || id === "pageLibraryData" || id === "pageSupportAbout" || id === "crtCalibration")
+        if (id === "aboutLicense" || id === "documentation" || id === "pageAppearance" || id === "pageDisplayInterface" || id === "pageLanguage" || id === "pageControlsInput" || id === "pageLibraryData" || id === "pageSupportAbout" || id === "crtCalibration")
             return "navigate";
         if (id === "updateMediaDb" || id === "runScraper" || id === "uploadLog")
             return "action";
@@ -1383,6 +1383,8 @@ Item {
                 settings.requestAccept("uploadLog");
             else if (id === "aboutLicense")
                 settings.requestAccept("aboutLicense");
+            else if (id === "documentation")
+                settings.requestAccept("documentation");
             else if (id === "crtCalibration")
                 settings.requestAccept("crtCalibration");
             else

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -266,8 +266,8 @@ Item {
         {
             kind: "field",
             id: "runScraper",
-            label: qsTr("Scrape metadata"),
-            description: qsTr("Downloads box art, descriptions, and tags for your games. Choose a source and which systems.")
+            label: qsTr("Get metadata"),
+            description: qsTr("Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.")
         },
         {
             kind: "header",
@@ -310,6 +310,12 @@ Item {
             id: "aboutLicense",
             label: qsTr("About / License"),
             description: qsTr("Version, build date, license terms, and the people who made this.")
+        },
+        {
+            kind: "field",
+            id: "documentation",
+            label: qsTr("Documentation"),
+            description: qsTr("Shows a code you can scan to open the Zaparoo Frontend guide on your phone.")
         },
         {
             kind: "field",
@@ -380,7 +386,7 @@ Item {
             return Browse.MediaStatus.scrape_paused ? qsTr("Paused") : qsTr("In progress");
         const total = Browse.MediaStatus.scrape_total_scraped;
         if (total > 0)
-            return qsTr("%1 scraped").arg(Format.count(total));
+            return qsTr("%1 imported").arg(Format.count(total));
         return "";
     }
 
@@ -626,7 +632,7 @@ Item {
         if (!settings._isField(settings.currentIndex))
             return false;
         const id = settings.fields[settings.currentIndex].id;
-        return settings.focusedFieldIsPicker || id === "updateMediaDb" || id === "runScraper" || id === "uploadLog" || id === "aboutLicense" || id === "pageAppearance" || id === "pageDisplayInterface" || id === "pageLanguage" || id === "pageControlsInput" || id === "pageLibraryData" || id === "pageSupportAbout" || id === "crtCalibration";
+        return settings.focusedFieldIsPicker || id === "updateMediaDb" || id === "runScraper" || id === "uploadLog" || id === "aboutLicense" || id === "documentation" || id === "pageAppearance" || id === "pageDisplayInterface" || id === "pageLanguage" || id === "pageControlsInput" || id === "pageLibraryData" || id === "pageSupportAbout" || id === "crtCalibration";
     }
     // Verb shown on the help-bar Accept hint for the focused action row.
     // updateMediaDb flips between Start and Cancel because the press

--- a/src/ui/screens/SettingsScreen.qml
+++ b/src/ui/screens/SettingsScreen.qml
@@ -267,7 +267,7 @@ Item {
             kind: "field",
             id: "runScraper",
             label: qsTr("Get metadata"),
-            description: qsTr("Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.")
+            description: qsTr("Imports artwork and details from files you already have. Zaparoo does not download them.")
         },
         {
             kind: "header",

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -397,45 +397,6 @@ Français - Wilfried</source>
     </message>
 </context>
 <context>
-    <name>FirstRunIndexModal</name>
-    <message>
-        <source>First-time setup</source>
-        <translation type="vanished">إعداد أول مرة</translation>
-    </message>
-    <message>
-        <source>Optimizing database - almost done</source>
-        <translation type="vanished">جارٍ تحسين قاعدة البيانات - أوشك على الانتهاء</translation>
-    </message>
-    <message>
-        <source>Indexing paused</source>
-        <translation type="vanished">تم إيقاف الفهرسة مؤقتًا</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2 - %3</source>
-        <translation type="vanished">الخطوة %1 من %2 - %3</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2</source>
-        <translation type="vanished">الخطوة %1 من %2</translation>
-    </message>
-    <message>
-        <source>Preparing…</source>
-        <translation type="vanished">جارٍ التحضير…</translation>
-    </message>
-    <message>
-        <source>Done. %1 files indexed.</source>
-        <translation type="vanished">تم. تمت فهرسة %1 ملفات.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">إلغاء</translation>
-    </message>
-    <message>
-        <source>Start scan</source>
-        <translation type="vanished">ابدأ الفحص</translation>
-    </message>
-</context>
-<context>
     <name>GameInfoModal</name>
     <message>
         <location filename="../components/GameInfoModal.qml" line="153"/>
@@ -548,6 +509,26 @@ Français - Wilfried</source>
         <translation>المفضلة</translation>
     </message>
     <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>Updating the media database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>No games found yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Your games appear here as Core finds them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Update media database in Settings &gt; Library.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Recently Played</source>
         <translation type="vanished">تم لعبها مؤخرًا</translation>
     </message>
@@ -577,35 +558,44 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
-        <translation>لا توجد أنظمة متاحة. شغّل تحديث قاعدة بيانات الوسائط من الإعدادات.</translation>
+        <translation type="vanished">لا توجد أنظمة متاحة. شغّل تحديث قاعدة بيانات الوسائط من الإعدادات.</translation>
     </message>
 </context>
 <context>
     <name>IndexSetupModal</name>
     <message>
         <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Start</source>
+        <translation type="unfinished">ابدأ</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Change</source>
+        <translation type="unfinished">تغيير</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="51"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="47"/>
+        <location filename="../components/IndexSetupModal.qml" line="53"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="115"/>
+        <location filename="../components/IndexSetupModal.qml" line="121"/>
         <source>Update media database</source>
         <translation type="unfinished">تحديث قاعدة بيانات الوسائط</translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="124"/>
+        <location filename="../components/IndexSetupModal.qml" line="130"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="137"/>
+        <location filename="../components/IndexSetupModal.qml" line="143"/>
         <source>Start update</source>
         <translation type="unfinished"></translation>
     </message>
@@ -683,30 +673,28 @@ Français - Wilfried</source>
         <translation type="vanished">تشغيل النواة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
-        <location filename="../app/Main.qml" line="2330"/>
-        <location filename="../app/Main.qml" line="2393"/>
-        <location filename="../app/Main.qml" line="2699"/>
-        <location filename="../app/Main.qml" line="3741"/>
-        <location filename="../app/Main.qml" line="3784"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
+        <location filename="../app/Main.qml" line="2341"/>
+        <location filename="../app/Main.qml" line="2410"/>
+        <location filename="../app/Main.qml" line="2716"/>
+        <location filename="../app/Main.qml" line="3795"/>
+        <location filename="../app/Main.qml" line="3838"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2183"/>
-        <location filename="../app/Main.qml" line="2218"/>
+        <location filename="../app/Main.qml" line="2185"/>
+        <location filename="../app/Main.qml" line="2220"/>
         <source>Update media database</source>
         <translation type="unfinished">تحديث قاعدة بيانات الوسائط</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2186"/>
-        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
-        <translation type="unfinished">استخراج البيانات الوصفية</translation>
+        <translation type="obsolete">استخراج البيانات الوصفية</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2179"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
@@ -716,53 +704,53 @@ Français - Wilfried</source>
         <translation type="unfinished">الإعدادات</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2096"/>
+        <location filename="../app/Main.qml" line="2098"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2153"/>
+        <location filename="../app/Main.qml" line="2155"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2179"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
-        <location filename="../app/Main.qml" line="2308"/>
+        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2319"/>
         <source>Launch game</source>
         <translation>تشغيل اللعبة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2258"/>
-        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2323"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
-        <location filename="../app/Main.qml" line="2346"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2280"/>
+        <location filename="../app/Main.qml" line="2357"/>
+        <location filename="../app/Main.qml" line="2451"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Remove from favorites</source>
         <translation>إزالة من المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Add to favorites</source>
         <translation>أضف إلى المفضلة</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2264"/>
-        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2266"/>
+        <location filename="../app/Main.qml" line="2346"/>
         <source>Write to NFC token</source>
         <translation>الكتابة إلى رمز NFC</translation>
     </message>
@@ -771,70 +759,95 @@ Français - Wilfried</source>
         <translation type="vanished">رمز QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3507"/>
+        <location filename="../app/Main.qml" line="2395"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3561"/>
         <source>Default</source>
         <translation type="unfinished">افتراضي</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2395"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2230"/>
-        <location filename="../app/Main.qml" line="2238"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="2164"/>
+        <location filename="../app/Main.qml" line="2215"/>
+        <location filename="../app/Main.qml" line="2232"/>
+        <location filename="../app/Main.qml" line="2240"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3454"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3432"/>
+        <location filename="../app/Main.qml" line="3153"/>
+        <source>Get metadata failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3154"/>
+        <source>Could not start getting metadata. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3156"/>
+        <source>Source list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3157"/>
+        <source>Could not load the list of metadata sources. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3307"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3486"/>
         <source>Favorites</source>
         <translation type="unfinished">المفضلة</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1070"/>
-        <location filename="../app/Main.qml" line="3417"/>
-        <location filename="../app/Main.qml" line="3464"/>
-        <location filename="../app/Main.qml" line="3474"/>
+        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3518"/>
+        <location filename="../app/Main.qml" line="3528"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3445"/>
+        <location filename="../app/Main.qml" line="3499"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3460"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3511"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3565"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3482"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3515"/>
+        <location filename="../app/Main.qml" line="3569"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3436"/>
+        <location filename="../app/Main.qml" line="3490"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -859,50 +872,51 @@ Français - Wilfried</source>
         <translation type="unfinished">إنهاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2173"/>
-        <location filename="../app/Main.qml" line="2282"/>
-        <location filename="../app/Main.qml" line="2301"/>
-        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2284"/>
+        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2361"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2268"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2270"/>
+        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2807"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2461"/>
+        <location filename="../app/Main.qml" line="2478"/>
         <source>Move</source>
         <translation type="unfinished">تحريك</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2667"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1032"/>
-        <location filename="../app/Main.qml" line="3043"/>
-        <location filename="../app/Main.qml" line="3065"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3131"/>
+        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3174"/>
         <source>OK</source>
         <translation type="unfinished">حسنًا</translation>
     </message>
@@ -917,225 +931,223 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="2188"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2293"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2807"/>
+        <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Scan this code to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3132"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3098"/>
+        <location filename="../app/Main.qml" line="3141"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3099"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3101"/>
+        <location filename="../app/Main.qml" line="3144"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3147"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3105"/>
+        <location filename="../app/Main.qml" line="3148"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3107"/>
+        <location filename="../app/Main.qml" line="3150"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3151"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3110"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3111"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3113"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3114"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3116"/>
+        <location filename="../app/Main.qml" line="3159"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3120"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3122"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3123"/>
+        <location filename="../app/Main.qml" line="3166"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3125"/>
+        <location filename="../app/Main.qml" line="3168"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3126"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3128"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3129"/>
+        <location filename="../app/Main.qml" line="3172"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3253"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3269"/>
+        <location filename="../app/Main.qml" line="3323"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3278"/>
+        <location filename="../app/Main.qml" line="3332"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3307"/>
+        <location filename="../app/Main.qml" line="3361"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3446"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3415"/>
-        <location filename="../app/Main.qml" line="3461"/>
+        <location filename="../app/Main.qml" line="3469"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3449"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3503"/>
+        <location filename="../app/Main.qml" line="3525"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3489"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3485"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3492"/>
+        <location filename="../app/Main.qml" line="3546"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3708"/>
+        <location filename="../app/Main.qml" line="3762"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3119"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
-        <location filename="../app/Main.qml" line="3318"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="2910"/>
+        <location filename="../app/Main.qml" line="3372"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Retry</source>
         <translation type="unfinished">إعادة المحاولة</translation>
     </message>
@@ -1144,37 +1156,37 @@ Français - Wilfried</source>
         <translation type="obsolete">إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4848"/>
+        <location filename="../app/Main.qml" line="4902"/>
         <source>Loading systems…</source>
         <translation>جارٍ تحميل الأنظمة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4850"/>
+        <location filename="../app/Main.qml" line="4904"/>
         <source>Loading games…</source>
         <translation>جارٍ تحميل الألعاب…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4852"/>
+        <location filename="../app/Main.qml" line="4906"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4855"/>
+        <location filename="../app/Main.qml" line="4909"/>
         <source>Loading favorites…</source>
         <translation>جارٍ تحميل المفضلة…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4857"/>
+        <location filename="../app/Main.qml" line="4911"/>
         <source>Loading recently played…</source>
         <translation>جارٍ تحميل آخر ما تم لعبه…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4859"/>
+        <location filename="../app/Main.qml" line="4913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4861"/>
+        <location filename="../app/Main.qml" line="4915"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>
@@ -1182,7 +1194,7 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Writing failed</source>
         <translation>فشلت الكتابة</translation>
     </message>
@@ -1196,8 +1208,8 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="531"/>
-        <location filename="../app/MainLayout.qml" line="533"/>
+        <location filename="../app/MainLayout.qml" line="537"/>
+        <location filename="../app/MainLayout.qml" line="539"/>
         <source>Favorites</source>
         <translation type="unfinished">المفضلة</translation>
     </message>
@@ -1206,128 +1218,130 @@ Français - Wilfried</source>
         <translation type="obsolete">تم لعبها مؤخرًا</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="916"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="917"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="936"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="943"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="1365"/>
         <source>OK</source>
         <translation type="unfinished">حسنًا</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="535"/>
+        <location filename="../app/MainLayout.qml" line="541"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Hold a writable token near the reader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1096"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
         <source>Are you sure you want to exit?</source>
         <translation>هل أنت متأكد أنك تريد الخروج؟</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1374"/>
-        <location filename="../app/MainLayout.qml" line="1454"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1596"/>
-        <location filename="../app/MainLayout.qml" line="1615"/>
-        <location filename="../app/MainLayout.qml" line="1688"/>
+        <location filename="../app/MainLayout.qml" line="1284"/>
+        <location filename="../app/MainLayout.qml" line="1383"/>
+        <location filename="../app/MainLayout.qml" line="1405"/>
+        <location filename="../app/MainLayout.qml" line="1486"/>
+        <location filename="../app/MainLayout.qml" line="1523"/>
+        <location filename="../app/MainLayout.qml" line="1572"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1647"/>
+        <location filename="../app/MainLayout.qml" line="1720"/>
         <source>Move</source>
         <translation>تحريك</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1387"/>
+        <location filename="../app/MainLayout.qml" line="1409"/>
         <source>Select</source>
         <translation>تحديد</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1283"/>
-        <location filename="../app/MainLayout.qml" line="1297"/>
-        <location filename="../app/MainLayout.qml" line="1312"/>
-        <location filename="../app/MainLayout.qml" line="1323"/>
-        <location filename="../app/MainLayout.qml" line="1349"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1321"/>
+        <location filename="../app/MainLayout.qml" line="1332"/>
+        <location filename="../app/MainLayout.qml" line="1358"/>
         <source>Close</source>
         <translation>إغلاق</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1425"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1339"/>
+        <location filename="../app/MainLayout.qml" line="1391"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1308"/>
+        <location filename="../app/MainLayout.qml" line="1317"/>
         <source>Done</source>
         <translation>تم</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1509"/>
-        <location filename="../app/MainLayout.qml" line="1567"/>
-        <location filename="../app/MainLayout.qml" line="1716"/>
+        <location filename="../app/MainLayout.qml" line="1328"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1541"/>
+        <location filename="../app/MainLayout.qml" line="1599"/>
+        <location filename="../app/MainLayout.qml" line="1748"/>
         <source>Retry</source>
         <translation>إعادة المحاولة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1338"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
         <source>I understand</source>
         <translation>أفهم</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1376"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1389"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1417"/>
+        <location filename="../app/MainLayout.qml" line="1449"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1421"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1336,11 +1350,11 @@ Français - Wilfried</source>
         <translation type="vanished">ابدأ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1496"/>
-        <location filename="../app/MainLayout.qml" line="1545"/>
-        <location filename="../app/MainLayout.qml" line="1601"/>
-        <location filename="../app/MainLayout.qml" line="1693"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1528"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1633"/>
+        <location filename="../app/MainLayout.qml" line="1725"/>
         <source>Open</source>
         <translation>فتح</translation>
     </message>
@@ -1349,28 +1363,29 @@ Français - Wilfried</source>
         <translation type="vanished">إنهاء</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1477"/>
-        <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1513"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1559"/>
-        <location filename="../app/MainLayout.qml" line="1577"/>
-        <location filename="../app/MainLayout.qml" line="1589"/>
-        <location filename="../app/MainLayout.qml" line="1605"/>
-        <location filename="../app/MainLayout.qml" line="1639"/>
-        <location filename="../app/MainLayout.qml" line="1660"/>
-        <location filename="../app/MainLayout.qml" line="1669"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
-        <location filename="../app/MainLayout.qml" line="1728"/>
+        <location filename="../app/MainLayout.qml" line="1413"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1561"/>
+        <location filename="../app/MainLayout.qml" line="1591"/>
+        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1621"/>
+        <location filename="../app/MainLayout.qml" line="1637"/>
+        <location filename="../app/MainLayout.qml" line="1671"/>
+        <location filename="../app/MainLayout.qml" line="1692"/>
+        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1741"/>
+        <location filename="../app/MainLayout.qml" line="1760"/>
         <source>Back</source>
         <translation>رجوع</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1468"/>
-        <location filename="../app/MainLayout.qml" line="1555"/>
-        <location filename="../app/MainLayout.qml" line="1573"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
-        <location filename="../app/MainLayout.qml" line="1724"/>
+        <location filename="../app/MainLayout.qml" line="1500"/>
+        <location filename="../app/MainLayout.qml" line="1587"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1737"/>
+        <location filename="../app/MainLayout.qml" line="1756"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1379,25 +1394,25 @@ Français - Wilfried</source>
         <translation type="vanished">صفحة</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1464"/>
-        <location filename="../app/MainLayout.qml" line="1499"/>
-        <location filename="../app/MainLayout.qml" line="1550"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1531"/>
+        <location filename="../app/MainLayout.qml" line="1582"/>
+        <location filename="../app/MainLayout.qml" line="1730"/>
         <source>Options</source>
         <translation>الخيارات</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1624"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Change</source>
         <translation>تغيير</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1630"/>
+        <location filename="../app/MainLayout.qml" line="1662"/>
         <source>Toggle</source>
         <translation>تبديل</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1656"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Scroll</source>
         <translation>تمرير</translation>
     </message>
@@ -1458,12 +1473,12 @@ Français - Wilfried</source>
 <context>
     <name>QrCodeModal</name>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="23"/>
+        <location filename="../components/QrCodeModal.qml" line="19"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="43"/>
+        <location filename="../components/QrCodeModal.qml" line="20"/>
         <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1493,43 +1508,67 @@ Français - Wilfried</source>
 <context>
     <name>ScrapeSetupModal</name>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="67"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Start</source>
+        <translation type="unfinished">ابدأ</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Toggle</source>
+        <translation type="unfinished">تبديل</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Change</source>
+        <translation type="unfinished">تغيير</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="89"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="69"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="91"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="171"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="193"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
+        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <source>Loading sources…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <source>Replace existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <source>Start import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scrape metadata</source>
-        <translation type="unfinished">استخراج البيانات الوصفية</translation>
+        <translation type="obsolete">استخراج البيانات الوصفية</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="185"/>
-        <source>Loading scrapers…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="196"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
         <source>Systems</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="222"/>
-        <source>Re-scrape existing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
-        <source>Start scrape</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1541,17 +1580,17 @@ Français - Wilfried</source>
         <translation>لا يوجد شيء هنا</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="36"/>
         <source>Loading…</source>
         <translation>جارٍ التحميل…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="37"/>
         <source>Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="79"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="85"/>
         <source>Failed to load</source>
         <translation>فشل التحميل</translation>
     </message>
@@ -1565,14 +1604,14 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="114"/>
         <location filename="../screens/SettingsScreen.qml" line="205"/>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
-        <location filename="../screens/SettingsScreen.qml" line="972"/>
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="978"/>
         <source>Language</source>
         <translation>اللغة</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="165"/>
-        <location filename="../screens/SettingsScreen.qml" line="999"/>
+        <location filename="../screens/SettingsScreen.qml" line="1005"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1582,25 +1621,25 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="225"/>
-        <location filename="../screens/SettingsScreen.qml" line="1051"/>
+        <location filename="../screens/SettingsScreen.qml" line="1057"/>
         <source>Button style</source>
         <translation>نمط الأزرار</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="1060"/>
+        <location filename="../screens/SettingsScreen.qml" line="1066"/>
         <source>Screensaver</source>
         <translation>شاشة التوقف</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Library</source>
         <translation>المكتبة</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="291"/>
-        <location filename="../screens/SettingsScreen.qml" line="1069"/>
+        <location filename="../screens/SettingsScreen.qml" line="1075"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1610,9 +1649,8 @@ Français - Wilfried</source>
         <translation>تحديث قاعدة بيانات الوسائط</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Scrape metadata</source>
-        <translation>استخراج البيانات الوصفية</translation>
+        <translation type="vanished">استخراج البيانات الوصفية</translation>
     </message>
     <message>
         <source>Advanced</source>
@@ -1624,12 +1662,12 @@ Français - Wilfried</source>
         <translation>دعم الفأرة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <location filename="../screens/SettingsScreen.qml" line="323"/>
         <source>Debug logging</source>
         <translation>تسجيل التصحيح</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="323"/>
+        <location filename="../screens/SettingsScreen.qml" line="329"/>
         <source>Upload log file</source>
         <translation>رفع ملف السجل</translation>
     </message>
@@ -1640,7 +1678,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="217"/>
-        <location filename="../screens/SettingsScreen.qml" line="981"/>
+        <location filename="../screens/SettingsScreen.qml" line="987"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1661,7 +1699,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <location filename="../screens/SettingsScreen.qml" line="1078"/>
+        <location filename="../screens/SettingsScreen.qml" line="1084"/>
         <source>Video standard</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1672,7 +1710,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="135"/>
-        <location filename="../screens/SettingsScreen.qml" line="1026"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
         <source>System logos</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1692,35 +1730,34 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Optimizing</source>
         <translation>جارٍ التحسين</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>Paused</source>
         <translation>متوقف مؤقتًا</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>In progress</source>
         <translation>قيد التنفيذ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>%1 indexed</source>
         <translation>تمت فهرسة %1</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>%1 scraped</source>
-        <translation>تم استخراج %1</translation>
+        <translation type="vanished">تم استخراج %1</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Cancel</source>
         <translation>إلغاء</translation>
     </message>
@@ -1729,12 +1766,12 @@ Français - Wilfried</source>
         <translation type="vanished">ابدأ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Upload</source>
         <translation>رفع</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="650"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Open</source>
         <translation>فتح</translation>
     </message>
@@ -1743,92 +1780,92 @@ Français - Wilfried</source>
         <translation type="vanished">افتراضي</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="758"/>
         <source>English</source>
         <translation>الإنجليزية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="760"/>
         <source>Italian</source>
         <translation>الإيطالية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="756"/>
+        <location filename="../screens/SettingsScreen.qml" line="762"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="758"/>
+        <location filename="../screens/SettingsScreen.qml" line="764"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="760"/>
+        <location filename="../screens/SettingsScreen.qml" line="766"/>
         <source>German</source>
         <translation>الألمانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="762"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Greek</source>
         <translation>اليونانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="764"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Japanese</source>
         <translation>اليابانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="766"/>
+        <location filename="../screens/SettingsScreen.qml" line="772"/>
         <source>Korean</source>
         <translation>الكورية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Dutch</source>
         <translation>الهولندية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="776"/>
         <source>Romanian</source>
         <translation>الرومانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="778"/>
         <source>Slovak</source>
         <translation>السلوفاكية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="774"/>
+        <location filename="../screens/SettingsScreen.qml" line="780"/>
         <source>Ukrainian</source>
         <translation>الأوكرانية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="776"/>
+        <location filename="../screens/SettingsScreen.qml" line="782"/>
         <source>Chinese (Simplified)</source>
         <translation>الصينية المبسطة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="778"/>
+        <location filename="../screens/SettingsScreen.qml" line="784"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="780"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Hebrew</source>
         <translation>العبرية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="782"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Arabic</source>
         <translation>العربية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="784"/>
+        <location filename="../screens/SettingsScreen.qml" line="790"/>
         <source>Hindi</source>
         <translation>الهندية</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>French</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1837,127 +1874,127 @@ Français - Wilfried</source>
         <translation type="vanished">تلقائي</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="792"/>
+        <location filename="../screens/SettingsScreen.qml" line="798"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="794"/>
+        <location filename="../screens/SettingsScreen.qml" line="800"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="805"/>
+        <location filename="../screens/SettingsScreen.qml" line="811"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="807"/>
+        <location filename="../screens/SettingsScreen.qml" line="813"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="809"/>
+        <location filename="../screens/SettingsScreen.qml" line="815"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
-        <location filename="../screens/SettingsScreen.qml" line="787"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
-        <location filename="../screens/SettingsScreen.qml" line="810"/>
-        <location filename="../screens/SettingsScreen.qml" line="877"/>
-        <location filename="../screens/SettingsScreen.qml" line="925"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="793"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
+        <location filename="../screens/SettingsScreen.qml" line="816"/>
+        <location filename="../screens/SettingsScreen.qml" line="883"/>
+        <location filename="../screens/SettingsScreen.qml" line="931"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="158"/>
-        <location filename="../screens/SettingsScreen.qml" line="963"/>
+        <location filename="../screens/SettingsScreen.qml" line="969"/>
         <source>Interface resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="129"/>
-        <location filename="../screens/SettingsScreen.qml" line="1035"/>
+        <location filename="../screens/SettingsScreen.qml" line="1041"/>
         <source>Color scheme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>%1 × %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Automatic (Recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="717"/>
         <source>%1 (Animations off)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="815"/>
+        <location filename="../screens/SettingsScreen.qml" line="821"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="817"/>
+        <location filename="../screens/SettingsScreen.qml" line="823"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="818"/>
+        <location filename="../screens/SettingsScreen.qml" line="824"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="823"/>
+        <location filename="../screens/SettingsScreen.qml" line="829"/>
         <source>Detailed list view</source>
         <translation>عرض قائمة مفصلة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="824"/>
+        <location filename="../screens/SettingsScreen.qml" line="830"/>
         <source>Grid view</source>
         <translation>عرض الشبكة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="829"/>
+        <location filename="../screens/SettingsScreen.qml" line="835"/>
         <source>Full color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="830"/>
+        <location filename="../screens/SettingsScreen.qml" line="836"/>
         <source>Tinted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="855"/>
+        <location filename="../screens/SettingsScreen.qml" line="861"/>
         <source>Nord</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="852"/>
+        <location filename="../screens/SettingsScreen.qml" line="858"/>
         <source>Dracula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="90"/>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="120"/>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="211"/>
-        <location filename="../screens/SettingsScreen.qml" line="990"/>
+        <location filename="../screens/SettingsScreen.qml" line="996"/>
         <source>Region</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1967,72 +2004,72 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="859"/>
+        <location filename="../screens/SettingsScreen.qml" line="865"/>
         <source>Synthwave &apos;84</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="846"/>
+        <location filename="../screens/SettingsScreen.qml" line="852"/>
         <source>Amber Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="848"/>
+        <location filename="../screens/SettingsScreen.qml" line="854"/>
         <source>Green Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="849"/>
+        <location filename="../screens/SettingsScreen.qml" line="855"/>
         <source>Neo Geo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="850"/>
+        <location filename="../screens/SettingsScreen.qml" line="856"/>
         <source>NES</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="851"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>Virtual Boy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="854"/>
+        <location filename="../screens/SettingsScreen.qml" line="860"/>
         <source>Gruvbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="853"/>
+        <location filename="../screens/SettingsScreen.qml" line="859"/>
         <source>Everforest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="858"/>
+        <location filename="../screens/SettingsScreen.qml" line="864"/>
         <source>Solarized Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="863"/>
         <source>Rosé Pine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="856"/>
+        <location filename="../screens/SettingsScreen.qml" line="862"/>
         <source>Oxocarbon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="860"/>
+        <location filename="../screens/SettingsScreen.qml" line="866"/>
         <source>Flexoki Paper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="861"/>
+        <location filename="../screens/SettingsScreen.qml" line="867"/>
         <source>Solarized Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="847"/>
+        <location filename="../screens/SettingsScreen.qml" line="853"/>
         <source>Game Boy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2087,19 +2124,14 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Downloads box art, descriptions, and tags for your games. Choose a source and which systems.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
-        <location filename="../screens/SettingsScreen.qml" line="1008"/>
+        <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="285"/>
-        <location filename="../screens/SettingsScreen.qml" line="1017"/>
+        <location filename="../screens/SettingsScreen.qml" line="1023"/>
         <source>Games layout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2114,103 +2146,103 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <location filename="../screens/SettingsScreen.qml" line="324"/>
         <source>Writes extra detail to the log file to help track down a problem. Restarts the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Configure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="868"/>
+        <location filename="../screens/SettingsScreen.qml" line="874"/>
         <source>Style B</source>
         <translation>النمط B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="870"/>
+        <location filename="../screens/SettingsScreen.qml" line="876"/>
         <source>Style C</source>
         <translation>النمط C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="872"/>
+        <location filename="../screens/SettingsScreen.qml" line="878"/>
         <source>Style D</source>
         <translation>النمط D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="874"/>
+        <location filename="../screens/SettingsScreen.qml" line="880"/>
         <source>Style E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="876"/>
+        <location filename="../screens/SettingsScreen.qml" line="882"/>
         <source>Style A</source>
         <translation>النمط A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="892"/>
+        <location filename="../screens/SettingsScreen.qml" line="898"/>
         <source>Off</source>
         <translation>إيقاف</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="894"/>
+        <location filename="../screens/SettingsScreen.qml" line="900"/>
         <source>1 second (testing)</source>
         <translation>ثانية واحدة (اختبار)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="896"/>
+        <location filename="../screens/SettingsScreen.qml" line="902"/>
         <source>1 minute</source>
         <translation>دقيقة واحدة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="898"/>
+        <location filename="../screens/SettingsScreen.qml" line="904"/>
         <source>2 minutes</source>
         <translation>دقيقتان</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="900"/>
+        <location filename="../screens/SettingsScreen.qml" line="906"/>
         <source>5 minutes</source>
         <translation>5 دقائق</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="902"/>
+        <location filename="../screens/SettingsScreen.qml" line="908"/>
         <source>10 minutes</source>
         <translation>10 دقائق</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="904"/>
+        <location filename="../screens/SettingsScreen.qml" line="910"/>
         <source>15 minutes</source>
         <translation>15 دقيقة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="906"/>
+        <location filename="../screens/SettingsScreen.qml" line="912"/>
         <source>30 minutes</source>
         <translation>30 دقيقة</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="907"/>
+        <location filename="../screens/SettingsScreen.qml" line="913"/>
         <source>%1 seconds</source>
         <translation>%1 ثوانٍ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="917"/>
+        <location filename="../screens/SettingsScreen.qml" line="923"/>
         <source>PAL (50 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="919"/>
+        <location filename="../screens/SettingsScreen.qml" line="925"/>
         <source>480i (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="920"/>
+        <location filename="../screens/SettingsScreen.qml" line="926"/>
         <source>NTSC (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1905"/>
+        <location filename="../screens/SettingsScreen.qml" line="1911"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2220,13 +2252,13 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="108"/>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2276,6 +2308,16 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="269"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="280"/>
         <source>Show systems as a grid of covers, or as a list with details beside it.</source>
         <translation type="unfinished"></translation>
@@ -2296,92 +2338,107 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="324"/>
+        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <source>Shows a code you can scan to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="330"/>
         <source>Uploads the log file and gives you a link to share when reporting a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="843"/>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <source>%1 imported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="849"/>
         <source>Zaparoo Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="844"/>
+        <location filename="../screens/SettingsScreen.qml" line="850"/>
         <source>Zaparoo Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="845"/>
+        <location filename="../screens/SettingsScreen.qml" line="851"/>
         <source>Classic Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="927"/>
+        <location filename="../screens/SettingsScreen.qml" line="933"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="929"/>
+        <location filename="../screens/SettingsScreen.qml" line="935"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="931"/>
+        <location filename="../screens/SettingsScreen.qml" line="937"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="933"/>
+        <location filename="../screens/SettingsScreen.qml" line="939"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="935"/>
+        <location filename="../screens/SettingsScreen.qml" line="941"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="937"/>
+        <location filename="../screens/SettingsScreen.qml" line="943"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="939"/>
+        <location filename="../screens/SettingsScreen.qml" line="945"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="941"/>
+        <location filename="../screens/SettingsScreen.qml" line="947"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="943"/>
+        <location filename="../screens/SettingsScreen.qml" line="949"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="945"/>
+        <location filename="../screens/SettingsScreen.qml" line="951"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="947"/>
+        <location filename="../screens/SettingsScreen.qml" line="953"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="949"/>
+        <location filename="../screens/SettingsScreen.qml" line="955"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="355"/>
+        <location filename="../screens/SettingsScreen.qml" line="361"/>
         <source>Settings</source>
         <translation>الإعدادات</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1887"/>
+        <location filename="../screens/SettingsScreen.qml" line="1893"/>
         <source>No settings available on this platform</source>
         <translation>لا توجد إعدادات متاحة على هذه المنصة</translation>
     </message>
@@ -2420,9 +2477,33 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/StatusLine.qml" line="105"/>
+        <source>Importing paused: game running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Import failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Imported %1 of %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scraping…</source>
-        <translation type="unfinished">جارٍ الاستخراج…</translation>
+        <translation type="obsolete">جارٍ الاستخراج…</translation>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
@@ -2451,16 +2532,6 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="105"/>
-        <source>Scraping paused: game running</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="106"/>
-        <source>Scraping: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>%1 files</source>
         <translation type="obsolete">%1 ملفات</translation>
     </message>
@@ -2476,16 +2547,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scraped %1 of %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -2124,6 +2124,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
         <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
@@ -2310,11 +2315,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Get metadata</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -2247,7 +2247,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1911"/>
+        <location filename="../screens/SettingsScreen.qml" line="1913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2438,7 +2438,7 @@ Français - Wilfried</source>
         <translation>الإعدادات</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1893"/>
+        <location filename="../screens/SettingsScreen.qml" line="1895"/>
         <source>No settings available on this platform</source>
         <translation>لا توجد إعدادات متاحة على هذه المنصة</translation>
     </message>

--- a/src/ui/translations/frontend_ar.ts
+++ b/src/ui/translations/frontend_ar.ts
@@ -35,8 +35,8 @@
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="212"/>
-        <source>Commercial licensing: legal@zaparoo.org</source>
-        <translation>الترخيص التجاري: legal@zaparoo.org</translation>
+        <source>Commercial licensing: legal@zaparoo.com</source>
+        <translation>الترخيص التجاري: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="223"/>
@@ -227,8 +227,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="116"/>
-        <source>Contact: legal@zaparoo.org</source>
-        <translation>للتواصل: legal@zaparoo.org</translation>
+        <source>Contact: legal@zaparoo.com</source>
+        <translation>للتواصل: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="127"/>
@@ -1538,27 +1538,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
-        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <source>Documentation: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="225"/>
         <source>Loading sources…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="262"/>
         <source>Replace existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="276"/>
         <source>Start import</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1567,7 +1567,7 @@ Français - Wilfried</source>
         <translation type="obsolete">استخراج البيانات الوصفية</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="249"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -389,45 +389,6 @@ Français - Wilfried</source>
     </message>
 </context>
 <context>
-    <name>FirstRunIndexModal</name>
-    <message>
-        <source>First-time setup</source>
-        <translation type="vanished">Ersteinrichtung</translation>
-    </message>
-    <message>
-        <source>Indexing paused</source>
-        <translation type="vanished">Indizierung pausiert</translation>
-    </message>
-    <message>
-        <source>Optimizing database - almost done</source>
-        <translation type="vanished">Datenbank wird optimiert – fast fertig</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2 - %3</source>
-        <translation type="vanished">Schritt %1 von %2 – %3</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2</source>
-        <translation type="vanished">Schritt %1 von %2</translation>
-    </message>
-    <message>
-        <source>Preparing…</source>
-        <translation type="vanished">Vorbereitung…</translation>
-    </message>
-    <message>
-        <source>Done. %1 files indexed.</source>
-        <translation type="vanished">Fertig. %1 Dateien indiziert.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Abbrechen</translation>
-    </message>
-    <message>
-        <source>Start scan</source>
-        <translation type="vanished">Scan starten</translation>
-    </message>
-</context>
-<context>
     <name>GameInfoModal</name>
     <message>
         <location filename="../components/GameInfoModal.qml" line="153"/>
@@ -540,6 +501,26 @@ Français - Wilfried</source>
         <translation>Favoriten</translation>
     </message>
     <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>Updating the media database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>No games found yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Your games appear here as Core finds them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Update media database in Settings &gt; Library.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Recently Played</source>
         <translation type="vanished">Zuletzt gespielt</translation>
     </message>
@@ -569,35 +550,44 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
-        <translation>Keine Systeme verfügbar. Bitte Mediendatenbank unter Einstellungen aktualisieren.</translation>
+        <translation type="vanished">Keine Systeme verfügbar. Bitte Mediendatenbank unter Einstellungen aktualisieren.</translation>
     </message>
 </context>
 <context>
     <name>IndexSetupModal</name>
     <message>
         <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Start</source>
+        <translation type="unfinished">Starten</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Change</source>
+        <translation type="unfinished">Ändern</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="51"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="47"/>
+        <location filename="../components/IndexSetupModal.qml" line="53"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="115"/>
+        <location filename="../components/IndexSetupModal.qml" line="121"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediendatenbank aktualisieren</translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="124"/>
+        <location filename="../components/IndexSetupModal.qml" line="130"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="137"/>
+        <location filename="../components/IndexSetupModal.qml" line="143"/>
         <source>Start update</source>
         <translation type="unfinished"></translation>
     </message>
@@ -675,29 +665,29 @@ Français - Wilfried</source>
         <translation type="vanished">Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
-        <location filename="../app/Main.qml" line="2330"/>
-        <location filename="../app/Main.qml" line="2393"/>
-        <location filename="../app/Main.qml" line="2699"/>
-        <location filename="../app/Main.qml" line="3741"/>
-        <location filename="../app/Main.qml" line="3784"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
+        <location filename="../app/Main.qml" line="2341"/>
+        <location filename="../app/Main.qml" line="2410"/>
+        <location filename="../app/Main.qml" line="2716"/>
+        <location filename="../app/Main.qml" line="3795"/>
+        <location filename="../app/Main.qml" line="3838"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Remove from favorites</source>
         <translation>Aus Favoriten entfernen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Add to favorites</source>
         <translation>Zu Favoriten hinzufügen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2264"/>
-        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2266"/>
+        <location filename="../app/Main.qml" line="2346"/>
         <source>Write to NFC token</source>
         <translation>Auf NFC-Token schreiben</translation>
     </message>
@@ -706,53 +696,76 @@ Français - Wilfried</source>
         <translation type="vanished">QR-Code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
-        <location filename="../app/Main.qml" line="2308"/>
+        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2319"/>
         <source>Launch game</source>
         <translation>Spiel starten</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1070"/>
-        <location filename="../app/Main.qml" line="3417"/>
-        <location filename="../app/Main.qml" line="3464"/>
-        <location filename="../app/Main.qml" line="3474"/>
+        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3518"/>
+        <location filename="../app/Main.qml" line="3528"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3153"/>
+        <source>Get metadata failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3154"/>
+        <source>Could not start getting metadata. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3156"/>
+        <source>Source list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3157"/>
+        <source>Could not load the list of metadata sources. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3307"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4848"/>
+        <location filename="../app/Main.qml" line="4902"/>
         <source>Loading systems…</source>
         <translation>Systeme werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4855"/>
+        <location filename="../app/Main.qml" line="4909"/>
         <source>Loading favorites…</source>
         <translation>Favoriten werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4850"/>
+        <location filename="../app/Main.qml" line="4904"/>
         <source>Loading games…</source>
         <translation>Spiele werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2183"/>
-        <location filename="../app/Main.qml" line="2218"/>
+        <location filename="../app/Main.qml" line="2185"/>
+        <location filename="../app/Main.qml" line="2220"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediendatenbank aktualisieren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2186"/>
-        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
-        <translation type="unfinished">Metadaten abrufen</translation>
+        <translation type="obsolete">Metadaten abrufen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2179"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
@@ -762,90 +775,90 @@ Français - Wilfried</source>
         <translation type="unfinished">Einstellungen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2096"/>
+        <location filename="../app/Main.qml" line="2098"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2153"/>
+        <location filename="../app/Main.qml" line="2155"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2179"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2258"/>
-        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2323"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
-        <location filename="../app/Main.qml" line="2346"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2280"/>
+        <location filename="../app/Main.qml" line="2357"/>
+        <location filename="../app/Main.qml" line="2451"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3507"/>
+        <location filename="../app/Main.qml" line="2395"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3561"/>
         <source>Default</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2395"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2230"/>
-        <location filename="../app/Main.qml" line="2238"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="2164"/>
+        <location filename="../app/Main.qml" line="2215"/>
+        <location filename="../app/Main.qml" line="2232"/>
+        <location filename="../app/Main.qml" line="2240"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3454"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3445"/>
+        <location filename="../app/Main.qml" line="3499"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3460"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3511"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3565"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3482"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3515"/>
+        <location filename="../app/Main.qml" line="3569"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3436"/>
+        <location filename="../app/Main.qml" line="3490"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -870,45 +883,46 @@ Français - Wilfried</source>
         <translation type="unfinished">Beenden</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2173"/>
-        <location filename="../app/Main.qml" line="2282"/>
-        <location filename="../app/Main.qml" line="2301"/>
-        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2284"/>
+        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2361"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2268"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2270"/>
+        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2807"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2461"/>
+        <location filename="../app/Main.qml" line="2478"/>
         <source>Move</source>
         <translation type="unfinished">Bewegen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2667"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1032"/>
-        <location filename="../app/Main.qml" line="3043"/>
-        <location filename="../app/Main.qml" line="3065"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3131"/>
+        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3174"/>
         <source>OK</source>
         <translation type="unfinished">In Ordnung</translation>
     </message>
@@ -923,226 +937,224 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="2188"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2293"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2807"/>
+        <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Scan this code to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3132"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3098"/>
+        <location filename="../app/Main.qml" line="3141"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3099"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3101"/>
+        <location filename="../app/Main.qml" line="3144"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3147"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3105"/>
+        <location filename="../app/Main.qml" line="3148"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3107"/>
+        <location filename="../app/Main.qml" line="3150"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3151"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3110"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3111"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3113"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3114"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3116"/>
+        <location filename="../app/Main.qml" line="3159"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3120"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3122"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3123"/>
+        <location filename="../app/Main.qml" line="3166"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3125"/>
+        <location filename="../app/Main.qml" line="3168"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3126"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3128"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3129"/>
+        <location filename="../app/Main.qml" line="3172"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3253"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3269"/>
+        <location filename="../app/Main.qml" line="3323"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3278"/>
+        <location filename="../app/Main.qml" line="3332"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3307"/>
+        <location filename="../app/Main.qml" line="3361"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3446"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3432"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3486"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoriten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3415"/>
-        <location filename="../app/Main.qml" line="3461"/>
+        <location filename="../app/Main.qml" line="3469"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3449"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3503"/>
+        <location filename="../app/Main.qml" line="3525"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3489"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3485"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3492"/>
+        <location filename="../app/Main.qml" line="3546"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3708"/>
+        <location filename="../app/Main.qml" line="3762"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3119"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
-        <location filename="../app/Main.qml" line="3318"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="2910"/>
+        <location filename="../app/Main.qml" line="3372"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Retry</source>
         <translation type="unfinished">Wiederholen</translation>
     </message>
@@ -1151,22 +1163,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4852"/>
+        <location filename="../app/Main.qml" line="4906"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4857"/>
+        <location filename="../app/Main.qml" line="4911"/>
         <source>Loading recently played…</source>
         <translation>Zuletzt gespielte werden geladen…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4859"/>
+        <location filename="../app/Main.qml" line="4913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4861"/>
+        <location filename="../app/Main.qml" line="4915"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>
@@ -1174,7 +1186,7 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Writing failed</source>
         <translation>Schreiben fehlgeschlagen</translation>
     </message>
@@ -1183,82 +1195,83 @@ Français - Wilfried</source>
         <translation type="vanished">Beschreibbare Karte an den Leser halten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="936"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="943"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="1365"/>
         <source>OK</source>
         <translation type="unfinished">In Ordnung</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="535"/>
+        <location filename="../app/MainLayout.qml" line="541"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Hold a writable token near the reader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
         <source>Are you sure you want to exit?</source>
         <translation>Wirklich beenden?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1387"/>
+        <location filename="../app/MainLayout.qml" line="1409"/>
         <source>Select</source>
         <translation>Auswählen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1283"/>
-        <location filename="../app/MainLayout.qml" line="1297"/>
-        <location filename="../app/MainLayout.qml" line="1312"/>
-        <location filename="../app/MainLayout.qml" line="1323"/>
-        <location filename="../app/MainLayout.qml" line="1349"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1321"/>
+        <location filename="../app/MainLayout.qml" line="1332"/>
+        <location filename="../app/MainLayout.qml" line="1358"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1425"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1339"/>
+        <location filename="../app/MainLayout.qml" line="1391"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1308"/>
+        <location filename="../app/MainLayout.qml" line="1317"/>
         <source>Done</source>
         <translation>Fertig</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1338"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
         <source>I understand</source>
         <translation>Ich verstehe</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1376"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1389"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1267,28 +1280,29 @@ Français - Wilfried</source>
         <translation type="vanished">Starten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1656"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Scroll</source>
         <translation>Scrollen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1468"/>
-        <location filename="../app/MainLayout.qml" line="1555"/>
-        <location filename="../app/MainLayout.qml" line="1573"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
-        <location filename="../app/MainLayout.qml" line="1724"/>
+        <location filename="../app/MainLayout.qml" line="1500"/>
+        <location filename="../app/MainLayout.qml" line="1587"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1737"/>
+        <location filename="../app/MainLayout.qml" line="1756"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1374"/>
-        <location filename="../app/MainLayout.qml" line="1454"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1596"/>
-        <location filename="../app/MainLayout.qml" line="1615"/>
-        <location filename="../app/MainLayout.qml" line="1688"/>
+        <location filename="../app/MainLayout.qml" line="1284"/>
+        <location filename="../app/MainLayout.qml" line="1383"/>
+        <location filename="../app/MainLayout.qml" line="1405"/>
+        <location filename="../app/MainLayout.qml" line="1486"/>
+        <location filename="../app/MainLayout.qml" line="1523"/>
+        <location filename="../app/MainLayout.qml" line="1572"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1647"/>
+        <location filename="../app/MainLayout.qml" line="1720"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
@@ -1298,8 +1312,8 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="531"/>
-        <location filename="../app/MainLayout.qml" line="533"/>
+        <location filename="../app/MainLayout.qml" line="537"/>
+        <location filename="../app/MainLayout.qml" line="539"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoriten</translation>
     </message>
@@ -1308,36 +1322,36 @@ Français - Wilfried</source>
         <translation type="obsolete">Zuletzt gespielt</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="916"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="917"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1096"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1417"/>
+        <location filename="../app/MainLayout.qml" line="1449"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1421"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1496"/>
-        <location filename="../app/MainLayout.qml" line="1545"/>
-        <location filename="../app/MainLayout.qml" line="1601"/>
-        <location filename="../app/MainLayout.qml" line="1693"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1528"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1633"/>
+        <location filename="../app/MainLayout.qml" line="1725"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
@@ -1346,19 +1360,20 @@ Français - Wilfried</source>
         <translation type="vanished">Beenden</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1477"/>
-        <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1513"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1559"/>
-        <location filename="../app/MainLayout.qml" line="1577"/>
-        <location filename="../app/MainLayout.qml" line="1589"/>
-        <location filename="../app/MainLayout.qml" line="1605"/>
-        <location filename="../app/MainLayout.qml" line="1639"/>
-        <location filename="../app/MainLayout.qml" line="1660"/>
-        <location filename="../app/MainLayout.qml" line="1669"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
-        <location filename="../app/MainLayout.qml" line="1728"/>
+        <location filename="../app/MainLayout.qml" line="1413"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1561"/>
+        <location filename="../app/MainLayout.qml" line="1591"/>
+        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1621"/>
+        <location filename="../app/MainLayout.qml" line="1637"/>
+        <location filename="../app/MainLayout.qml" line="1671"/>
+        <location filename="../app/MainLayout.qml" line="1692"/>
+        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1741"/>
+        <location filename="../app/MainLayout.qml" line="1760"/>
         <source>Back</source>
         <translation>Zurück</translation>
     </message>
@@ -1367,29 +1382,29 @@ Français - Wilfried</source>
         <translation type="vanished">Seite</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1464"/>
-        <location filename="../app/MainLayout.qml" line="1499"/>
-        <location filename="../app/MainLayout.qml" line="1550"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1531"/>
+        <location filename="../app/MainLayout.qml" line="1582"/>
+        <location filename="../app/MainLayout.qml" line="1730"/>
         <source>Options</source>
         <translation>Optionen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1509"/>
-        <location filename="../app/MainLayout.qml" line="1567"/>
-        <location filename="../app/MainLayout.qml" line="1716"/>
+        <location filename="../app/MainLayout.qml" line="1328"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1541"/>
+        <location filename="../app/MainLayout.qml" line="1599"/>
+        <location filename="../app/MainLayout.qml" line="1748"/>
         <source>Retry</source>
         <translation>Wiederholen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1624"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Change</source>
         <translation>Ändern</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1630"/>
+        <location filename="../app/MainLayout.qml" line="1662"/>
         <source>Toggle</source>
         <translation>Umschalten</translation>
     </message>
@@ -1450,12 +1465,12 @@ Français - Wilfried</source>
 <context>
     <name>QrCodeModal</name>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="23"/>
+        <location filename="../components/QrCodeModal.qml" line="19"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="43"/>
+        <location filename="../components/QrCodeModal.qml" line="20"/>
         <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1485,43 +1500,67 @@ Français - Wilfried</source>
 <context>
     <name>ScrapeSetupModal</name>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="67"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Start</source>
+        <translation type="unfinished">Starten</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Toggle</source>
+        <translation type="unfinished">Umschalten</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Change</source>
+        <translation type="unfinished">Ändern</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="89"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="69"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="91"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="171"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="193"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
+        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <source>Loading sources…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <source>Replace existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <source>Start import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scrape metadata</source>
-        <translation type="unfinished">Metadaten abrufen</translation>
+        <translation type="obsolete">Metadaten abrufen</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="185"/>
-        <source>Loading scrapers…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="196"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
         <source>Systems</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="222"/>
-        <source>Re-scrape existing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
-        <source>Start scrape</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1533,17 +1572,17 @@ Français - Wilfried</source>
         <translation>Nichts hier</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="36"/>
         <source>Loading…</source>
         <translation>Wird geladen…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="37"/>
         <source>Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="79"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="85"/>
         <source>Failed to load</source>
         <translation>Laden fehlgeschlagen</translation>
     </message>
@@ -1553,8 +1592,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="114"/>
         <location filename="../screens/SettingsScreen.qml" line="205"/>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
-        <location filename="../screens/SettingsScreen.qml" line="972"/>
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="978"/>
         <source>Language</source>
         <translation>Sprache</translation>
     </message>
@@ -1578,50 +1617,49 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="165"/>
-        <location filename="../screens/SettingsScreen.qml" line="999"/>
+        <location filename="../screens/SettingsScreen.qml" line="1005"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="225"/>
-        <location filename="../screens/SettingsScreen.qml" line="1051"/>
+        <location filename="../screens/SettingsScreen.qml" line="1057"/>
         <source>Button style</source>
         <translation>Schaltflächenstil</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="1060"/>
+        <location filename="../screens/SettingsScreen.qml" line="1066"/>
         <source>Screensaver</source>
         <translation>Bildschirmschoner</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Library</source>
         <translation>Bibliothek</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="291"/>
-        <location filename="../screens/SettingsScreen.qml" line="1069"/>
+        <location filename="../screens/SettingsScreen.qml" line="1075"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Scrape metadata</source>
-        <translation>Metadaten abrufen</translation>
+        <translation type="vanished">Metadaten abrufen</translation>
     </message>
     <message>
         <source>Advanced</source>
         <translation type="vanished">Erweitert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <location filename="../screens/SettingsScreen.qml" line="323"/>
         <source>Debug logging</source>
         <translation>Debug-Protokollierung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="323"/>
+        <location filename="../screens/SettingsScreen.qml" line="329"/>
         <source>Upload log file</source>
         <translation>Protokolldatei hochladen</translation>
     </message>
@@ -1632,7 +1670,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="217"/>
-        <location filename="../screens/SettingsScreen.qml" line="981"/>
+        <location filename="../screens/SettingsScreen.qml" line="987"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1643,13 +1681,13 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="158"/>
-        <location filename="../screens/SettingsScreen.qml" line="963"/>
+        <location filename="../screens/SettingsScreen.qml" line="969"/>
         <source>Interface resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="129"/>
-        <location filename="../screens/SettingsScreen.qml" line="1035"/>
+        <location filename="../screens/SettingsScreen.qml" line="1041"/>
         <source>Color scheme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1665,7 +1703,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <location filename="../screens/SettingsScreen.qml" line="1078"/>
+        <location filename="../screens/SettingsScreen.qml" line="1084"/>
         <source>Video standard</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1676,7 +1714,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="135"/>
-        <location filename="../screens/SettingsScreen.qml" line="1026"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
         <source>System logos</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1697,19 +1735,19 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="90"/>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="120"/>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="211"/>
-        <location filename="../screens/SettingsScreen.qml" line="990"/>
+        <location filename="../screens/SettingsScreen.qml" line="996"/>
         <source>Region</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1719,35 +1757,34 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Optimizing</source>
         <translation>Wird optimiert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>Paused</source>
         <translation>Pausiert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>In progress</source>
         <translation>In Bearbeitung</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>%1 indexed</source>
         <translation>%1 indiziert</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>%1 scraped</source>
-        <translation>%1 erfasst</translation>
+        <translation type="vanished">%1 erfasst</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
@@ -1756,117 +1793,117 @@ Français - Wilfried</source>
         <translation type="vanished">Starten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Upload</source>
         <translation>Hochladen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="650"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Open</source>
         <translation>Öffnen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>%1 × %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Automatic (Recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="717"/>
         <source>%1 (Animations off)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="758"/>
         <source>English</source>
         <translation>Englisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="760"/>
         <source>Italian</source>
         <translation>Italienisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="756"/>
+        <location filename="../screens/SettingsScreen.qml" line="762"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="758"/>
+        <location filename="../screens/SettingsScreen.qml" line="764"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="760"/>
+        <location filename="../screens/SettingsScreen.qml" line="766"/>
         <source>German</source>
         <translation>Deutsch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="762"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Greek</source>
         <translation>Griechisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="764"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Japanese</source>
         <translation>Japanisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="766"/>
+        <location filename="../screens/SettingsScreen.qml" line="772"/>
         <source>Korean</source>
         <translation>Koreanisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Dutch</source>
         <translation>Niederländisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="776"/>
         <source>Romanian</source>
         <translation>Rumänisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="778"/>
         <source>Slovak</source>
         <translation>Slowakisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="774"/>
+        <location filename="../screens/SettingsScreen.qml" line="780"/>
         <source>Ukrainian</source>
         <translation>Ukrainisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="776"/>
+        <location filename="../screens/SettingsScreen.qml" line="782"/>
         <source>Chinese (Simplified)</source>
         <translation>Chinesisch (vereinfacht)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="778"/>
+        <location filename="../screens/SettingsScreen.qml" line="784"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="780"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Hebrew</source>
         <translation>Hebräisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="782"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="784"/>
+        <location filename="../screens/SettingsScreen.qml" line="790"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>French</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1875,37 +1912,37 @@ Français - Wilfried</source>
         <translation type="vanished">Automatisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="792"/>
+        <location filename="../screens/SettingsScreen.qml" line="798"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="794"/>
+        <location filename="../screens/SettingsScreen.qml" line="800"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="805"/>
+        <location filename="../screens/SettingsScreen.qml" line="811"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="807"/>
+        <location filename="../screens/SettingsScreen.qml" line="813"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="809"/>
+        <location filename="../screens/SettingsScreen.qml" line="815"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
-        <location filename="../screens/SettingsScreen.qml" line="787"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
-        <location filename="../screens/SettingsScreen.qml" line="810"/>
-        <location filename="../screens/SettingsScreen.qml" line="877"/>
-        <location filename="../screens/SettingsScreen.qml" line="925"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="793"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
+        <location filename="../screens/SettingsScreen.qml" line="816"/>
+        <location filename="../screens/SettingsScreen.qml" line="883"/>
+        <location filename="../screens/SettingsScreen.qml" line="931"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1960,19 +1997,14 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Downloads box art, descriptions, and tags for your games. Choose a source and which systems.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
-        <location filename="../screens/SettingsScreen.qml" line="1008"/>
+        <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="285"/>
-        <location filename="../screens/SettingsScreen.qml" line="1017"/>
+        <location filename="../screens/SettingsScreen.qml" line="1023"/>
         <source>Games layout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1987,93 +2019,93 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <location filename="../screens/SettingsScreen.qml" line="324"/>
         <source>Writes extra detail to the log file to help track down a problem. Restarts the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Configure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="815"/>
+        <location filename="../screens/SettingsScreen.qml" line="821"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="817"/>
+        <location filename="../screens/SettingsScreen.qml" line="823"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="818"/>
+        <location filename="../screens/SettingsScreen.qml" line="824"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="823"/>
+        <location filename="../screens/SettingsScreen.qml" line="829"/>
         <source>Detailed list view</source>
         <translation>Detaillierte Listenansicht</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="824"/>
+        <location filename="../screens/SettingsScreen.qml" line="830"/>
         <source>Grid view</source>
         <translation>Rasteransicht</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="829"/>
+        <location filename="../screens/SettingsScreen.qml" line="835"/>
         <source>Full color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="830"/>
+        <location filename="../screens/SettingsScreen.qml" line="836"/>
         <source>Tinted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="868"/>
+        <location filename="../screens/SettingsScreen.qml" line="874"/>
         <source>Style B</source>
         <translation>Stil B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="870"/>
+        <location filename="../screens/SettingsScreen.qml" line="876"/>
         <source>Style C</source>
         <translation>Stil C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="872"/>
+        <location filename="../screens/SettingsScreen.qml" line="878"/>
         <source>Style D</source>
         <translation>Stil D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="874"/>
+        <location filename="../screens/SettingsScreen.qml" line="880"/>
         <source>Style E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="876"/>
+        <location filename="../screens/SettingsScreen.qml" line="882"/>
         <source>Style A</source>
         <translation>Stil A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="917"/>
+        <location filename="../screens/SettingsScreen.qml" line="923"/>
         <source>PAL (50 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="919"/>
+        <location filename="../screens/SettingsScreen.qml" line="925"/>
         <source>480i (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="920"/>
+        <location filename="../screens/SettingsScreen.qml" line="926"/>
         <source>NTSC (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1905"/>
+        <location filename="../screens/SettingsScreen.qml" line="1911"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2082,47 +2114,47 @@ Français - Wilfried</source>
         <translation type="vanished">Standard</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="892"/>
+        <location filename="../screens/SettingsScreen.qml" line="898"/>
         <source>Off</source>
         <translation>Aus</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="894"/>
+        <location filename="../screens/SettingsScreen.qml" line="900"/>
         <source>1 second (testing)</source>
         <translation>1 Sekunde (Test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="896"/>
+        <location filename="../screens/SettingsScreen.qml" line="902"/>
         <source>1 minute</source>
         <translation>1 Minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="898"/>
+        <location filename="../screens/SettingsScreen.qml" line="904"/>
         <source>2 minutes</source>
         <translation>2 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="900"/>
+        <location filename="../screens/SettingsScreen.qml" line="906"/>
         <source>5 minutes</source>
         <translation>5 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="902"/>
+        <location filename="../screens/SettingsScreen.qml" line="908"/>
         <source>10 minutes</source>
         <translation>10 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="904"/>
+        <location filename="../screens/SettingsScreen.qml" line="910"/>
         <source>15 minutes</source>
         <translation>15 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="906"/>
+        <location filename="../screens/SettingsScreen.qml" line="912"/>
         <source>30 minutes</source>
         <translation>30 Minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="907"/>
+        <location filename="../screens/SettingsScreen.qml" line="913"/>
         <source>%1 seconds</source>
         <translation>%1 Sekunden</translation>
     </message>
@@ -2132,93 +2164,93 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="108"/>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="855"/>
+        <location filename="../screens/SettingsScreen.qml" line="861"/>
         <source>Nord</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="852"/>
+        <location filename="../screens/SettingsScreen.qml" line="858"/>
         <source>Dracula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="859"/>
+        <location filename="../screens/SettingsScreen.qml" line="865"/>
         <source>Synthwave &apos;84</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="846"/>
+        <location filename="../screens/SettingsScreen.qml" line="852"/>
         <source>Amber Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="848"/>
+        <location filename="../screens/SettingsScreen.qml" line="854"/>
         <source>Green Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="849"/>
+        <location filename="../screens/SettingsScreen.qml" line="855"/>
         <source>Neo Geo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="850"/>
+        <location filename="../screens/SettingsScreen.qml" line="856"/>
         <source>NES</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="851"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>Virtual Boy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="854"/>
+        <location filename="../screens/SettingsScreen.qml" line="860"/>
         <source>Gruvbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="853"/>
+        <location filename="../screens/SettingsScreen.qml" line="859"/>
         <source>Everforest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="858"/>
+        <location filename="../screens/SettingsScreen.qml" line="864"/>
         <source>Solarized Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="863"/>
         <source>Rosé Pine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="856"/>
+        <location filename="../screens/SettingsScreen.qml" line="862"/>
         <source>Oxocarbon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="860"/>
+        <location filename="../screens/SettingsScreen.qml" line="866"/>
         <source>Flexoki Paper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="861"/>
+        <location filename="../screens/SettingsScreen.qml" line="867"/>
         <source>Solarized Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="847"/>
+        <location filename="../screens/SettingsScreen.qml" line="853"/>
         <source>Game Boy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2268,6 +2300,16 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="269"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="280"/>
         <source>Show systems as a grid of covers, or as a list with details beside it.</source>
         <translation type="unfinished"></translation>
@@ -2288,92 +2330,107 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="324"/>
+        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <source>Shows a code you can scan to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="330"/>
         <source>Uploads the log file and gives you a link to share when reporting a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="927"/>
-        <source>Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="929"/>
-        <source>Thumbnail</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="931"/>
-        <source>Box art</source>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <source>%1 imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="933"/>
-        <source>3D box art</source>
+        <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="935"/>
-        <source>Screenshot</source>
+        <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="937"/>
-        <source>Wheel</source>
+        <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="939"/>
-        <source>Title screen</source>
+        <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="941"/>
-        <source>Map</source>
+        <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="943"/>
-        <source>Marquee</source>
+        <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="945"/>
-        <source>Fan art</source>
+        <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="947"/>
-        <source>Box side</source>
+        <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="949"/>
+        <source>Marquee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="951"/>
+        <source>Fan art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="953"/>
+        <source>Box side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="955"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="355"/>
+        <location filename="../screens/SettingsScreen.qml" line="361"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="843"/>
+        <location filename="../screens/SettingsScreen.qml" line="849"/>
         <source>Zaparoo Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="844"/>
+        <location filename="../screens/SettingsScreen.qml" line="850"/>
         <source>Zaparoo Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="845"/>
+        <location filename="../screens/SettingsScreen.qml" line="851"/>
         <source>Classic Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1887"/>
+        <location filename="../screens/SettingsScreen.qml" line="1893"/>
         <source>No settings available on this platform</source>
         <translation>Keine Einstellungen für diese Plattform verfügbar</translation>
     </message>
@@ -2412,9 +2469,33 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/StatusLine.qml" line="105"/>
+        <source>Importing paused: game running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Import failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Imported %1 of %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scraping…</source>
-        <translation type="unfinished">Metadaten werden abgerufen…</translation>
+        <translation type="obsolete">Metadaten werden abgerufen…</translation>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
@@ -2443,16 +2524,6 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="105"/>
-        <source>Scraping paused: game running</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="106"/>
-        <source>Scraping: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>%1 files</source>
         <translation type="obsolete">%1 Dateien</translation>
     </message>
@@ -2468,16 +2539,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scraped %1 of %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -2110,7 +2110,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1911"/>
+        <location filename="../screens/SettingsScreen.qml" line="1913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2430,7 +2430,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1893"/>
+        <location filename="../screens/SettingsScreen.qml" line="1895"/>
         <source>No settings available on this platform</source>
         <translation>Keine Einstellungen für diese Plattform verfügbar</translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -35,8 +35,8 @@
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="212"/>
-        <source>Commercial licensing: legal@zaparoo.org</source>
-        <translation>Kommerzielle Lizenzierung: legal@zaparoo.org</translation>
+        <source>Commercial licensing: legal@zaparoo.com</source>
+        <translation>Kommerzielle Lizenzierung: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="223"/>
@@ -227,8 +227,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="116"/>
-        <source>Contact: legal@zaparoo.org</source>
-        <translation>Kontakt: legal@zaparoo.org</translation>
+        <source>Contact: legal@zaparoo.com</source>
+        <translation>Kontakt: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="127"/>
@@ -1530,27 +1530,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
-        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <source>Documentation: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="225"/>
         <source>Loading sources…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="262"/>
         <source>Replace existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="276"/>
         <source>Start import</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1559,7 +1559,7 @@ Français - Wilfried</source>
         <translation type="obsolete">Metadaten abrufen</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="249"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_de.ts
+++ b/src/ui/translations/frontend_de.ts
@@ -1997,6 +1997,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
         <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
@@ -2302,11 +2307,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Get metadata</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -389,45 +389,6 @@ Français - Wilfried</source>
     </message>
 </context>
 <context>
-    <name>FirstRunIndexModal</name>
-    <message>
-        <source>First-time setup</source>
-        <translation type="vanished">Αρχική ρύθμιση</translation>
-    </message>
-    <message>
-        <source>Indexing paused</source>
-        <translation type="vanished">Ευρετηρίαση σε παύση</translation>
-    </message>
-    <message>
-        <source>Optimizing database - almost done</source>
-        <translation type="vanished">Βελτιστοποίηση βάσης δεδομένων – σχεδόν έτοιμο</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2 - %3</source>
-        <translation type="vanished">Βήμα %1 από %2 – %3</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2</source>
-        <translation type="vanished">Βήμα %1 από %2</translation>
-    </message>
-    <message>
-        <source>Preparing…</source>
-        <translation type="vanished">Προετοιμασία…</translation>
-    </message>
-    <message>
-        <source>Done. %1 files indexed.</source>
-        <translation type="vanished">Ολοκληρώθηκε. %1 αρχεία ευρετηριάστηκαν.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Ακύρωση</translation>
-    </message>
-    <message>
-        <source>Start scan</source>
-        <translation type="vanished">Έναρξη σάρωσης</translation>
-    </message>
-</context>
-<context>
     <name>GameInfoModal</name>
     <message>
         <location filename="../components/GameInfoModal.qml" line="153"/>
@@ -540,6 +501,26 @@ Français - Wilfried</source>
         <translation>Αγαπημένα</translation>
     </message>
     <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>Updating the media database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>No games found yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Your games appear here as Core finds them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Update media database in Settings &gt; Library.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Recently Played</source>
         <translation type="vanished">Πρόσφατα Παιγμένα</translation>
     </message>
@@ -569,35 +550,44 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
-        <translation>Δεν υπάρχουν διαθέσιμα συστήματα. Εκτελέστε Ενημέρωση βάσης δεδομένων από τις Ρυθμίσεις.</translation>
+        <translation type="vanished">Δεν υπάρχουν διαθέσιμα συστήματα. Εκτελέστε Ενημέρωση βάσης δεδομένων από τις Ρυθμίσεις.</translation>
     </message>
 </context>
 <context>
     <name>IndexSetupModal</name>
     <message>
         <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Start</source>
+        <translation type="unfinished">Έναρξη</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Change</source>
+        <translation type="unfinished">Αλλαγή</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="51"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="47"/>
+        <location filename="../components/IndexSetupModal.qml" line="53"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="115"/>
+        <location filename="../components/IndexSetupModal.qml" line="121"/>
         <source>Update media database</source>
         <translation type="unfinished">Ενημέρωση βάσης δεδομένων</translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="124"/>
+        <location filename="../components/IndexSetupModal.qml" line="130"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="137"/>
+        <location filename="../components/IndexSetupModal.qml" line="143"/>
         <source>Start update</source>
         <translation type="unfinished"></translation>
     </message>
@@ -675,29 +665,29 @@ Français - Wilfried</source>
         <translation type="vanished">Εκκίνηση Core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
-        <location filename="../app/Main.qml" line="2330"/>
-        <location filename="../app/Main.qml" line="2393"/>
-        <location filename="../app/Main.qml" line="2699"/>
-        <location filename="../app/Main.qml" line="3741"/>
-        <location filename="../app/Main.qml" line="3784"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
+        <location filename="../app/Main.qml" line="2341"/>
+        <location filename="../app/Main.qml" line="2410"/>
+        <location filename="../app/Main.qml" line="2716"/>
+        <location filename="../app/Main.qml" line="3795"/>
+        <location filename="../app/Main.qml" line="3838"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Remove from favorites</source>
         <translation>Αφαίρεση από αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Add to favorites</source>
         <translation>Προσθήκη στα αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2264"/>
-        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2266"/>
+        <location filename="../app/Main.qml" line="2346"/>
         <source>Write to NFC token</source>
         <translation>Εγγραφή σε NFC token</translation>
     </message>
@@ -706,53 +696,76 @@ Français - Wilfried</source>
         <translation type="vanished">Κωδικός QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
-        <location filename="../app/Main.qml" line="2308"/>
+        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2319"/>
         <source>Launch game</source>
         <translation>Εκκίνηση παιχνιδιού</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1070"/>
-        <location filename="../app/Main.qml" line="3417"/>
-        <location filename="../app/Main.qml" line="3464"/>
-        <location filename="../app/Main.qml" line="3474"/>
+        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3518"/>
+        <location filename="../app/Main.qml" line="3528"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3153"/>
+        <source>Get metadata failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3154"/>
+        <source>Could not start getting metadata. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3156"/>
+        <source>Source list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3157"/>
+        <source>Could not load the list of metadata sources. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3307"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4848"/>
+        <location filename="../app/Main.qml" line="4902"/>
         <source>Loading systems…</source>
         <translation>Φόρτωση συστημάτων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4855"/>
+        <location filename="../app/Main.qml" line="4909"/>
         <source>Loading favorites…</source>
         <translation>Φόρτωση αγαπημένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4850"/>
+        <location filename="../app/Main.qml" line="4904"/>
         <source>Loading games…</source>
         <translation>Φόρτωση παιχνιδιών…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2183"/>
-        <location filename="../app/Main.qml" line="2218"/>
+        <location filename="../app/Main.qml" line="2185"/>
+        <location filename="../app/Main.qml" line="2220"/>
         <source>Update media database</source>
         <translation type="unfinished">Ενημέρωση βάσης δεδομένων</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2186"/>
-        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
-        <translation type="unfinished">Ανάκτηση μεταδεδομένων</translation>
+        <translation type="obsolete">Ανάκτηση μεταδεδομένων</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2179"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
@@ -762,90 +775,90 @@ Français - Wilfried</source>
         <translation type="unfinished">Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2096"/>
+        <location filename="../app/Main.qml" line="2098"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2153"/>
+        <location filename="../app/Main.qml" line="2155"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2179"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2258"/>
-        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2323"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
-        <location filename="../app/Main.qml" line="2346"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2280"/>
+        <location filename="../app/Main.qml" line="2357"/>
+        <location filename="../app/Main.qml" line="2451"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3507"/>
+        <location filename="../app/Main.qml" line="2395"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3561"/>
         <source>Default</source>
         <translation type="unfinished">Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2395"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2230"/>
-        <location filename="../app/Main.qml" line="2238"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="2164"/>
+        <location filename="../app/Main.qml" line="2215"/>
+        <location filename="../app/Main.qml" line="2232"/>
+        <location filename="../app/Main.qml" line="2240"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3454"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3445"/>
+        <location filename="../app/Main.qml" line="3499"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3460"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3511"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3565"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3482"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3515"/>
+        <location filename="../app/Main.qml" line="3569"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3436"/>
+        <location filename="../app/Main.qml" line="3490"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -870,45 +883,46 @@ Français - Wilfried</source>
         <translation type="unfinished">Έξοδος</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2173"/>
-        <location filename="../app/Main.qml" line="2282"/>
-        <location filename="../app/Main.qml" line="2301"/>
-        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2284"/>
+        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2361"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2268"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2270"/>
+        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2807"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2461"/>
+        <location filename="../app/Main.qml" line="2478"/>
         <source>Move</source>
         <translation type="unfinished">Μετακίνηση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2667"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1032"/>
-        <location filename="../app/Main.qml" line="3043"/>
-        <location filename="../app/Main.qml" line="3065"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3131"/>
+        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3174"/>
         <source>OK</source>
         <translation type="unfinished">Εντάξει</translation>
     </message>
@@ -923,226 +937,224 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="2188"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2293"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2807"/>
+        <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Scan this code to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3132"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3098"/>
+        <location filename="../app/Main.qml" line="3141"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3099"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3101"/>
+        <location filename="../app/Main.qml" line="3144"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3147"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3105"/>
+        <location filename="../app/Main.qml" line="3148"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3107"/>
+        <location filename="../app/Main.qml" line="3150"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3151"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3110"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3111"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3113"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3114"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3116"/>
+        <location filename="../app/Main.qml" line="3159"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3120"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3122"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3123"/>
+        <location filename="../app/Main.qml" line="3166"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3125"/>
+        <location filename="../app/Main.qml" line="3168"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3126"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3128"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3129"/>
+        <location filename="../app/Main.qml" line="3172"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3253"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3269"/>
+        <location filename="../app/Main.qml" line="3323"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3278"/>
+        <location filename="../app/Main.qml" line="3332"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3307"/>
+        <location filename="../app/Main.qml" line="3361"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3446"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3432"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3486"/>
         <source>Favorites</source>
         <translation type="unfinished">Αγαπημένα</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3415"/>
-        <location filename="../app/Main.qml" line="3461"/>
+        <location filename="../app/Main.qml" line="3469"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3449"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3503"/>
+        <location filename="../app/Main.qml" line="3525"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3489"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3485"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3492"/>
+        <location filename="../app/Main.qml" line="3546"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3708"/>
+        <location filename="../app/Main.qml" line="3762"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3119"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
-        <location filename="../app/Main.qml" line="3318"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="2910"/>
+        <location filename="../app/Main.qml" line="3372"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Retry</source>
         <translation type="unfinished">Επανάληψη</translation>
     </message>
@@ -1151,22 +1163,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4852"/>
+        <location filename="../app/Main.qml" line="4906"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4857"/>
+        <location filename="../app/Main.qml" line="4911"/>
         <source>Loading recently played…</source>
         <translation>Φόρτωση πρόσφατα παιγμένων…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4859"/>
+        <location filename="../app/Main.qml" line="4913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4861"/>
+        <location filename="../app/Main.qml" line="4915"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>
@@ -1174,7 +1186,7 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Writing failed</source>
         <translation>Αποτυχία εγγραφής</translation>
     </message>
@@ -1183,82 +1195,83 @@ Français - Wilfried</source>
         <translation type="vanished">Τοποθετήστε μια εγγράψιμη κάρτα κοντά στον αναγνώστη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="936"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="943"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="1365"/>
         <source>OK</source>
         <translation type="unfinished">Εντάξει</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="535"/>
+        <location filename="../app/MainLayout.qml" line="541"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Hold a writable token near the reader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
         <source>Are you sure you want to exit?</source>
         <translation>Είστε σίγουροι ότι θέλετε να βγείτε;</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1387"/>
+        <location filename="../app/MainLayout.qml" line="1409"/>
         <source>Select</source>
         <translation>Επιλογή</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1283"/>
-        <location filename="../app/MainLayout.qml" line="1297"/>
-        <location filename="../app/MainLayout.qml" line="1312"/>
-        <location filename="../app/MainLayout.qml" line="1323"/>
-        <location filename="../app/MainLayout.qml" line="1349"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1321"/>
+        <location filename="../app/MainLayout.qml" line="1332"/>
+        <location filename="../app/MainLayout.qml" line="1358"/>
         <source>Close</source>
         <translation>Κλείσιμο</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1425"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1339"/>
+        <location filename="../app/MainLayout.qml" line="1391"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1308"/>
+        <location filename="../app/MainLayout.qml" line="1317"/>
         <source>Done</source>
         <translation>Ολοκληρώθηκε</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1338"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
         <source>I understand</source>
         <translation>Κατανοώ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1376"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1389"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1267,28 +1280,29 @@ Français - Wilfried</source>
         <translation type="vanished">Έναρξη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1656"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Scroll</source>
         <translation>Κύλιση</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1468"/>
-        <location filename="../app/MainLayout.qml" line="1555"/>
-        <location filename="../app/MainLayout.qml" line="1573"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
-        <location filename="../app/MainLayout.qml" line="1724"/>
+        <location filename="../app/MainLayout.qml" line="1500"/>
+        <location filename="../app/MainLayout.qml" line="1587"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1737"/>
+        <location filename="../app/MainLayout.qml" line="1756"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1374"/>
-        <location filename="../app/MainLayout.qml" line="1454"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1596"/>
-        <location filename="../app/MainLayout.qml" line="1615"/>
-        <location filename="../app/MainLayout.qml" line="1688"/>
+        <location filename="../app/MainLayout.qml" line="1284"/>
+        <location filename="../app/MainLayout.qml" line="1383"/>
+        <location filename="../app/MainLayout.qml" line="1405"/>
+        <location filename="../app/MainLayout.qml" line="1486"/>
+        <location filename="../app/MainLayout.qml" line="1523"/>
+        <location filename="../app/MainLayout.qml" line="1572"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1647"/>
+        <location filename="../app/MainLayout.qml" line="1720"/>
         <source>Move</source>
         <translation>Μετακίνηση</translation>
     </message>
@@ -1298,8 +1312,8 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="531"/>
-        <location filename="../app/MainLayout.qml" line="533"/>
+        <location filename="../app/MainLayout.qml" line="537"/>
+        <location filename="../app/MainLayout.qml" line="539"/>
         <source>Favorites</source>
         <translation type="unfinished">Αγαπημένα</translation>
     </message>
@@ -1308,36 +1322,36 @@ Français - Wilfried</source>
         <translation type="obsolete">Πρόσφατα Παιγμένα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="916"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="917"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1096"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1417"/>
+        <location filename="../app/MainLayout.qml" line="1449"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1421"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1496"/>
-        <location filename="../app/MainLayout.qml" line="1545"/>
-        <location filename="../app/MainLayout.qml" line="1601"/>
-        <location filename="../app/MainLayout.qml" line="1693"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1528"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1633"/>
+        <location filename="../app/MainLayout.qml" line="1725"/>
         <source>Open</source>
         <translation>Άνοιγμα</translation>
     </message>
@@ -1346,19 +1360,20 @@ Français - Wilfried</source>
         <translation type="vanished">Έξοδος</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1477"/>
-        <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1513"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1559"/>
-        <location filename="../app/MainLayout.qml" line="1577"/>
-        <location filename="../app/MainLayout.qml" line="1589"/>
-        <location filename="../app/MainLayout.qml" line="1605"/>
-        <location filename="../app/MainLayout.qml" line="1639"/>
-        <location filename="../app/MainLayout.qml" line="1660"/>
-        <location filename="../app/MainLayout.qml" line="1669"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
-        <location filename="../app/MainLayout.qml" line="1728"/>
+        <location filename="../app/MainLayout.qml" line="1413"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1561"/>
+        <location filename="../app/MainLayout.qml" line="1591"/>
+        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1621"/>
+        <location filename="../app/MainLayout.qml" line="1637"/>
+        <location filename="../app/MainLayout.qml" line="1671"/>
+        <location filename="../app/MainLayout.qml" line="1692"/>
+        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1741"/>
+        <location filename="../app/MainLayout.qml" line="1760"/>
         <source>Back</source>
         <translation>Πίσω</translation>
     </message>
@@ -1367,29 +1382,29 @@ Français - Wilfried</source>
         <translation type="vanished">Σελίδα</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1464"/>
-        <location filename="../app/MainLayout.qml" line="1499"/>
-        <location filename="../app/MainLayout.qml" line="1550"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1531"/>
+        <location filename="../app/MainLayout.qml" line="1582"/>
+        <location filename="../app/MainLayout.qml" line="1730"/>
         <source>Options</source>
         <translation>Επιλογές</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1509"/>
-        <location filename="../app/MainLayout.qml" line="1567"/>
-        <location filename="../app/MainLayout.qml" line="1716"/>
+        <location filename="../app/MainLayout.qml" line="1328"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1541"/>
+        <location filename="../app/MainLayout.qml" line="1599"/>
+        <location filename="../app/MainLayout.qml" line="1748"/>
         <source>Retry</source>
         <translation>Επανάληψη</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1624"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Change</source>
         <translation>Αλλαγή</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1630"/>
+        <location filename="../app/MainLayout.qml" line="1662"/>
         <source>Toggle</source>
         <translation>Εναλλαγή</translation>
     </message>
@@ -1450,12 +1465,12 @@ Français - Wilfried</source>
 <context>
     <name>QrCodeModal</name>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="23"/>
+        <location filename="../components/QrCodeModal.qml" line="19"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="43"/>
+        <location filename="../components/QrCodeModal.qml" line="20"/>
         <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1485,43 +1500,67 @@ Français - Wilfried</source>
 <context>
     <name>ScrapeSetupModal</name>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="67"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Start</source>
+        <translation type="unfinished">Έναρξη</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Toggle</source>
+        <translation type="unfinished">Εναλλαγή</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Change</source>
+        <translation type="unfinished">Αλλαγή</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="89"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="69"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="91"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="171"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="193"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
+        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <source>Loading sources…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <source>Replace existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <source>Start import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scrape metadata</source>
-        <translation type="unfinished">Ανάκτηση μεταδεδομένων</translation>
+        <translation type="obsolete">Ανάκτηση μεταδεδομένων</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="185"/>
-        <source>Loading scrapers…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="196"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
         <source>Systems</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="222"/>
-        <source>Re-scrape existing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
-        <source>Start scrape</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1533,17 +1572,17 @@ Français - Wilfried</source>
         <translation>Τίποτα εδώ</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="36"/>
         <source>Loading…</source>
         <translation>Φόρτωση…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="37"/>
         <source>Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="79"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="85"/>
         <source>Failed to load</source>
         <translation>Αποτυχία φόρτωσης</translation>
     </message>
@@ -1553,8 +1592,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="114"/>
         <location filename="../screens/SettingsScreen.qml" line="205"/>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
-        <location filename="../screens/SettingsScreen.qml" line="972"/>
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="978"/>
         <source>Language</source>
         <translation>Γλώσσα</translation>
     </message>
@@ -1578,50 +1617,49 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="165"/>
-        <location filename="../screens/SettingsScreen.qml" line="999"/>
+        <location filename="../screens/SettingsScreen.qml" line="1005"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="225"/>
-        <location filename="../screens/SettingsScreen.qml" line="1051"/>
+        <location filename="../screens/SettingsScreen.qml" line="1057"/>
         <source>Button style</source>
         <translation>Στυλ κουμπιών</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="1060"/>
+        <location filename="../screens/SettingsScreen.qml" line="1066"/>
         <source>Screensaver</source>
         <translation>Προφύλαξη οθόνης</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Library</source>
         <translation>Βιβλιοθήκη</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="291"/>
-        <location filename="../screens/SettingsScreen.qml" line="1069"/>
+        <location filename="../screens/SettingsScreen.qml" line="1075"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Scrape metadata</source>
-        <translation>Ανάκτηση μεταδεδομένων</translation>
+        <translation type="vanished">Ανάκτηση μεταδεδομένων</translation>
     </message>
     <message>
         <source>Advanced</source>
         <translation type="vanished">Για προχωρημένους</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <location filename="../screens/SettingsScreen.qml" line="323"/>
         <source>Debug logging</source>
         <translation>Καταγραφή εντοπισμού σφαλμάτων</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="323"/>
+        <location filename="../screens/SettingsScreen.qml" line="329"/>
         <source>Upload log file</source>
         <translation>Αποστολή αρχείου καταγραφής</translation>
     </message>
@@ -1632,7 +1670,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="217"/>
-        <location filename="../screens/SettingsScreen.qml" line="981"/>
+        <location filename="../screens/SettingsScreen.qml" line="987"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1643,13 +1681,13 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="158"/>
-        <location filename="../screens/SettingsScreen.qml" line="963"/>
+        <location filename="../screens/SettingsScreen.qml" line="969"/>
         <source>Interface resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="129"/>
-        <location filename="../screens/SettingsScreen.qml" line="1035"/>
+        <location filename="../screens/SettingsScreen.qml" line="1041"/>
         <source>Color scheme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1665,7 +1703,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <location filename="../screens/SettingsScreen.qml" line="1078"/>
+        <location filename="../screens/SettingsScreen.qml" line="1084"/>
         <source>Video standard</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1676,7 +1714,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="135"/>
-        <location filename="../screens/SettingsScreen.qml" line="1026"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
         <source>System logos</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1697,19 +1735,19 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="90"/>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="120"/>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="211"/>
-        <location filename="../screens/SettingsScreen.qml" line="990"/>
+        <location filename="../screens/SettingsScreen.qml" line="996"/>
         <source>Region</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1719,35 +1757,34 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Optimizing</source>
         <translation>Βελτιστοποίηση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>Paused</source>
         <translation>Σε παύση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>In progress</source>
         <translation>Σε εξέλιξη</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>%1 indexed</source>
         <translation>%1 ευρετηριάστηκαν</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>%1 scraped</source>
-        <translation>%1 συλλέχθηκαν</translation>
+        <translation type="vanished">%1 συλλέχθηκαν</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Cancel</source>
         <translation>Ακύρωση</translation>
     </message>
@@ -1756,117 +1793,117 @@ Français - Wilfried</source>
         <translation type="vanished">Έναρξη</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Upload</source>
         <translation>Μεταφόρτωση</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="650"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Open</source>
         <translation>Άνοιγμα</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>%1 × %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Automatic (Recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="717"/>
         <source>%1 (Animations off)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="758"/>
         <source>English</source>
         <translation>Αγγλικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="760"/>
         <source>Italian</source>
         <translation>Ιταλικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="756"/>
+        <location filename="../screens/SettingsScreen.qml" line="762"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="758"/>
+        <location filename="../screens/SettingsScreen.qml" line="764"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="760"/>
+        <location filename="../screens/SettingsScreen.qml" line="766"/>
         <source>German</source>
         <translation>Γερμανικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="762"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Greek</source>
         <translation>Ελληνικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="764"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Japanese</source>
         <translation>Ιαπωνικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="766"/>
+        <location filename="../screens/SettingsScreen.qml" line="772"/>
         <source>Korean</source>
         <translation>Κορεατικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Dutch</source>
         <translation>Ολλανδικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="776"/>
         <source>Romanian</source>
         <translation>Ρουμανικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="778"/>
         <source>Slovak</source>
         <translation>Σλοβακικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="774"/>
+        <location filename="../screens/SettingsScreen.qml" line="780"/>
         <source>Ukrainian</source>
         <translation>Ουκρανικά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="776"/>
+        <location filename="../screens/SettingsScreen.qml" line="782"/>
         <source>Chinese (Simplified)</source>
         <translation>Κινεζικά (Απλοποιημένα)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="778"/>
+        <location filename="../screens/SettingsScreen.qml" line="784"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="780"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Hebrew</source>
         <translation>Εβραϊκά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="782"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="784"/>
+        <location filename="../screens/SettingsScreen.qml" line="790"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>French</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1875,37 +1912,37 @@ Français - Wilfried</source>
         <translation type="vanished">Αυτόματο</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="792"/>
+        <location filename="../screens/SettingsScreen.qml" line="798"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="794"/>
+        <location filename="../screens/SettingsScreen.qml" line="800"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="805"/>
+        <location filename="../screens/SettingsScreen.qml" line="811"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="807"/>
+        <location filename="../screens/SettingsScreen.qml" line="813"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="809"/>
+        <location filename="../screens/SettingsScreen.qml" line="815"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
-        <location filename="../screens/SettingsScreen.qml" line="787"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
-        <location filename="../screens/SettingsScreen.qml" line="810"/>
-        <location filename="../screens/SettingsScreen.qml" line="877"/>
-        <location filename="../screens/SettingsScreen.qml" line="925"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="793"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
+        <location filename="../screens/SettingsScreen.qml" line="816"/>
+        <location filename="../screens/SettingsScreen.qml" line="883"/>
+        <location filename="../screens/SettingsScreen.qml" line="931"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1960,19 +1997,14 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Downloads box art, descriptions, and tags for your games. Choose a source and which systems.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
-        <location filename="../screens/SettingsScreen.qml" line="1008"/>
+        <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="285"/>
-        <location filename="../screens/SettingsScreen.qml" line="1017"/>
+        <location filename="../screens/SettingsScreen.qml" line="1023"/>
         <source>Games layout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1987,93 +2019,93 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <location filename="../screens/SettingsScreen.qml" line="324"/>
         <source>Writes extra detail to the log file to help track down a problem. Restarts the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Configure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="815"/>
+        <location filename="../screens/SettingsScreen.qml" line="821"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="817"/>
+        <location filename="../screens/SettingsScreen.qml" line="823"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="818"/>
+        <location filename="../screens/SettingsScreen.qml" line="824"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="823"/>
+        <location filename="../screens/SettingsScreen.qml" line="829"/>
         <source>Detailed list view</source>
         <translation>Λεπτομερής προβολή λίστας</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="824"/>
+        <location filename="../screens/SettingsScreen.qml" line="830"/>
         <source>Grid view</source>
         <translation>Προβολή πλέγματος</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="829"/>
+        <location filename="../screens/SettingsScreen.qml" line="835"/>
         <source>Full color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="830"/>
+        <location filename="../screens/SettingsScreen.qml" line="836"/>
         <source>Tinted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="868"/>
+        <location filename="../screens/SettingsScreen.qml" line="874"/>
         <source>Style B</source>
         <translation>Στυλ B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="870"/>
+        <location filename="../screens/SettingsScreen.qml" line="876"/>
         <source>Style C</source>
         <translation>Στυλ C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="872"/>
+        <location filename="../screens/SettingsScreen.qml" line="878"/>
         <source>Style D</source>
         <translation>Στυλ D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="874"/>
+        <location filename="../screens/SettingsScreen.qml" line="880"/>
         <source>Style E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="876"/>
+        <location filename="../screens/SettingsScreen.qml" line="882"/>
         <source>Style A</source>
         <translation>Στυλ A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="917"/>
+        <location filename="../screens/SettingsScreen.qml" line="923"/>
         <source>PAL (50 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="919"/>
+        <location filename="../screens/SettingsScreen.qml" line="925"/>
         <source>480i (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="920"/>
+        <location filename="../screens/SettingsScreen.qml" line="926"/>
         <source>NTSC (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1905"/>
+        <location filename="../screens/SettingsScreen.qml" line="1911"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2082,47 +2114,47 @@ Français - Wilfried</source>
         <translation type="vanished">Προεπιλογή</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="892"/>
+        <location filename="../screens/SettingsScreen.qml" line="898"/>
         <source>Off</source>
         <translation>Απενεργοποιημένο</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="894"/>
+        <location filename="../screens/SettingsScreen.qml" line="900"/>
         <source>1 second (testing)</source>
         <translation>1 δευτερόλεπτο (δοκιμή)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="896"/>
+        <location filename="../screens/SettingsScreen.qml" line="902"/>
         <source>1 minute</source>
         <translation>1 λεπτό</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="898"/>
+        <location filename="../screens/SettingsScreen.qml" line="904"/>
         <source>2 minutes</source>
         <translation>2 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="900"/>
+        <location filename="../screens/SettingsScreen.qml" line="906"/>
         <source>5 minutes</source>
         <translation>5 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="902"/>
+        <location filename="../screens/SettingsScreen.qml" line="908"/>
         <source>10 minutes</source>
         <translation>10 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="904"/>
+        <location filename="../screens/SettingsScreen.qml" line="910"/>
         <source>15 minutes</source>
         <translation>15 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="906"/>
+        <location filename="../screens/SettingsScreen.qml" line="912"/>
         <source>30 minutes</source>
         <translation>30 λεπτά</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="907"/>
+        <location filename="../screens/SettingsScreen.qml" line="913"/>
         <source>%1 seconds</source>
         <translation>%1 δευτερόλεπτα</translation>
     </message>
@@ -2132,93 +2164,93 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="108"/>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="855"/>
+        <location filename="../screens/SettingsScreen.qml" line="861"/>
         <source>Nord</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="852"/>
+        <location filename="../screens/SettingsScreen.qml" line="858"/>
         <source>Dracula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="859"/>
+        <location filename="../screens/SettingsScreen.qml" line="865"/>
         <source>Synthwave &apos;84</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="846"/>
+        <location filename="../screens/SettingsScreen.qml" line="852"/>
         <source>Amber Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="848"/>
+        <location filename="../screens/SettingsScreen.qml" line="854"/>
         <source>Green Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="849"/>
+        <location filename="../screens/SettingsScreen.qml" line="855"/>
         <source>Neo Geo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="850"/>
+        <location filename="../screens/SettingsScreen.qml" line="856"/>
         <source>NES</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="851"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>Virtual Boy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="854"/>
+        <location filename="../screens/SettingsScreen.qml" line="860"/>
         <source>Gruvbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="853"/>
+        <location filename="../screens/SettingsScreen.qml" line="859"/>
         <source>Everforest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="858"/>
+        <location filename="../screens/SettingsScreen.qml" line="864"/>
         <source>Solarized Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="863"/>
         <source>Rosé Pine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="856"/>
+        <location filename="../screens/SettingsScreen.qml" line="862"/>
         <source>Oxocarbon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="860"/>
+        <location filename="../screens/SettingsScreen.qml" line="866"/>
         <source>Flexoki Paper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="861"/>
+        <location filename="../screens/SettingsScreen.qml" line="867"/>
         <source>Solarized Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="847"/>
+        <location filename="../screens/SettingsScreen.qml" line="853"/>
         <source>Game Boy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2268,6 +2300,16 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="269"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="280"/>
         <source>Show systems as a grid of covers, or as a list with details beside it.</source>
         <translation type="unfinished"></translation>
@@ -2288,92 +2330,107 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="324"/>
+        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <source>Shows a code you can scan to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="330"/>
         <source>Uploads the log file and gives you a link to share when reporting a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="927"/>
-        <source>Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="929"/>
-        <source>Thumbnail</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="931"/>
-        <source>Box art</source>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <source>%1 imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="933"/>
-        <source>3D box art</source>
+        <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="935"/>
-        <source>Screenshot</source>
+        <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="937"/>
-        <source>Wheel</source>
+        <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="939"/>
-        <source>Title screen</source>
+        <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="941"/>
-        <source>Map</source>
+        <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="943"/>
-        <source>Marquee</source>
+        <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="945"/>
-        <source>Fan art</source>
+        <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="947"/>
-        <source>Box side</source>
+        <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="949"/>
+        <source>Marquee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="951"/>
+        <source>Fan art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="953"/>
+        <source>Box side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="955"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="355"/>
+        <location filename="../screens/SettingsScreen.qml" line="361"/>
         <source>Settings</source>
         <translation>Ρυθμίσεις</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="843"/>
+        <location filename="../screens/SettingsScreen.qml" line="849"/>
         <source>Zaparoo Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="844"/>
+        <location filename="../screens/SettingsScreen.qml" line="850"/>
         <source>Zaparoo Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="845"/>
+        <location filename="../screens/SettingsScreen.qml" line="851"/>
         <source>Classic Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1887"/>
+        <location filename="../screens/SettingsScreen.qml" line="1893"/>
         <source>No settings available on this platform</source>
         <translation>Δεν υπάρχουν διαθέσιμες ρυθμίσεις για αυτή την πλατφόρμα</translation>
     </message>
@@ -2412,9 +2469,33 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/StatusLine.qml" line="105"/>
+        <source>Importing paused: game running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Import failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Imported %1 of %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scraping…</source>
-        <translation type="unfinished">Γίνεται συλλογή…</translation>
+        <translation type="obsolete">Γίνεται συλλογή…</translation>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
@@ -2443,16 +2524,6 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="105"/>
-        <source>Scraping paused: game running</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="106"/>
-        <source>Scraping: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>%1 files</source>
         <translation type="obsolete">%1 αρχεία</translation>
     </message>
@@ -2468,16 +2539,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scraped %1 of %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -2110,7 +2110,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1911"/>
+        <location filename="../screens/SettingsScreen.qml" line="1913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2430,7 +2430,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1893"/>
+        <location filename="../screens/SettingsScreen.qml" line="1895"/>
         <source>No settings available on this platform</source>
         <translation>Δεν υπάρχουν διαθέσιμες ρυθμίσεις για αυτή την πλατφόρμα</translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -35,8 +35,8 @@
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="212"/>
-        <source>Commercial licensing: legal@zaparoo.org</source>
-        <translation>Εμπορική αδειοδότηση: legal@zaparoo.org</translation>
+        <source>Commercial licensing: legal@zaparoo.com</source>
+        <translation>Εμπορική αδειοδότηση: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="223"/>
@@ -227,8 +227,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="116"/>
-        <source>Contact: legal@zaparoo.org</source>
-        <translation>Επικοινωνία: legal@zaparoo.org</translation>
+        <source>Contact: legal@zaparoo.com</source>
+        <translation>Επικοινωνία: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="127"/>
@@ -1530,27 +1530,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
-        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <source>Documentation: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="225"/>
         <source>Loading sources…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="262"/>
         <source>Replace existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="276"/>
         <source>Start import</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1559,7 +1559,7 @@ Français - Wilfried</source>
         <translation type="obsolete">Ανάκτηση μεταδεδομένων</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="249"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_el.ts
+++ b/src/ui/translations/frontend_el.ts
@@ -1997,6 +1997,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
         <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
@@ -2302,11 +2307,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Get metadata</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -1711,6 +1711,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="298"/>
         <source>Shows hidden systems and categories, marked as hidden, so you can unhide them.</source>
         <translation type="unfinished"></translation>
@@ -2195,11 +2200,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Get metadata</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -35,7 +35,7 @@
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="212"/>
-        <source>Commercial licensing: legal@zaparoo.org</source>
+        <source>Commercial licensing: legal@zaparoo.com</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -227,7 +227,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="116"/>
-        <source>Contact: legal@zaparoo.org</source>
+        <source>Contact: legal@zaparoo.com</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -1456,32 +1456,32 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
-        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <source>Documentation: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="225"/>
         <source>Loading sources…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="262"/>
         <source>Replace existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="276"/>
         <source>Start import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="249"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -2001,7 +2001,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1911"/>
+        <location filename="../screens/SettingsScreen.qml" line="1913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2328,7 +2328,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1893"/>
+        <location filename="../screens/SettingsScreen.qml" line="1895"/>
         <source>No settings available on this platform</source>
         <translation>No settings available on this platform</translation>
     </message>

--- a/src/ui/translations/frontend_en.ts
+++ b/src/ui/translations/frontend_en.ts
@@ -347,13 +347,6 @@ Français - Wilfried</source>
     </message>
 </context>
 <context>
-    <name>FirstRunIndexModal</name>
-    <message>
-        <source>Cancel</source>
-        <translation type="obsolete">Cancel</translation>
-    </message>
-</context>
-<context>
     <name>GameInfoModal</name>
     <message>
         <location filename="../components/GameInfoModal.qml" line="153"/>
@@ -470,6 +463,26 @@ Français - Wilfried</source>
         <translation>Favorites</translation>
     </message>
     <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>Updating the media database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>No games found yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Your games appear here as Core finds them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Update media database in Settings &gt; Library.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Recently Played</source>
         <translation type="vanished">Recently Played</translation>
     </message>
@@ -498,36 +511,41 @@ Français - Wilfried</source>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <location filename="../screens/HubScreen.qml" line="1609"/>
-        <source>No systems available. Run Update media database from Settings.</source>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>IndexSetupModal</name>
     <message>
         <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Change</source>
+        <translation type="unfinished">Change</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="51"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="47"/>
+        <location filename="../components/IndexSetupModal.qml" line="53"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="115"/>
+        <location filename="../components/IndexSetupModal.qml" line="121"/>
         <source>Update media database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="124"/>
+        <location filename="../components/IndexSetupModal.qml" line="130"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="137"/>
+        <location filename="../components/IndexSetupModal.qml" line="143"/>
         <source>Start update</source>
         <translation type="unfinished"></translation>
     </message>
@@ -589,80 +607,99 @@ Français - Wilfried</source>
 <context>
     <name>Main</name>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
-        <location filename="../app/Main.qml" line="2330"/>
-        <location filename="../app/Main.qml" line="2393"/>
-        <location filename="../app/Main.qml" line="2699"/>
-        <location filename="../app/Main.qml" line="3741"/>
-        <location filename="../app/Main.qml" line="3784"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
+        <location filename="../app/Main.qml" line="2341"/>
+        <location filename="../app/Main.qml" line="2410"/>
+        <location filename="../app/Main.qml" line="2716"/>
+        <location filename="../app/Main.qml" line="3795"/>
+        <location filename="../app/Main.qml" line="3838"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Remove from favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Add to favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2264"/>
-        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2266"/>
+        <location filename="../app/Main.qml" line="2346"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Write to NFC token</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
-        <location filename="../app/Main.qml" line="2308"/>
+        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2319"/>
         <source>Launch game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1070"/>
-        <location filename="../app/Main.qml" line="3417"/>
-        <location filename="../app/Main.qml" line="3464"/>
-        <location filename="../app/Main.qml" line="3474"/>
+        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3518"/>
+        <location filename="../app/Main.qml" line="3528"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3153"/>
+        <source>Get metadata failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3154"/>
+        <source>Could not start getting metadata. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3156"/>
+        <source>Source list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3157"/>
+        <source>Could not load the list of metadata sources. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3307"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4848"/>
+        <location filename="../app/Main.qml" line="4902"/>
         <source>Loading systems…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4855"/>
+        <location filename="../app/Main.qml" line="4909"/>
         <source>Loading favorites…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4850"/>
+        <location filename="../app/Main.qml" line="4904"/>
         <source>Loading games…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2183"/>
-        <location filename="../app/Main.qml" line="2218"/>
+        <location filename="../app/Main.qml" line="2185"/>
+        <location filename="../app/Main.qml" line="2220"/>
         <source>Update media database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2186"/>
-        <location filename="../app/Main.qml" line="2221"/>
-        <source>Scrape metadata</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2179"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
@@ -672,90 +709,90 @@ Français - Wilfried</source>
         <translation type="unfinished">Settings</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2096"/>
+        <location filename="../app/Main.qml" line="2098"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2153"/>
+        <location filename="../app/Main.qml" line="2155"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2179"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2258"/>
-        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2323"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
-        <location filename="../app/Main.qml" line="2346"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2280"/>
+        <location filename="../app/Main.qml" line="2357"/>
+        <location filename="../app/Main.qml" line="2451"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3507"/>
+        <location filename="../app/Main.qml" line="2395"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3561"/>
         <source>Default</source>
         <translation type="unfinished">Default</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2395"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2230"/>
-        <location filename="../app/Main.qml" line="2238"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="2164"/>
+        <location filename="../app/Main.qml" line="2215"/>
+        <location filename="../app/Main.qml" line="2232"/>
+        <location filename="../app/Main.qml" line="2240"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3454"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3445"/>
+        <location filename="../app/Main.qml" line="3499"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3460"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3511"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3565"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3482"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3515"/>
+        <location filename="../app/Main.qml" line="3569"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3436"/>
+        <location filename="../app/Main.qml" line="3490"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -780,45 +817,46 @@ Français - Wilfried</source>
         <translation type="unfinished">Quit</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2173"/>
-        <location filename="../app/Main.qml" line="2282"/>
-        <location filename="../app/Main.qml" line="2301"/>
-        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2284"/>
+        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2361"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2268"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2270"/>
+        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2807"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2461"/>
+        <location filename="../app/Main.qml" line="2478"/>
         <source>Move</source>
         <translation type="unfinished">Move</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2667"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1032"/>
-        <location filename="../app/Main.qml" line="3043"/>
-        <location filename="../app/Main.qml" line="3065"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3131"/>
+        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3174"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
@@ -833,226 +871,224 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="2188"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2293"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2807"/>
+        <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Scan this code to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3132"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3098"/>
+        <location filename="../app/Main.qml" line="3141"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3099"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3101"/>
+        <location filename="../app/Main.qml" line="3144"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3147"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3105"/>
+        <location filename="../app/Main.qml" line="3148"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3107"/>
+        <location filename="../app/Main.qml" line="3150"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3151"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3110"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3111"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3113"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3114"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3116"/>
+        <location filename="../app/Main.qml" line="3159"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3120"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3122"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3123"/>
+        <location filename="../app/Main.qml" line="3166"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3125"/>
+        <location filename="../app/Main.qml" line="3168"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3126"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3128"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3129"/>
+        <location filename="../app/Main.qml" line="3172"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3253"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3269"/>
+        <location filename="../app/Main.qml" line="3323"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3278"/>
+        <location filename="../app/Main.qml" line="3332"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3307"/>
+        <location filename="../app/Main.qml" line="3361"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3446"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3432"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3486"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorites</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3415"/>
-        <location filename="../app/Main.qml" line="3461"/>
+        <location filename="../app/Main.qml" line="3469"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3449"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3503"/>
+        <location filename="../app/Main.qml" line="3525"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3489"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3485"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3492"/>
+        <location filename="../app/Main.qml" line="3546"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3708"/>
+        <location filename="../app/Main.qml" line="3762"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3119"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
-        <location filename="../app/Main.qml" line="3318"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="2910"/>
+        <location filename="../app/Main.qml" line="3372"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Retry</source>
         <translation type="unfinished">Retry</translation>
     </message>
@@ -1061,22 +1097,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Cancel</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4852"/>
+        <location filename="../app/Main.qml" line="4906"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4857"/>
+        <location filename="../app/Main.qml" line="4911"/>
         <source>Loading recently played…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4859"/>
+        <location filename="../app/Main.qml" line="4913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4861"/>
+        <location filename="../app/Main.qml" line="4915"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>
@@ -1084,7 +1120,7 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Writing failed</source>
         <translation>Writing failed</translation>
     </message>
@@ -1093,118 +1129,120 @@ Français - Wilfried</source>
         <translation type="vanished">Put a writable card near the reader</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="936"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="943"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="1365"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="535"/>
+        <location filename="../app/MainLayout.qml" line="541"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Hold a writable token near the reader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
         <source>Are you sure you want to exit?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1387"/>
+        <location filename="../app/MainLayout.qml" line="1409"/>
         <source>Select</source>
         <translation>Select</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1283"/>
-        <location filename="../app/MainLayout.qml" line="1297"/>
-        <location filename="../app/MainLayout.qml" line="1312"/>
-        <location filename="../app/MainLayout.qml" line="1323"/>
-        <location filename="../app/MainLayout.qml" line="1349"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1321"/>
+        <location filename="../app/MainLayout.qml" line="1332"/>
+        <location filename="../app/MainLayout.qml" line="1358"/>
         <source>Close</source>
         <translation>Close</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1425"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1339"/>
+        <location filename="../app/MainLayout.qml" line="1391"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
         <source>Cancel</source>
         <translation>Cancel</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1308"/>
+        <location filename="../app/MainLayout.qml" line="1317"/>
         <source>Done</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1338"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
         <source>I understand</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1376"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1389"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1417"/>
+        <location filename="../app/MainLayout.qml" line="1449"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1421"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1656"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Scroll</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1468"/>
-        <location filename="../app/MainLayout.qml" line="1555"/>
-        <location filename="../app/MainLayout.qml" line="1573"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
-        <location filename="../app/MainLayout.qml" line="1724"/>
+        <location filename="../app/MainLayout.qml" line="1500"/>
+        <location filename="../app/MainLayout.qml" line="1587"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1737"/>
+        <location filename="../app/MainLayout.qml" line="1756"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1374"/>
-        <location filename="../app/MainLayout.qml" line="1454"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1596"/>
-        <location filename="../app/MainLayout.qml" line="1615"/>
-        <location filename="../app/MainLayout.qml" line="1688"/>
+        <location filename="../app/MainLayout.qml" line="1284"/>
+        <location filename="../app/MainLayout.qml" line="1383"/>
+        <location filename="../app/MainLayout.qml" line="1405"/>
+        <location filename="../app/MainLayout.qml" line="1486"/>
+        <location filename="../app/MainLayout.qml" line="1523"/>
+        <location filename="../app/MainLayout.qml" line="1572"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1647"/>
+        <location filename="../app/MainLayout.qml" line="1720"/>
         <source>Move</source>
         <translation>Move</translation>
     </message>
@@ -1214,8 +1252,8 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="531"/>
-        <location filename="../app/MainLayout.qml" line="533"/>
+        <location filename="../app/MainLayout.qml" line="537"/>
+        <location filename="../app/MainLayout.qml" line="539"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorites</translation>
     </message>
@@ -1224,26 +1262,26 @@ Français - Wilfried</source>
         <translation type="obsolete">Recently Played</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="916"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="917"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1096"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1496"/>
-        <location filename="../app/MainLayout.qml" line="1545"/>
-        <location filename="../app/MainLayout.qml" line="1601"/>
-        <location filename="../app/MainLayout.qml" line="1693"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1528"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1633"/>
+        <location filename="../app/MainLayout.qml" line="1725"/>
         <source>Open</source>
         <translation>Open</translation>
     </message>
@@ -1252,46 +1290,47 @@ Français - Wilfried</source>
         <translation type="vanished">Quit</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1477"/>
-        <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1513"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1559"/>
-        <location filename="../app/MainLayout.qml" line="1577"/>
-        <location filename="../app/MainLayout.qml" line="1589"/>
-        <location filename="../app/MainLayout.qml" line="1605"/>
-        <location filename="../app/MainLayout.qml" line="1639"/>
-        <location filename="../app/MainLayout.qml" line="1660"/>
-        <location filename="../app/MainLayout.qml" line="1669"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
-        <location filename="../app/MainLayout.qml" line="1728"/>
+        <location filename="../app/MainLayout.qml" line="1413"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1561"/>
+        <location filename="../app/MainLayout.qml" line="1591"/>
+        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1621"/>
+        <location filename="../app/MainLayout.qml" line="1637"/>
+        <location filename="../app/MainLayout.qml" line="1671"/>
+        <location filename="../app/MainLayout.qml" line="1692"/>
+        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1741"/>
+        <location filename="../app/MainLayout.qml" line="1760"/>
         <source>Back</source>
         <translation>Back</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1464"/>
-        <location filename="../app/MainLayout.qml" line="1499"/>
-        <location filename="../app/MainLayout.qml" line="1550"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1531"/>
+        <location filename="../app/MainLayout.qml" line="1582"/>
+        <location filename="../app/MainLayout.qml" line="1730"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1509"/>
-        <location filename="../app/MainLayout.qml" line="1567"/>
-        <location filename="../app/MainLayout.qml" line="1716"/>
+        <location filename="../app/MainLayout.qml" line="1328"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1541"/>
+        <location filename="../app/MainLayout.qml" line="1599"/>
+        <location filename="../app/MainLayout.qml" line="1748"/>
         <source>Retry</source>
         <translation>Retry</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1624"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Change</source>
         <translation>Change</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1630"/>
+        <location filename="../app/MainLayout.qml" line="1662"/>
         <source>Toggle</source>
         <translation>Toggle</translation>
     </message>
@@ -1352,12 +1391,12 @@ Français - Wilfried</source>
 <context>
     <name>QrCodeModal</name>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="23"/>
+        <location filename="../components/QrCodeModal.qml" line="19"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="43"/>
+        <location filename="../components/QrCodeModal.qml" line="20"/>
         <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1387,43 +1426,63 @@ Français - Wilfried</source>
 <context>
     <name>ScrapeSetupModal</name>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="67"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Start</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Toggle</source>
+        <translation type="unfinished">Toggle</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Change</source>
+        <translation type="unfinished">Change</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="89"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="69"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="91"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="171"/>
-        <source>Scrape metadata</source>
+        <location filename="../components/ScrapeSetupModal.qml" line="193"/>
+        <source>Get metadata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="185"/>
-        <source>Loading scrapers…</source>
+        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
+        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="196"/>
-        <source>Scraper</source>
+        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <source>Loading sources…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <source>Replace existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <source>Start import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
         <source>Systems</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="222"/>
-        <source>Re-scrape existing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
-        <source>Start scrape</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1435,17 +1494,17 @@ Français - Wilfried</source>
         <translation>Nothing here</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="36"/>
         <source>Loading…</source>
         <translation type="unfinished">Loading…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="37"/>
         <source>Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="79"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="85"/>
         <source>Failed to load</source>
         <translation>Failed to load</translation>
     </message>
@@ -1455,8 +1514,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="114"/>
         <location filename="../screens/SettingsScreen.qml" line="205"/>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
-        <location filename="../screens/SettingsScreen.qml" line="972"/>
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="978"/>
         <source>Language</source>
         <translation>Language</translation>
     </message>
@@ -1476,40 +1535,35 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="165"/>
-        <location filename="../screens/SettingsScreen.qml" line="999"/>
+        <location filename="../screens/SettingsScreen.qml" line="1005"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="225"/>
-        <location filename="../screens/SettingsScreen.qml" line="1051"/>
+        <location filename="../screens/SettingsScreen.qml" line="1057"/>
         <source>Button style</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="1060"/>
+        <location filename="../screens/SettingsScreen.qml" line="1066"/>
         <source>Screensaver</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="291"/>
-        <location filename="../screens/SettingsScreen.qml" line="1069"/>
+        <location filename="../screens/SettingsScreen.qml" line="1075"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="269"/>
-        <source>Scrape metadata</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <location filename="../screens/SettingsScreen.qml" line="323"/>
         <source>Debug logging</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="323"/>
+        <location filename="../screens/SettingsScreen.qml" line="329"/>
         <source>Upload log file</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1520,7 +1574,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="217"/>
-        <location filename="../screens/SettingsScreen.qml" line="981"/>
+        <location filename="../screens/SettingsScreen.qml" line="987"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1531,13 +1585,13 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="158"/>
-        <location filename="../screens/SettingsScreen.qml" line="963"/>
+        <location filename="../screens/SettingsScreen.qml" line="969"/>
         <source>Interface resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="129"/>
-        <location filename="../screens/SettingsScreen.qml" line="1035"/>
+        <location filename="../screens/SettingsScreen.qml" line="1041"/>
         <source>Color scheme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1553,7 +1607,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <location filename="../screens/SettingsScreen.qml" line="1078"/>
+        <location filename="../screens/SettingsScreen.qml" line="1084"/>
         <source>Video standard</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1564,7 +1618,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="135"/>
-        <location filename="../screens/SettingsScreen.qml" line="1026"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
         <source>System logos</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1585,13 +1639,13 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="90"/>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="120"/>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1617,7 +1671,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="211"/>
-        <location filename="../screens/SettingsScreen.qml" line="990"/>
+        <location filename="../screens/SettingsScreen.qml" line="996"/>
         <source>Region</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1657,11 +1711,6 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Downloads box art, descriptions, and tags for your games. Choose a source and which systems.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../screens/SettingsScreen.qml" line="298"/>
         <source>Shows hidden systems and categories, marked as hidden, so you can unhide them.</source>
         <translation type="unfinished"></translation>
@@ -1672,155 +1721,150 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <location filename="../screens/SettingsScreen.qml" line="324"/>
         <source>Writes extra detail to the log file to help track down a problem. Restarts the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Optimizing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>Paused</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>In progress</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>%1 indexed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
-        <source>%1 scraped</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Cancel</source>
         <translation type="unfinished">Cancel</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Upload</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="650"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Open</source>
         <translation type="unfinished">Open</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>%1 × %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Automatic (Recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="717"/>
         <source>%1 (Animations off)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="758"/>
         <source>English</source>
         <translation>English</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="760"/>
         <source>Italian</source>
         <translation>Italian</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="756"/>
+        <location filename="../screens/SettingsScreen.qml" line="762"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="758"/>
+        <location filename="../screens/SettingsScreen.qml" line="764"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="760"/>
+        <location filename="../screens/SettingsScreen.qml" line="766"/>
         <source>German</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="762"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Greek</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="764"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Japanese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="766"/>
+        <location filename="../screens/SettingsScreen.qml" line="772"/>
         <source>Korean</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Dutch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="776"/>
         <source>Romanian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="778"/>
         <source>Slovak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="774"/>
+        <location filename="../screens/SettingsScreen.qml" line="780"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="776"/>
+        <location filename="../screens/SettingsScreen.qml" line="782"/>
         <source>Chinese (Simplified)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="778"/>
+        <location filename="../screens/SettingsScreen.qml" line="784"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="780"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="782"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="784"/>
+        <location filename="../screens/SettingsScreen.qml" line="790"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>French</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1829,130 +1873,130 @@ Français - Wilfried</source>
         <translation type="vanished">Auto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="792"/>
+        <location filename="../screens/SettingsScreen.qml" line="798"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="794"/>
+        <location filename="../screens/SettingsScreen.qml" line="800"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="805"/>
+        <location filename="../screens/SettingsScreen.qml" line="811"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="807"/>
+        <location filename="../screens/SettingsScreen.qml" line="813"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="809"/>
+        <location filename="../screens/SettingsScreen.qml" line="815"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
-        <location filename="../screens/SettingsScreen.qml" line="787"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
-        <location filename="../screens/SettingsScreen.qml" line="810"/>
-        <location filename="../screens/SettingsScreen.qml" line="877"/>
-        <location filename="../screens/SettingsScreen.qml" line="925"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="793"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
+        <location filename="../screens/SettingsScreen.qml" line="816"/>
+        <location filename="../screens/SettingsScreen.qml" line="883"/>
+        <location filename="../screens/SettingsScreen.qml" line="931"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
-        <location filename="../screens/SettingsScreen.qml" line="1008"/>
+        <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="285"/>
-        <location filename="../screens/SettingsScreen.qml" line="1017"/>
+        <location filename="../screens/SettingsScreen.qml" line="1023"/>
         <source>Games layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Configure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="815"/>
+        <location filename="../screens/SettingsScreen.qml" line="821"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="817"/>
+        <location filename="../screens/SettingsScreen.qml" line="823"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="818"/>
+        <location filename="../screens/SettingsScreen.qml" line="824"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="823"/>
+        <location filename="../screens/SettingsScreen.qml" line="829"/>
         <source>Detailed list view</source>
         <translation>Detailed list view</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="824"/>
+        <location filename="../screens/SettingsScreen.qml" line="830"/>
         <source>Grid view</source>
         <translation>Grid view</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="829"/>
+        <location filename="../screens/SettingsScreen.qml" line="835"/>
         <source>Full color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="830"/>
+        <location filename="../screens/SettingsScreen.qml" line="836"/>
         <source>Tinted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="868"/>
+        <location filename="../screens/SettingsScreen.qml" line="874"/>
         <source>Style B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="870"/>
+        <location filename="../screens/SettingsScreen.qml" line="876"/>
         <source>Style C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="872"/>
+        <location filename="../screens/SettingsScreen.qml" line="878"/>
         <source>Style D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="876"/>
+        <location filename="../screens/SettingsScreen.qml" line="882"/>
         <source>Style A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="917"/>
+        <location filename="../screens/SettingsScreen.qml" line="923"/>
         <source>PAL (50 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="919"/>
+        <location filename="../screens/SettingsScreen.qml" line="925"/>
         <source>480i (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="920"/>
+        <location filename="../screens/SettingsScreen.qml" line="926"/>
         <source>NTSC (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1905"/>
+        <location filename="../screens/SettingsScreen.qml" line="1911"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1961,145 +2005,145 @@ Français - Wilfried</source>
         <translation type="vanished">Default</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="892"/>
+        <location filename="../screens/SettingsScreen.qml" line="898"/>
         <source>Off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="894"/>
+        <location filename="../screens/SettingsScreen.qml" line="900"/>
         <source>1 second (testing)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="896"/>
+        <location filename="../screens/SettingsScreen.qml" line="902"/>
         <source>1 minute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="898"/>
+        <location filename="../screens/SettingsScreen.qml" line="904"/>
         <source>2 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="900"/>
+        <location filename="../screens/SettingsScreen.qml" line="906"/>
         <source>5 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="902"/>
+        <location filename="../screens/SettingsScreen.qml" line="908"/>
         <source>10 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="904"/>
+        <location filename="../screens/SettingsScreen.qml" line="910"/>
         <source>15 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="906"/>
+        <location filename="../screens/SettingsScreen.qml" line="912"/>
         <source>30 minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="907"/>
+        <location filename="../screens/SettingsScreen.qml" line="913"/>
         <source>%1 seconds</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="108"/>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="855"/>
+        <location filename="../screens/SettingsScreen.qml" line="861"/>
         <source>Nord</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="852"/>
+        <location filename="../screens/SettingsScreen.qml" line="858"/>
         <source>Dracula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="859"/>
+        <location filename="../screens/SettingsScreen.qml" line="865"/>
         <source>Synthwave &apos;84</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="846"/>
+        <location filename="../screens/SettingsScreen.qml" line="852"/>
         <source>Amber Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="848"/>
+        <location filename="../screens/SettingsScreen.qml" line="854"/>
         <source>Green Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="849"/>
+        <location filename="../screens/SettingsScreen.qml" line="855"/>
         <source>Neo Geo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="850"/>
+        <location filename="../screens/SettingsScreen.qml" line="856"/>
         <source>NES</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="851"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>Virtual Boy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="854"/>
+        <location filename="../screens/SettingsScreen.qml" line="860"/>
         <source>Gruvbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="853"/>
+        <location filename="../screens/SettingsScreen.qml" line="859"/>
         <source>Everforest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="858"/>
+        <location filename="../screens/SettingsScreen.qml" line="864"/>
         <source>Solarized Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="863"/>
         <source>Rosé Pine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="856"/>
+        <location filename="../screens/SettingsScreen.qml" line="862"/>
         <source>Oxocarbon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="860"/>
+        <location filename="../screens/SettingsScreen.qml" line="866"/>
         <source>Flexoki Paper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="861"/>
+        <location filename="../screens/SettingsScreen.qml" line="867"/>
         <source>Solarized Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="847"/>
+        <location filename="../screens/SettingsScreen.qml" line="853"/>
         <source>Game Boy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2149,6 +2193,16 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="269"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="280"/>
         <source>Show systems as a grid of covers, or as a list with details beside it.</source>
         <translation type="unfinished"></translation>
@@ -2169,97 +2223,112 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="324"/>
+        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <source>Shows a code you can scan to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="330"/>
         <source>Uploads the log file and gives you a link to share when reporting a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="874"/>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <source>%1 imported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="880"/>
         <source>Style E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="927"/>
+        <location filename="../screens/SettingsScreen.qml" line="933"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="929"/>
+        <location filename="../screens/SettingsScreen.qml" line="935"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="931"/>
+        <location filename="../screens/SettingsScreen.qml" line="937"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="933"/>
+        <location filename="../screens/SettingsScreen.qml" line="939"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="935"/>
+        <location filename="../screens/SettingsScreen.qml" line="941"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="937"/>
+        <location filename="../screens/SettingsScreen.qml" line="943"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="939"/>
+        <location filename="../screens/SettingsScreen.qml" line="945"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="941"/>
+        <location filename="../screens/SettingsScreen.qml" line="947"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="943"/>
+        <location filename="../screens/SettingsScreen.qml" line="949"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="945"/>
+        <location filename="../screens/SettingsScreen.qml" line="951"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="947"/>
+        <location filename="../screens/SettingsScreen.qml" line="953"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="949"/>
+        <location filename="../screens/SettingsScreen.qml" line="955"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="355"/>
+        <location filename="../screens/SettingsScreen.qml" line="361"/>
         <source>Settings</source>
         <translation>Settings</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="843"/>
+        <location filename="../screens/SettingsScreen.qml" line="849"/>
         <source>Zaparoo Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="844"/>
+        <location filename="../screens/SettingsScreen.qml" line="850"/>
         <source>Zaparoo Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="845"/>
+        <location filename="../screens/SettingsScreen.qml" line="851"/>
         <source>Classic Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1887"/>
+        <location filename="../screens/SettingsScreen.qml" line="1893"/>
         <source>No settings available on this platform</source>
         <translation>No settings available on this platform</translation>
     </message>
@@ -2298,8 +2367,28 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/StatusLine.qml" line="105"/>
+        <source>Importing paused: game running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/StatusLine.qml" line="106"/>
-        <source>Scraping…</source>
+        <source>Importing: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Import failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Imported %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2329,16 +2418,6 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="105"/>
-        <source>Scraping paused: game running</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="106"/>
-        <source>Scraping: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>%1 files</source>
         <translation type="obsolete">%1 files</translation>
     </message>
@@ -2350,16 +2429,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scraped %1 of %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -2106,7 +2106,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1911"/>
+        <location filename="../screens/SettingsScreen.qml" line="1913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2426,7 +2426,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1893"/>
+        <location filename="../screens/SettingsScreen.qml" line="1895"/>
         <source>No settings available on this platform</source>
         <translation>No hay ajustes en esta plataforma</translation>
     </message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -1993,6 +1993,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
         <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
@@ -2298,11 +2303,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Get metadata</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -389,45 +389,6 @@ Français - Wilfried</source>
     </message>
 </context>
 <context>
-    <name>FirstRunIndexModal</name>
-    <message>
-        <source>First-time setup</source>
-        <translation type="vanished">Configuración inicial</translation>
-    </message>
-    <message>
-        <source>Indexing paused</source>
-        <translation type="vanished">Indexación en pausa</translation>
-    </message>
-    <message>
-        <source>Optimizing database - almost done</source>
-        <translation type="vanished">Optimizando la base de datos: casi listo</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2 - %3</source>
-        <translation type="vanished">Paso %1 de %2 - %3</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2</source>
-        <translation type="vanished">Paso %1 de %2</translation>
-    </message>
-    <message>
-        <source>Preparing…</source>
-        <translation type="vanished">Preparando…</translation>
-    </message>
-    <message>
-        <source>Done. %1 files indexed.</source>
-        <translation type="vanished">Hecho. %1 archivos indexados.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Cancelar</translation>
-    </message>
-    <message>
-        <source>Start scan</source>
-        <translation type="vanished">Iniciar escaneo</translation>
-    </message>
-</context>
-<context>
     <name>GameInfoModal</name>
     <message>
         <location filename="../components/GameInfoModal.qml" line="153"/>
@@ -540,6 +501,26 @@ Français - Wilfried</source>
         <translation>Favoritos</translation>
     </message>
     <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>Updating the media database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>No games found yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Your games appear here as Core finds them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Update media database in Settings &gt; Library.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Recently Played</source>
         <translation type="vanished">Recientemente Jugados</translation>
     </message>
@@ -569,35 +550,44 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
-        <translation>No hay sistemas disponibles. Ejecuta Actualizar la base de datos de medios desde Ajustes.</translation>
+        <translation type="vanished">No hay sistemas disponibles. Ejecuta Actualizar la base de datos de medios desde Ajustes.</translation>
     </message>
 </context>
 <context>
     <name>IndexSetupModal</name>
     <message>
         <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Start</source>
+        <translation type="unfinished">Iniciar</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Change</source>
+        <translation type="unfinished">Cambiar</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="51"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="47"/>
+        <location filename="../components/IndexSetupModal.qml" line="53"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="115"/>
+        <location filename="../components/IndexSetupModal.qml" line="121"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizar base de datos de medios</translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="124"/>
+        <location filename="../components/IndexSetupModal.qml" line="130"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="137"/>
+        <location filename="../components/IndexSetupModal.qml" line="143"/>
         <source>Start update</source>
         <translation type="unfinished"></translation>
     </message>
@@ -675,29 +665,29 @@ Français - Wilfried</source>
         <translation type="vanished">Lanzar core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
-        <location filename="../app/Main.qml" line="2330"/>
-        <location filename="../app/Main.qml" line="2393"/>
-        <location filename="../app/Main.qml" line="2699"/>
-        <location filename="../app/Main.qml" line="3741"/>
-        <location filename="../app/Main.qml" line="3784"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
+        <location filename="../app/Main.qml" line="2341"/>
+        <location filename="../app/Main.qml" line="2410"/>
+        <location filename="../app/Main.qml" line="2716"/>
+        <location filename="../app/Main.qml" line="3795"/>
+        <location filename="../app/Main.qml" line="3838"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Remove from favorites</source>
         <translation>Eliminar de favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Add to favorites</source>
         <translation>Agregar a favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2264"/>
-        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2266"/>
+        <location filename="../app/Main.qml" line="2346"/>
         <source>Write to NFC token</source>
         <translation>Escribir en token NFC</translation>
     </message>
@@ -706,53 +696,76 @@ Français - Wilfried</source>
         <translation type="vanished">Código QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
-        <location filename="../app/Main.qml" line="2308"/>
+        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2319"/>
         <source>Launch game</source>
         <translation>Iniciar juego</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1070"/>
-        <location filename="../app/Main.qml" line="3417"/>
-        <location filename="../app/Main.qml" line="3464"/>
-        <location filename="../app/Main.qml" line="3474"/>
+        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3518"/>
+        <location filename="../app/Main.qml" line="3528"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3153"/>
+        <source>Get metadata failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3154"/>
+        <source>Could not start getting metadata. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3156"/>
+        <source>Source list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3157"/>
+        <source>Could not load the list of metadata sources. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3307"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4848"/>
+        <location filename="../app/Main.qml" line="4902"/>
         <source>Loading systems…</source>
         <translation>Cargando sistemas…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4855"/>
+        <location filename="../app/Main.qml" line="4909"/>
         <source>Loading favorites…</source>
         <translation>Cargando favoritos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4850"/>
+        <location filename="../app/Main.qml" line="4904"/>
         <source>Loading games…</source>
         <translation>Cargando juegos…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2183"/>
-        <location filename="../app/Main.qml" line="2218"/>
+        <location filename="../app/Main.qml" line="2185"/>
+        <location filename="../app/Main.qml" line="2220"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizar base de datos de medios</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2186"/>
-        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
-        <translation type="unfinished">Extraer metadatos</translation>
+        <translation type="obsolete">Extraer metadatos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2179"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
@@ -762,90 +775,90 @@ Français - Wilfried</source>
         <translation type="unfinished">Ajustes</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2096"/>
+        <location filename="../app/Main.qml" line="2098"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2153"/>
+        <location filename="../app/Main.qml" line="2155"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2179"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2258"/>
-        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2323"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
-        <location filename="../app/Main.qml" line="2346"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2280"/>
+        <location filename="../app/Main.qml" line="2357"/>
+        <location filename="../app/Main.qml" line="2451"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3507"/>
+        <location filename="../app/Main.qml" line="2395"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3561"/>
         <source>Default</source>
         <translation type="unfinished">Por defecto</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2395"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2230"/>
-        <location filename="../app/Main.qml" line="2238"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="2164"/>
+        <location filename="../app/Main.qml" line="2215"/>
+        <location filename="../app/Main.qml" line="2232"/>
+        <location filename="../app/Main.qml" line="2240"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3454"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3445"/>
+        <location filename="../app/Main.qml" line="3499"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3460"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3511"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3565"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3482"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3515"/>
+        <location filename="../app/Main.qml" line="3569"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3436"/>
+        <location filename="../app/Main.qml" line="3490"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -870,45 +883,46 @@ Français - Wilfried</source>
         <translation type="unfinished">Salir</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2173"/>
-        <location filename="../app/Main.qml" line="2282"/>
-        <location filename="../app/Main.qml" line="2301"/>
-        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2284"/>
+        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2361"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2268"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2270"/>
+        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2807"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2461"/>
+        <location filename="../app/Main.qml" line="2478"/>
         <source>Move</source>
         <translation type="unfinished">Mover</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2667"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1032"/>
-        <location filename="../app/Main.qml" line="3043"/>
-        <location filename="../app/Main.qml" line="3065"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3131"/>
+        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3174"/>
         <source>OK</source>
         <translation type="unfinished">Aceptar</translation>
     </message>
@@ -923,226 +937,224 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="2188"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2293"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2807"/>
+        <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Scan this code to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3132"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3098"/>
+        <location filename="../app/Main.qml" line="3141"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3099"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3101"/>
+        <location filename="../app/Main.qml" line="3144"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3147"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3105"/>
+        <location filename="../app/Main.qml" line="3148"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3107"/>
+        <location filename="../app/Main.qml" line="3150"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3151"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3110"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3111"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3113"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3114"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3116"/>
+        <location filename="../app/Main.qml" line="3159"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3120"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3122"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3123"/>
+        <location filename="../app/Main.qml" line="3166"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3125"/>
+        <location filename="../app/Main.qml" line="3168"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3126"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3128"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3129"/>
+        <location filename="../app/Main.qml" line="3172"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3253"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3269"/>
+        <location filename="../app/Main.qml" line="3323"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3278"/>
+        <location filename="../app/Main.qml" line="3332"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3307"/>
+        <location filename="../app/Main.qml" line="3361"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3446"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3432"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3486"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoritos</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3415"/>
-        <location filename="../app/Main.qml" line="3461"/>
+        <location filename="../app/Main.qml" line="3469"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3449"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3503"/>
+        <location filename="../app/Main.qml" line="3525"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3489"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3485"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3492"/>
+        <location filename="../app/Main.qml" line="3546"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3708"/>
+        <location filename="../app/Main.qml" line="3762"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3119"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
-        <location filename="../app/Main.qml" line="3318"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="2910"/>
+        <location filename="../app/Main.qml" line="3372"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Retry</source>
         <translation type="unfinished">Reintentar</translation>
     </message>
@@ -1151,22 +1163,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4852"/>
+        <location filename="../app/Main.qml" line="4906"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4857"/>
+        <location filename="../app/Main.qml" line="4911"/>
         <source>Loading recently played…</source>
         <translation>Cargando jugados recientemente…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4859"/>
+        <location filename="../app/Main.qml" line="4913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4861"/>
+        <location filename="../app/Main.qml" line="4915"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>
@@ -1174,7 +1186,7 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Writing failed</source>
         <translation>Error de escritura</translation>
     </message>
@@ -1183,82 +1195,83 @@ Français - Wilfried</source>
         <translation type="vanished">Pon una tarjeta escribible junto al lector</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="936"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="943"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="1365"/>
         <source>OK</source>
         <translation type="unfinished">Aceptar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="535"/>
+        <location filename="../app/MainLayout.qml" line="541"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Hold a writable token near the reader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
         <source>Are you sure you want to exit?</source>
         <translation>¿Seguro que quieres salir?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1387"/>
+        <location filename="../app/MainLayout.qml" line="1409"/>
         <source>Select</source>
         <translation>Seleccionar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1283"/>
-        <location filename="../app/MainLayout.qml" line="1297"/>
-        <location filename="../app/MainLayout.qml" line="1312"/>
-        <location filename="../app/MainLayout.qml" line="1323"/>
-        <location filename="../app/MainLayout.qml" line="1349"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1321"/>
+        <location filename="../app/MainLayout.qml" line="1332"/>
+        <location filename="../app/MainLayout.qml" line="1358"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1425"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1339"/>
+        <location filename="../app/MainLayout.qml" line="1391"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1308"/>
+        <location filename="../app/MainLayout.qml" line="1317"/>
         <source>Done</source>
         <translation>Hecho</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1338"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
         <source>I understand</source>
         <translation>Entendido</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1376"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1389"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1267,28 +1280,29 @@ Français - Wilfried</source>
         <translation type="vanished">Iniciar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1656"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Scroll</source>
         <translation>Desplazar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1468"/>
-        <location filename="../app/MainLayout.qml" line="1555"/>
-        <location filename="../app/MainLayout.qml" line="1573"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
-        <location filename="../app/MainLayout.qml" line="1724"/>
+        <location filename="../app/MainLayout.qml" line="1500"/>
+        <location filename="../app/MainLayout.qml" line="1587"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1737"/>
+        <location filename="../app/MainLayout.qml" line="1756"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1374"/>
-        <location filename="../app/MainLayout.qml" line="1454"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1596"/>
-        <location filename="../app/MainLayout.qml" line="1615"/>
-        <location filename="../app/MainLayout.qml" line="1688"/>
+        <location filename="../app/MainLayout.qml" line="1284"/>
+        <location filename="../app/MainLayout.qml" line="1383"/>
+        <location filename="../app/MainLayout.qml" line="1405"/>
+        <location filename="../app/MainLayout.qml" line="1486"/>
+        <location filename="../app/MainLayout.qml" line="1523"/>
+        <location filename="../app/MainLayout.qml" line="1572"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1647"/>
+        <location filename="../app/MainLayout.qml" line="1720"/>
         <source>Move</source>
         <translation>Mover</translation>
     </message>
@@ -1298,42 +1312,42 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="531"/>
-        <location filename="../app/MainLayout.qml" line="533"/>
+        <location filename="../app/MainLayout.qml" line="537"/>
+        <location filename="../app/MainLayout.qml" line="539"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoritos</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="916"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="917"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1096"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1417"/>
+        <location filename="../app/MainLayout.qml" line="1449"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1421"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1496"/>
-        <location filename="../app/MainLayout.qml" line="1545"/>
-        <location filename="../app/MainLayout.qml" line="1601"/>
-        <location filename="../app/MainLayout.qml" line="1693"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1528"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1633"/>
+        <location filename="../app/MainLayout.qml" line="1725"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
@@ -1342,19 +1356,20 @@ Français - Wilfried</source>
         <translation type="vanished">Salir</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1477"/>
-        <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1513"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1559"/>
-        <location filename="../app/MainLayout.qml" line="1577"/>
-        <location filename="../app/MainLayout.qml" line="1589"/>
-        <location filename="../app/MainLayout.qml" line="1605"/>
-        <location filename="../app/MainLayout.qml" line="1639"/>
-        <location filename="../app/MainLayout.qml" line="1660"/>
-        <location filename="../app/MainLayout.qml" line="1669"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
-        <location filename="../app/MainLayout.qml" line="1728"/>
+        <location filename="../app/MainLayout.qml" line="1413"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1561"/>
+        <location filename="../app/MainLayout.qml" line="1591"/>
+        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1621"/>
+        <location filename="../app/MainLayout.qml" line="1637"/>
+        <location filename="../app/MainLayout.qml" line="1671"/>
+        <location filename="../app/MainLayout.qml" line="1692"/>
+        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1741"/>
+        <location filename="../app/MainLayout.qml" line="1760"/>
         <source>Back</source>
         <translation>Atrás</translation>
     </message>
@@ -1363,29 +1378,29 @@ Français - Wilfried</source>
         <translation type="vanished">Página</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1464"/>
-        <location filename="../app/MainLayout.qml" line="1499"/>
-        <location filename="../app/MainLayout.qml" line="1550"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1531"/>
+        <location filename="../app/MainLayout.qml" line="1582"/>
+        <location filename="../app/MainLayout.qml" line="1730"/>
         <source>Options</source>
         <translation>Opciones</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1509"/>
-        <location filename="../app/MainLayout.qml" line="1567"/>
-        <location filename="../app/MainLayout.qml" line="1716"/>
+        <location filename="../app/MainLayout.qml" line="1328"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1541"/>
+        <location filename="../app/MainLayout.qml" line="1599"/>
+        <location filename="../app/MainLayout.qml" line="1748"/>
         <source>Retry</source>
         <translation>Reintentar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1624"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Change</source>
         <translation>Cambiar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1630"/>
+        <location filename="../app/MainLayout.qml" line="1662"/>
         <source>Toggle</source>
         <translation>Alternar</translation>
     </message>
@@ -1446,12 +1461,12 @@ Français - Wilfried</source>
 <context>
     <name>QrCodeModal</name>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="23"/>
+        <location filename="../components/QrCodeModal.qml" line="19"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="43"/>
+        <location filename="../components/QrCodeModal.qml" line="20"/>
         <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1481,43 +1496,67 @@ Français - Wilfried</source>
 <context>
     <name>ScrapeSetupModal</name>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="67"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Start</source>
+        <translation type="unfinished">Iniciar</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Toggle</source>
+        <translation type="unfinished">Alternar</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Change</source>
+        <translation type="unfinished">Cambiar</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="89"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="69"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="91"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="171"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="193"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
+        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <source>Loading sources…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <source>Replace existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <source>Start import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scrape metadata</source>
-        <translation type="unfinished">Extraer metadatos</translation>
+        <translation type="obsolete">Extraer metadatos</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="185"/>
-        <source>Loading scrapers…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="196"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
         <source>Systems</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="222"/>
-        <source>Re-scrape existing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
-        <source>Start scrape</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1529,17 +1568,17 @@ Français - Wilfried</source>
         <translation>Nada aquí</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="36"/>
         <source>Loading…</source>
         <translation>Cargando…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="37"/>
         <source>Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="79"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="85"/>
         <source>Failed to load</source>
         <translation>Fallo al cargar</translation>
     </message>
@@ -1549,8 +1588,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="114"/>
         <location filename="../screens/SettingsScreen.qml" line="205"/>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
-        <location filename="../screens/SettingsScreen.qml" line="972"/>
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="978"/>
         <source>Language</source>
         <translation>Idioma</translation>
     </message>
@@ -1570,7 +1609,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="165"/>
-        <location filename="../screens/SettingsScreen.qml" line="999"/>
+        <location filename="../screens/SettingsScreen.qml" line="1005"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1580,44 +1619,43 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="225"/>
-        <location filename="../screens/SettingsScreen.qml" line="1051"/>
+        <location filename="../screens/SettingsScreen.qml" line="1057"/>
         <source>Button style</source>
         <translation>Estilo de botón</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="1060"/>
+        <location filename="../screens/SettingsScreen.qml" line="1066"/>
         <source>Screensaver</source>
         <translation>Salvapantallas</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Library</source>
         <translation>Biblioteca</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="291"/>
-        <location filename="../screens/SettingsScreen.qml" line="1069"/>
+        <location filename="../screens/SettingsScreen.qml" line="1075"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Scrape metadata</source>
-        <translation>Extraer metadatos</translation>
+        <translation type="vanished">Extraer metadatos</translation>
     </message>
     <message>
         <source>Advanced</source>
         <translation type="vanished">Avanzado</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <location filename="../screens/SettingsScreen.qml" line="323"/>
         <source>Debug logging</source>
         <translation>Registro de depuración</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="323"/>
+        <location filename="../screens/SettingsScreen.qml" line="329"/>
         <source>Upload log file</source>
         <translation>Subir archivo de registro</translation>
     </message>
@@ -1628,7 +1666,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="217"/>
-        <location filename="../screens/SettingsScreen.qml" line="981"/>
+        <location filename="../screens/SettingsScreen.qml" line="987"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1639,13 +1677,13 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="158"/>
-        <location filename="../screens/SettingsScreen.qml" line="963"/>
+        <location filename="../screens/SettingsScreen.qml" line="969"/>
         <source>Interface resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="129"/>
-        <location filename="../screens/SettingsScreen.qml" line="1035"/>
+        <location filename="../screens/SettingsScreen.qml" line="1041"/>
         <source>Color scheme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1661,7 +1699,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <location filename="../screens/SettingsScreen.qml" line="1078"/>
+        <location filename="../screens/SettingsScreen.qml" line="1084"/>
         <source>Video standard</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1672,7 +1710,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="135"/>
-        <location filename="../screens/SettingsScreen.qml" line="1026"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
         <source>System logos</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1693,19 +1731,19 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="90"/>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="120"/>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="211"/>
-        <location filename="../screens/SettingsScreen.qml" line="990"/>
+        <location filename="../screens/SettingsScreen.qml" line="996"/>
         <source>Region</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1715,35 +1753,34 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Optimizing</source>
         <translation>Optimizando</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>Paused</source>
         <translation>Pausado</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>In progress</source>
         <translation>En progreso</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>%1 indexed</source>
         <translation>%1 indexados</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>%1 scraped</source>
-        <translation>%1 extraídos</translation>
+        <translation type="vanished">%1 extraídos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
@@ -1752,117 +1789,117 @@ Français - Wilfried</source>
         <translation type="vanished">Iniciar</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Upload</source>
         <translation>Subir</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="650"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Open</source>
         <translation>Abrir</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>%1 × %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Automatic (Recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="717"/>
         <source>%1 (Animations off)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="758"/>
         <source>English</source>
         <translation>Inglés</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="760"/>
         <source>Italian</source>
         <translation>Italiano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="756"/>
+        <location filename="../screens/SettingsScreen.qml" line="762"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="758"/>
+        <location filename="../screens/SettingsScreen.qml" line="764"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="760"/>
+        <location filename="../screens/SettingsScreen.qml" line="766"/>
         <source>German</source>
         <translation>Alemán</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="762"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Greek</source>
         <translation>Griego</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="764"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Japanese</source>
         <translation>Japonés</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="766"/>
+        <location filename="../screens/SettingsScreen.qml" line="772"/>
         <source>Korean</source>
         <translation>Coreano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Dutch</source>
         <translation>Neerlandés</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="776"/>
         <source>Romanian</source>
         <translation>Rumano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="778"/>
         <source>Slovak</source>
         <translation>Eslovaco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="774"/>
+        <location filename="../screens/SettingsScreen.qml" line="780"/>
         <source>Ukrainian</source>
         <translation>Ucraniano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="776"/>
+        <location filename="../screens/SettingsScreen.qml" line="782"/>
         <source>Chinese (Simplified)</source>
         <translation>Chino (simplificado)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="778"/>
+        <location filename="../screens/SettingsScreen.qml" line="784"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="780"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Hebrew</source>
         <translation>Hebreo</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="782"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="784"/>
+        <location filename="../screens/SettingsScreen.qml" line="790"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>French</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1871,37 +1908,37 @@ Français - Wilfried</source>
         <translation type="vanished">Automático</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="792"/>
+        <location filename="../screens/SettingsScreen.qml" line="798"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="794"/>
+        <location filename="../screens/SettingsScreen.qml" line="800"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="805"/>
+        <location filename="../screens/SettingsScreen.qml" line="811"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="807"/>
+        <location filename="../screens/SettingsScreen.qml" line="813"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="809"/>
+        <location filename="../screens/SettingsScreen.qml" line="815"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
-        <location filename="../screens/SettingsScreen.qml" line="787"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
-        <location filename="../screens/SettingsScreen.qml" line="810"/>
-        <location filename="../screens/SettingsScreen.qml" line="877"/>
-        <location filename="../screens/SettingsScreen.qml" line="925"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="793"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
+        <location filename="../screens/SettingsScreen.qml" line="816"/>
+        <location filename="../screens/SettingsScreen.qml" line="883"/>
+        <location filename="../screens/SettingsScreen.qml" line="931"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1956,19 +1993,14 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Downloads box art, descriptions, and tags for your games. Choose a source and which systems.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
-        <location filename="../screens/SettingsScreen.qml" line="1008"/>
+        <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="285"/>
-        <location filename="../screens/SettingsScreen.qml" line="1017"/>
+        <location filename="../screens/SettingsScreen.qml" line="1023"/>
         <source>Games layout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1983,93 +2015,93 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <location filename="../screens/SettingsScreen.qml" line="324"/>
         <source>Writes extra detail to the log file to help track down a problem. Restarts the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Configure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="815"/>
+        <location filename="../screens/SettingsScreen.qml" line="821"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="817"/>
+        <location filename="../screens/SettingsScreen.qml" line="823"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="818"/>
+        <location filename="../screens/SettingsScreen.qml" line="824"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="823"/>
+        <location filename="../screens/SettingsScreen.qml" line="829"/>
         <source>Detailed list view</source>
         <translation>Vista de lista detallada</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="824"/>
+        <location filename="../screens/SettingsScreen.qml" line="830"/>
         <source>Grid view</source>
         <translation>Vista de cuadrícula</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="829"/>
+        <location filename="../screens/SettingsScreen.qml" line="835"/>
         <source>Full color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="830"/>
+        <location filename="../screens/SettingsScreen.qml" line="836"/>
         <source>Tinted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="868"/>
+        <location filename="../screens/SettingsScreen.qml" line="874"/>
         <source>Style B</source>
         <translation>Estilo B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="870"/>
+        <location filename="../screens/SettingsScreen.qml" line="876"/>
         <source>Style C</source>
         <translation>Estilo C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="872"/>
+        <location filename="../screens/SettingsScreen.qml" line="878"/>
         <source>Style D</source>
         <translation>Estilo D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="874"/>
+        <location filename="../screens/SettingsScreen.qml" line="880"/>
         <source>Style E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="876"/>
+        <location filename="../screens/SettingsScreen.qml" line="882"/>
         <source>Style A</source>
         <translation>Estilo A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="917"/>
+        <location filename="../screens/SettingsScreen.qml" line="923"/>
         <source>PAL (50 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="919"/>
+        <location filename="../screens/SettingsScreen.qml" line="925"/>
         <source>480i (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="920"/>
+        <location filename="../screens/SettingsScreen.qml" line="926"/>
         <source>NTSC (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1905"/>
+        <location filename="../screens/SettingsScreen.qml" line="1911"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2078,47 +2110,47 @@ Français - Wilfried</source>
         <translation type="vanished">Por defecto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="892"/>
+        <location filename="../screens/SettingsScreen.qml" line="898"/>
         <source>Off</source>
         <translation>Desactivado</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="894"/>
+        <location filename="../screens/SettingsScreen.qml" line="900"/>
         <source>1 second (testing)</source>
         <translation>1 segundo (prueba)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="896"/>
+        <location filename="../screens/SettingsScreen.qml" line="902"/>
         <source>1 minute</source>
         <translation>1 minuto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="898"/>
+        <location filename="../screens/SettingsScreen.qml" line="904"/>
         <source>2 minutes</source>
         <translation>2 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="900"/>
+        <location filename="../screens/SettingsScreen.qml" line="906"/>
         <source>5 minutes</source>
         <translation>5 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="902"/>
+        <location filename="../screens/SettingsScreen.qml" line="908"/>
         <source>10 minutes</source>
         <translation>10 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="904"/>
+        <location filename="../screens/SettingsScreen.qml" line="910"/>
         <source>15 minutes</source>
         <translation>15 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="906"/>
+        <location filename="../screens/SettingsScreen.qml" line="912"/>
         <source>30 minutes</source>
         <translation>30 minutos</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="907"/>
+        <location filename="../screens/SettingsScreen.qml" line="913"/>
         <source>%1 seconds</source>
         <translation>%1 segundos</translation>
     </message>
@@ -2128,93 +2160,93 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="108"/>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="855"/>
+        <location filename="../screens/SettingsScreen.qml" line="861"/>
         <source>Nord</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="852"/>
+        <location filename="../screens/SettingsScreen.qml" line="858"/>
         <source>Dracula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="859"/>
+        <location filename="../screens/SettingsScreen.qml" line="865"/>
         <source>Synthwave &apos;84</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="846"/>
+        <location filename="../screens/SettingsScreen.qml" line="852"/>
         <source>Amber Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="848"/>
+        <location filename="../screens/SettingsScreen.qml" line="854"/>
         <source>Green Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="849"/>
+        <location filename="../screens/SettingsScreen.qml" line="855"/>
         <source>Neo Geo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="850"/>
+        <location filename="../screens/SettingsScreen.qml" line="856"/>
         <source>NES</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="851"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>Virtual Boy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="854"/>
+        <location filename="../screens/SettingsScreen.qml" line="860"/>
         <source>Gruvbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="853"/>
+        <location filename="../screens/SettingsScreen.qml" line="859"/>
         <source>Everforest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="858"/>
+        <location filename="../screens/SettingsScreen.qml" line="864"/>
         <source>Solarized Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="863"/>
         <source>Rosé Pine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="856"/>
+        <location filename="../screens/SettingsScreen.qml" line="862"/>
         <source>Oxocarbon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="860"/>
+        <location filename="../screens/SettingsScreen.qml" line="866"/>
         <source>Flexoki Paper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="861"/>
+        <location filename="../screens/SettingsScreen.qml" line="867"/>
         <source>Solarized Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="847"/>
+        <location filename="../screens/SettingsScreen.qml" line="853"/>
         <source>Game Boy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2264,6 +2296,16 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="269"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="280"/>
         <source>Show systems as a grid of covers, or as a list with details beside it.</source>
         <translation type="unfinished"></translation>
@@ -2284,92 +2326,107 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="324"/>
+        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <source>Shows a code you can scan to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="330"/>
         <source>Uploads the log file and gives you a link to share when reporting a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="927"/>
-        <source>Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="929"/>
-        <source>Thumbnail</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="931"/>
-        <source>Box art</source>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <source>%1 imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="933"/>
-        <source>3D box art</source>
+        <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="935"/>
-        <source>Screenshot</source>
+        <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="937"/>
-        <source>Wheel</source>
+        <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="939"/>
-        <source>Title screen</source>
+        <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="941"/>
-        <source>Map</source>
+        <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="943"/>
-        <source>Marquee</source>
+        <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="945"/>
-        <source>Fan art</source>
+        <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="947"/>
-        <source>Box side</source>
+        <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="949"/>
+        <source>Marquee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="951"/>
+        <source>Fan art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="953"/>
+        <source>Box side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="955"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="355"/>
+        <location filename="../screens/SettingsScreen.qml" line="361"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="843"/>
+        <location filename="../screens/SettingsScreen.qml" line="849"/>
         <source>Zaparoo Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="844"/>
+        <location filename="../screens/SettingsScreen.qml" line="850"/>
         <source>Zaparoo Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="845"/>
+        <location filename="../screens/SettingsScreen.qml" line="851"/>
         <source>Classic Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1887"/>
+        <location filename="../screens/SettingsScreen.qml" line="1893"/>
         <source>No settings available on this platform</source>
         <translation>No hay ajustes en esta plataforma</translation>
     </message>
@@ -2408,9 +2465,33 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/StatusLine.qml" line="105"/>
+        <source>Importing paused: game running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Import failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Imported %1 of %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scraping…</source>
-        <translation type="unfinished">Extrayendo…</translation>
+        <translation type="obsolete">Extrayendo…</translation>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
@@ -2439,16 +2520,6 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="105"/>
-        <source>Scraping paused: game running</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="106"/>
-        <source>Scraping: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>%1 files</source>
         <translation type="obsolete">%1 archivos</translation>
     </message>
@@ -2464,16 +2535,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scraped %1 of %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_es.ts
+++ b/src/ui/translations/frontend_es.ts
@@ -35,8 +35,8 @@
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="212"/>
-        <source>Commercial licensing: legal@zaparoo.org</source>
-        <translation>Licencia comercial: legal@zaparoo.org</translation>
+        <source>Commercial licensing: legal@zaparoo.com</source>
+        <translation>Licencia comercial: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="223"/>
@@ -227,8 +227,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="116"/>
-        <source>Contact: legal@zaparoo.org</source>
-        <translation>Contacto: legal@zaparoo.org</translation>
+        <source>Contact: legal@zaparoo.com</source>
+        <translation>Contacto: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="127"/>
@@ -1526,27 +1526,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
-        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <source>Documentation: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="225"/>
         <source>Loading sources…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="262"/>
         <source>Replace existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="276"/>
         <source>Start import</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1555,7 +1555,7 @@ Français - Wilfried</source>
         <translation type="obsolete">Extraer metadatos</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="249"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -35,8 +35,8 @@
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="212"/>
-        <source>Commercial licensing: legal@zaparoo.org</source>
-        <translation type="unfinished">Lizentziazio komertizala: legal@zaparoo.org</translation>
+        <source>Commercial licensing: legal@zaparoo.com</source>
+        <translation type="unfinished">Lizentziazio komertizala: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="223"/>
@@ -227,8 +227,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="116"/>
-        <source>Contact: legal@zaparoo.org</source>
-        <translation type="unfinished">Kontaktua: legal@zaparoo.org</translation>
+        <source>Contact: legal@zaparoo.com</source>
+        <translation type="unfinished">Kontaktua: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="127"/>
@@ -1554,27 +1554,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
-        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <source>Documentation: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="225"/>
         <source>Loading sources…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="262"/>
         <source>Replace existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="276"/>
         <source>Start import</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1583,7 +1583,7 @@ Français - Wilfried</source>
         <translation type="obsolete">Metadatuak scrapeatu</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="249"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -393,49 +393,6 @@ Français - Wilfried</source>
     </message>
 </context>
 <context>
-    <name>FirstRunIndexModal</name>
-    <message>
-        <source>First-time setup</source>
-        <translation type="obsolete">Lehenengo aldiko konfigurazioa</translation>
-    </message>
-    <message>
-        <source>Indexing paused</source>
-        <translation type="obsolete">Indexatzea pausatuta</translation>
-    </message>
-    <message>
-        <source>Optimizing database - almost done</source>
-        <translation type="obsolete">Datu base optimizazioa - ia amaituta</translation>
-    </message>
-    <message>
-        <source>Zaparoo needs to scan your games before you can use the frontend. This usually takes a few minutes.</source>
-        <translation type="obsolete">Zaparoo-k zure jokuak eskanetu beharra dauka frontend-a erabili aurretik. Honek normaleak minutu gutxi batzuk hartzen ditu.</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2 - %3</source>
-        <translation type="obsolete">%1 pausoa %2tik  - %3 </translation>
-    </message>
-    <message>
-        <source>Step %1 of %2</source>
-        <translation type="obsolete">%1 pausoa %2tik</translation>
-    </message>
-    <message>
-        <source>Preparing…</source>
-        <translation type="obsolete">Prestatzen</translation>
-    </message>
-    <message>
-        <source>Done. %1 files indexed.</source>
-        <translation type="obsolete">Eginda. %1 fitxategi indexatuta</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="obsolete">Bertan behera utzi</translation>
-    </message>
-    <message>
-        <source>Start scan</source>
-        <translation type="obsolete">Hasi eskaneoa</translation>
-    </message>
-</context>
-<context>
     <name>GameInfoModal</name>
     <message>
         <location filename="../components/GameInfoModal.qml" line="153"/>
@@ -556,6 +513,26 @@ Français - Wilfried</source>
         <translation>Gogokoak</translation>
     </message>
     <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>Updating the media database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>No games found yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Your games appear here as Core finds them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Update media database in Settings &gt; Library.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Recently Played</source>
         <translation type="vanished">Duela gutxi jolastuta</translation>
     </message>
@@ -585,35 +562,44 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
-        <translation type="unfinished">Ez dago sistemarik eskuragarri. Exekutatu Eguneratu baliabide datubasea Aukeretatik</translation>
+        <translation type="obsolete">Ez dago sistemarik eskuragarri. Exekutatu Eguneratu baliabide datubasea Aukeretatik</translation>
     </message>
 </context>
 <context>
     <name>IndexSetupModal</name>
     <message>
         <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Start</source>
+        <translation type="unfinished">Hasi</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Change</source>
+        <translation type="unfinished">Aldatu</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="51"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="47"/>
+        <location filename="../components/IndexSetupModal.qml" line="53"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="115"/>
+        <location filename="../components/IndexSetupModal.qml" line="121"/>
         <source>Update media database</source>
         <translation type="unfinished">Eguneratu multimedia datu-basea</translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="124"/>
+        <location filename="../components/IndexSetupModal.qml" line="130"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="137"/>
+        <location filename="../components/IndexSetupModal.qml" line="143"/>
         <source>Start update</source>
         <translation type="unfinished"></translation>
     </message>
@@ -691,29 +677,29 @@ Français - Wilfried</source>
         <translation type="obsolete">Exekutatu nukleoa</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
-        <location filename="../app/Main.qml" line="2330"/>
-        <location filename="../app/Main.qml" line="2393"/>
-        <location filename="../app/Main.qml" line="2699"/>
-        <location filename="../app/Main.qml" line="3741"/>
-        <location filename="../app/Main.qml" line="3784"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
+        <location filename="../app/Main.qml" line="2341"/>
+        <location filename="../app/Main.qml" line="2410"/>
+        <location filename="../app/Main.qml" line="2716"/>
+        <location filename="../app/Main.qml" line="3795"/>
+        <location filename="../app/Main.qml" line="3838"/>
         <source>Change launcher</source>
         <translation type="unfinished">Aldatu abiarazlea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Remove from favorites</source>
         <translation type="unfinished">Kendu gogokoetatik</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Add to favorites</source>
         <translation type="unfinished">Gehitu gogokoetan</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2264"/>
-        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2266"/>
+        <location filename="../app/Main.qml" line="2346"/>
         <source>Write to NFC token</source>
         <translation type="unfinished">Idatzi NFC token-a</translation>
     </message>
@@ -722,53 +708,76 @@ Français - Wilfried</source>
         <translation type="obsolete">QR kodea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
-        <location filename="../app/Main.qml" line="2308"/>
+        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2319"/>
         <source>Launch game</source>
         <translation type="unfinished">Abiarazi jokua</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1070"/>
-        <location filename="../app/Main.qml" line="3417"/>
-        <location filename="../app/Main.qml" line="3464"/>
-        <location filename="../app/Main.qml" line="3474"/>
+        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3518"/>
+        <location filename="../app/Main.qml" line="3528"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3153"/>
+        <source>Get metadata failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3154"/>
+        <source>Could not start getting metadata. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3156"/>
+        <source>Source list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3157"/>
+        <source>Could not load the list of metadata sources. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3307"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4848"/>
+        <location filename="../app/Main.qml" line="4902"/>
         <source>Loading systems…</source>
         <translation type="unfinished">Sistemak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4855"/>
+        <location filename="../app/Main.qml" line="4909"/>
         <source>Loading favorites…</source>
         <translation type="unfinished">Gogokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4850"/>
+        <location filename="../app/Main.qml" line="4904"/>
         <source>Loading games…</source>
         <translation type="unfinished">Jokoak kargatzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2183"/>
-        <location filename="../app/Main.qml" line="2218"/>
+        <location filename="../app/Main.qml" line="2185"/>
+        <location filename="../app/Main.qml" line="2220"/>
         <source>Update media database</source>
         <translation type="unfinished">Eguneratu multimedia datu-basea</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2186"/>
-        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
-        <translation type="unfinished">Metadatuak scrapeatu</translation>
+        <translation type="obsolete">Metadatuak scrapeatu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2179"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
@@ -778,90 +787,90 @@ Français - Wilfried</source>
         <translation type="unfinished">Ezarpenak</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2096"/>
+        <location filename="../app/Main.qml" line="2098"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2153"/>
+        <location filename="../app/Main.qml" line="2155"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2179"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2258"/>
-        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2323"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
-        <location filename="../app/Main.qml" line="2346"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2280"/>
+        <location filename="../app/Main.qml" line="2357"/>
+        <location filename="../app/Main.qml" line="2451"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3507"/>
+        <location filename="../app/Main.qml" line="2395"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3561"/>
         <source>Default</source>
         <translation type="unfinished">Lehenetsia</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2395"/>
         <source>Current: %1</source>
         <translation type="unfinished">Unekoa: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2230"/>
-        <location filename="../app/Main.qml" line="2238"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="2164"/>
+        <location filename="../app/Main.qml" line="2215"/>
+        <location filename="../app/Main.qml" line="2232"/>
+        <location filename="../app/Main.qml" line="2240"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3454"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3445"/>
+        <location filename="../app/Main.qml" line="3499"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3460"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3511"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3565"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3482"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3515"/>
+        <location filename="../app/Main.qml" line="3569"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3436"/>
+        <location filename="../app/Main.qml" line="3490"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -886,45 +895,46 @@ Français - Wilfried</source>
         <translation type="unfinished">Irten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2173"/>
-        <location filename="../app/Main.qml" line="2282"/>
-        <location filename="../app/Main.qml" line="2301"/>
-        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2284"/>
+        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2361"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2268"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2270"/>
+        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2807"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2461"/>
+        <location filename="../app/Main.qml" line="2478"/>
         <source>Move</source>
         <translation type="unfinished">Mugitu</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2667"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1032"/>
-        <location filename="../app/Main.qml" line="3043"/>
-        <location filename="../app/Main.qml" line="3065"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3131"/>
+        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3174"/>
         <source>OK</source>
         <translation type="unfinished">Ados</translation>
     </message>
@@ -939,195 +949,193 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="2188"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2293"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2807"/>
+        <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Scan this code to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3132"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3098"/>
+        <location filename="../app/Main.qml" line="3141"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3099"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3101"/>
+        <location filename="../app/Main.qml" line="3144"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3147"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3105"/>
+        <location filename="../app/Main.qml" line="3148"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3107"/>
+        <location filename="../app/Main.qml" line="3150"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3151"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3110"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3111"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3113"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3114"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3116"/>
+        <location filename="../app/Main.qml" line="3159"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3120"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3122"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3123"/>
+        <location filename="../app/Main.qml" line="3166"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3125"/>
+        <location filename="../app/Main.qml" line="3168"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3126"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3128"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3129"/>
+        <location filename="../app/Main.qml" line="3172"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3253"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3269"/>
+        <location filename="../app/Main.qml" line="3323"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3278"/>
+        <location filename="../app/Main.qml" line="3332"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3307"/>
+        <location filename="../app/Main.qml" line="3361"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3446"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3432"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3486"/>
         <source>Favorites</source>
         <translation type="unfinished">Gogokoak</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3415"/>
-        <location filename="../app/Main.qml" line="3461"/>
+        <location filename="../app/Main.qml" line="3469"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3449"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3503"/>
+        <location filename="../app/Main.qml" line="3525"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3489"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3485"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3492"/>
+        <location filename="../app/Main.qml" line="3546"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1136,24 +1144,24 @@ Français - Wilfried</source>
         <translation type="obsolete">Abiarazlea gordetzen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3708"/>
+        <location filename="../app/Main.qml" line="3762"/>
         <source>Saving…</source>
         <translation type="unfinished">Gordetzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3119"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Launcher update failed</source>
         <translation type="unfinished">Abiarazle egukeraketak huts egin du</translation>
     </message>
@@ -1162,11 +1170,11 @@ Français - Wilfried</source>
         <translation type="obsolete">Errorea: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
-        <location filename="../app/Main.qml" line="3318"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="2910"/>
+        <location filename="../app/Main.qml" line="3372"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Retry</source>
         <translation type="unfinished">Berriro saiatu</translation>
     </message>
@@ -1175,22 +1183,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Utzi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4852"/>
+        <location filename="../app/Main.qml" line="4906"/>
         <source>Loading game…</source>
         <translation type="unfinished">Jokua kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4857"/>
+        <location filename="../app/Main.qml" line="4911"/>
         <source>Loading recently played…</source>
         <translation type="unfinished">Duela gutxi jokatutakoak kargatzen...</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4859"/>
+        <location filename="../app/Main.qml" line="4913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4861"/>
+        <location filename="../app/Main.qml" line="4915"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
@@ -1198,7 +1206,7 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Writing failed</source>
         <translation>Idazketak huts egin du</translation>
     </message>
@@ -1207,82 +1215,83 @@ Français - Wilfried</source>
         <translation type="vanished">Jarri idatzi daitekeen txartel bat irakurlearen ondoan</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="936"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="943"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="1365"/>
         <source>OK</source>
         <translation type="unfinished">Ados</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="535"/>
+        <location filename="../app/MainLayout.qml" line="541"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Hold a writable token near the reader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
         <source>Are you sure you want to exit?</source>
         <translation type="unfinished">Ziur zaude irten nahi duzula?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1387"/>
+        <location filename="../app/MainLayout.qml" line="1409"/>
         <source>Select</source>
         <translation>Aukeratu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1283"/>
-        <location filename="../app/MainLayout.qml" line="1297"/>
-        <location filename="../app/MainLayout.qml" line="1312"/>
-        <location filename="../app/MainLayout.qml" line="1323"/>
-        <location filename="../app/MainLayout.qml" line="1349"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1321"/>
+        <location filename="../app/MainLayout.qml" line="1332"/>
+        <location filename="../app/MainLayout.qml" line="1358"/>
         <source>Close</source>
         <translation>Itxi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1425"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1339"/>
+        <location filename="../app/MainLayout.qml" line="1391"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
         <source>Cancel</source>
         <translation>Utzi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1308"/>
+        <location filename="../app/MainLayout.qml" line="1317"/>
         <source>Done</source>
         <translation type="unfinished">Eginda</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1338"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
         <source>I understand</source>
         <translation type="unfinished">Ulertzen dut</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1376"/>
         <source>Saving…</source>
         <translation type="unfinished">Gordetzen...</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1389"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1291,28 +1300,29 @@ Français - Wilfried</source>
         <translation type="obsolete">Hasi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1656"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Scroll</source>
         <translation type="unfinished">Scroll-a egin</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1468"/>
-        <location filename="../app/MainLayout.qml" line="1555"/>
-        <location filename="../app/MainLayout.qml" line="1573"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
-        <location filename="../app/MainLayout.qml" line="1724"/>
+        <location filename="../app/MainLayout.qml" line="1500"/>
+        <location filename="../app/MainLayout.qml" line="1587"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1737"/>
+        <location filename="../app/MainLayout.qml" line="1756"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1374"/>
-        <location filename="../app/MainLayout.qml" line="1454"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1596"/>
-        <location filename="../app/MainLayout.qml" line="1615"/>
-        <location filename="../app/MainLayout.qml" line="1688"/>
+        <location filename="../app/MainLayout.qml" line="1284"/>
+        <location filename="../app/MainLayout.qml" line="1383"/>
+        <location filename="../app/MainLayout.qml" line="1405"/>
+        <location filename="../app/MainLayout.qml" line="1486"/>
+        <location filename="../app/MainLayout.qml" line="1523"/>
+        <location filename="../app/MainLayout.qml" line="1572"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1647"/>
+        <location filename="../app/MainLayout.qml" line="1720"/>
         <source>Move</source>
         <translation>Mugitu</translation>
     </message>
@@ -1322,8 +1332,8 @@ Français - Wilfried</source>
         <translation type="unfinished">Zaparoo Frontend</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="531"/>
-        <location filename="../app/MainLayout.qml" line="533"/>
+        <location filename="../app/MainLayout.qml" line="537"/>
+        <location filename="../app/MainLayout.qml" line="539"/>
         <source>Favorites</source>
         <translation type="unfinished">Gogokoak</translation>
     </message>
@@ -1332,36 +1342,36 @@ Français - Wilfried</source>
         <translation type="obsolete">Duela gutxi jokatuak</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="916"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished">Itxi eta Zaparoo Frontend berabiarazi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="917"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished">Ezarpenak indarrean jartzeko frontend-a berrabiarazi behar dugu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1096"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished">Itxi Zaparoo Frontend?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1417"/>
+        <location filename="../app/MainLayout.qml" line="1449"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1421"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1496"/>
-        <location filename="../app/MainLayout.qml" line="1545"/>
-        <location filename="../app/MainLayout.qml" line="1601"/>
-        <location filename="../app/MainLayout.qml" line="1693"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1528"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1633"/>
+        <location filename="../app/MainLayout.qml" line="1725"/>
         <source>Open</source>
         <translation>Ireki</translation>
     </message>
@@ -1370,19 +1380,20 @@ Français - Wilfried</source>
         <translation type="vanished">Irten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1477"/>
-        <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1513"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1559"/>
-        <location filename="../app/MainLayout.qml" line="1577"/>
-        <location filename="../app/MainLayout.qml" line="1589"/>
-        <location filename="../app/MainLayout.qml" line="1605"/>
-        <location filename="../app/MainLayout.qml" line="1639"/>
-        <location filename="../app/MainLayout.qml" line="1660"/>
-        <location filename="../app/MainLayout.qml" line="1669"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
-        <location filename="../app/MainLayout.qml" line="1728"/>
+        <location filename="../app/MainLayout.qml" line="1413"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1561"/>
+        <location filename="../app/MainLayout.qml" line="1591"/>
+        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1621"/>
+        <location filename="../app/MainLayout.qml" line="1637"/>
+        <location filename="../app/MainLayout.qml" line="1671"/>
+        <location filename="../app/MainLayout.qml" line="1692"/>
+        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1741"/>
+        <location filename="../app/MainLayout.qml" line="1760"/>
         <source>Back</source>
         <translation>Atzera</translation>
     </message>
@@ -1391,29 +1402,29 @@ Français - Wilfried</source>
         <translation type="obsolete">Orria</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1464"/>
-        <location filename="../app/MainLayout.qml" line="1499"/>
-        <location filename="../app/MainLayout.qml" line="1550"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1531"/>
+        <location filename="../app/MainLayout.qml" line="1582"/>
+        <location filename="../app/MainLayout.qml" line="1730"/>
         <source>Options</source>
         <translation type="unfinished">Aukerak</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1509"/>
-        <location filename="../app/MainLayout.qml" line="1567"/>
-        <location filename="../app/MainLayout.qml" line="1716"/>
+        <location filename="../app/MainLayout.qml" line="1328"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1541"/>
+        <location filename="../app/MainLayout.qml" line="1599"/>
+        <location filename="../app/MainLayout.qml" line="1748"/>
         <source>Retry</source>
         <translation>Berriro saiatu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1624"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Change</source>
         <translation>Aldatu</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1630"/>
+        <location filename="../app/MainLayout.qml" line="1662"/>
         <source>Toggle</source>
         <translation>Txandakatu</translation>
     </message>
@@ -1478,12 +1489,12 @@ Français - Wilfried</source>
 <context>
     <name>QrCodeModal</name>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="23"/>
+        <location filename="../components/QrCodeModal.qml" line="19"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="43"/>
+        <location filename="../components/QrCodeModal.qml" line="20"/>
         <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1513,44 +1524,72 @@ Français - Wilfried</source>
 <context>
     <name>ScrapeSetupModal</name>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="67"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Start</source>
+        <translation type="unfinished">Hasi</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Toggle</source>
+        <translation type="unfinished">Txandakatu</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Change</source>
+        <translation type="unfinished">Aldatu</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="89"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="69"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="91"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="171"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="193"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
+        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <source>Loading sources…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <source>Replace existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <source>Start import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scrape metadata</source>
-        <translation type="unfinished">Metadatuak scrapeatu</translation>
+        <translation type="obsolete">Metadatuak scrapeatu</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="185"/>
-        <source>Loading scrapers…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="196"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="222"/>
         <source>Re-scrape existing</source>
-        <translation type="unfinished">Berriro scrapeatzea existitzen da</translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
-        <source>Start scrape</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">Berriro scrapeatzea existitzen da</translation>
     </message>
 </context>
 <context>
@@ -1561,17 +1600,17 @@ Français - Wilfried</source>
         <translation>Ez dago ezer hemen</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="36"/>
         <source>Loading…</source>
         <translation type="unfinished">Kargatzen…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="37"/>
         <source>Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="79"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="85"/>
         <source>Failed to load</source>
         <translation>Ezin izan da kargatu</translation>
     </message>
@@ -1581,8 +1620,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="114"/>
         <location filename="../screens/SettingsScreen.qml" line="205"/>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
-        <location filename="../screens/SettingsScreen.qml" line="972"/>
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="978"/>
         <source>Language</source>
         <translation>Hizkuntza</translation>
     </message>
@@ -1606,25 +1645,25 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="165"/>
-        <location filename="../screens/SettingsScreen.qml" line="999"/>
+        <location filename="../screens/SettingsScreen.qml" line="1005"/>
         <source>Orientation</source>
         <translation type="unfinished">Orientazioa</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="225"/>
-        <location filename="../screens/SettingsScreen.qml" line="1051"/>
+        <location filename="../screens/SettingsScreen.qml" line="1057"/>
         <source>Button style</source>
         <translation type="unfinished">Botoi estiloa</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="1060"/>
+        <location filename="../screens/SettingsScreen.qml" line="1066"/>
         <source>Screensaver</source>
         <translation type="unfinished">Pantaila babeslea</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Library</source>
         <translation type="unfinished">Liburutegia</translation>
     </message>
@@ -1634,14 +1673,13 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="291"/>
-        <location filename="../screens/SettingsScreen.qml" line="1069"/>
+        <location filename="../screens/SettingsScreen.qml" line="1075"/>
         <source>Preferred artwork</source>
         <translation type="unfinished">Hobetsitako artelana</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Scrape metadata</source>
-        <translation type="unfinished">Metadatuak scrapeatu</translation>
+        <translation type="obsolete">Metadatuak scrapeatu</translation>
     </message>
     <message>
         <source>Re-scrape existing</source>
@@ -1652,12 +1690,12 @@ Français - Wilfried</source>
         <translation type="obsolete">Aurreratua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <location filename="../screens/SettingsScreen.qml" line="323"/>
         <source>Debug logging</source>
         <translation type="unfinished">Arazte erregistroa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="323"/>
+        <location filename="../screens/SettingsScreen.qml" line="329"/>
         <source>Upload log file</source>
         <translation type="unfinished">Igo erregistro fitxategia</translation>
     </message>
@@ -1668,7 +1706,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="217"/>
-        <location filename="../screens/SettingsScreen.qml" line="981"/>
+        <location filename="../screens/SettingsScreen.qml" line="987"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1679,13 +1717,13 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="158"/>
-        <location filename="../screens/SettingsScreen.qml" line="963"/>
+        <location filename="../screens/SettingsScreen.qml" line="969"/>
         <source>Interface resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="129"/>
-        <location filename="../screens/SettingsScreen.qml" line="1035"/>
+        <location filename="../screens/SettingsScreen.qml" line="1041"/>
         <source>Color scheme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1701,7 +1739,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <location filename="../screens/SettingsScreen.qml" line="1078"/>
+        <location filename="../screens/SettingsScreen.qml" line="1084"/>
         <source>Video standard</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1712,7 +1750,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="135"/>
-        <location filename="../screens/SettingsScreen.qml" line="1026"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
         <source>System logos</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1733,19 +1771,19 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="90"/>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="120"/>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="211"/>
-        <location filename="../screens/SettingsScreen.qml" line="990"/>
+        <location filename="../screens/SettingsScreen.qml" line="996"/>
         <source>Region</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1755,35 +1793,34 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Optimizing</source>
         <translation type="unfinished">Optimizatzen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>Paused</source>
         <translation type="unfinished">Geldituta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>In progress</source>
         <translation type="unfinished">Abian</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>%1 indexed</source>
         <translation type="unfinished">%1 indexatuta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>%1 scraped</source>
-        <translation type="unfinished">%1 scrapetatuta</translation>
+        <translation type="obsolete">%1 scrapetatuta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Cancel</source>
         <translation type="unfinished">Utzi</translation>
     </message>
@@ -1792,117 +1829,117 @@ Français - Wilfried</source>
         <translation type="obsolete">Hasi</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Upload</source>
         <translation type="unfinished">Igo</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="650"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Open</source>
         <translation type="unfinished">Ireki</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>%1 × %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Automatic (Recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="717"/>
         <source>%1 (Animations off)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="758"/>
         <source>English</source>
         <translation>Ingelera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="760"/>
         <source>Italian</source>
         <translation>Italiera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="756"/>
+        <location filename="../screens/SettingsScreen.qml" line="762"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="758"/>
+        <location filename="../screens/SettingsScreen.qml" line="764"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="760"/>
+        <location filename="../screens/SettingsScreen.qml" line="766"/>
         <source>German</source>
         <translation type="unfinished">Alemaniera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="762"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Greek</source>
         <translation type="unfinished">Grekoa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="764"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Japanese</source>
         <translation type="unfinished">Japoniera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="766"/>
+        <location filename="../screens/SettingsScreen.qml" line="772"/>
         <source>Korean</source>
         <translation type="unfinished">Koreera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Dutch</source>
         <translation type="unfinished">Holandera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="776"/>
         <source>Romanian</source>
         <translation type="unfinished">Errumaniera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="778"/>
         <source>Slovak</source>
         <translation type="unfinished">eslovakiera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="774"/>
+        <location filename="../screens/SettingsScreen.qml" line="780"/>
         <source>Ukrainian</source>
         <translation type="unfinished">Ukraniera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="776"/>
+        <location filename="../screens/SettingsScreen.qml" line="782"/>
         <source>Chinese (Simplified)</source>
         <translation type="unfinished">Txinera (sinplifikatua)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="778"/>
+        <location filename="../screens/SettingsScreen.qml" line="784"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="780"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="782"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Arabic</source>
         <translation type="unfinished">Arabiera</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="784"/>
+        <location filename="../screens/SettingsScreen.qml" line="790"/>
         <source>Hindi</source>
         <translation type="unfinished">HIndia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>French</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1911,37 +1948,37 @@ Français - Wilfried</source>
         <translation type="vanished">Auto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="792"/>
+        <location filename="../screens/SettingsScreen.qml" line="798"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="794"/>
+        <location filename="../screens/SettingsScreen.qml" line="800"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="805"/>
+        <location filename="../screens/SettingsScreen.qml" line="811"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="807"/>
+        <location filename="../screens/SettingsScreen.qml" line="813"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="809"/>
+        <location filename="../screens/SettingsScreen.qml" line="815"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
-        <location filename="../screens/SettingsScreen.qml" line="787"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
-        <location filename="../screens/SettingsScreen.qml" line="810"/>
-        <location filename="../screens/SettingsScreen.qml" line="877"/>
-        <location filename="../screens/SettingsScreen.qml" line="925"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="793"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
+        <location filename="../screens/SettingsScreen.qml" line="816"/>
+        <location filename="../screens/SettingsScreen.qml" line="883"/>
+        <location filename="../screens/SettingsScreen.qml" line="931"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1996,19 +2033,14 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Downloads box art, descriptions, and tags for your games. Choose a source and which systems.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
-        <location filename="../screens/SettingsScreen.qml" line="1008"/>
+        <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="285"/>
-        <location filename="../screens/SettingsScreen.qml" line="1017"/>
+        <location filename="../screens/SettingsScreen.qml" line="1023"/>
         <source>Games layout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2023,93 +2055,93 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <location filename="../screens/SettingsScreen.qml" line="324"/>
         <source>Writes extra detail to the log file to help track down a problem. Restarts the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Configure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="815"/>
+        <location filename="../screens/SettingsScreen.qml" line="821"/>
         <source>Rotated CW</source>
         <translation type="unfinished">CW biratua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="817"/>
+        <location filename="../screens/SettingsScreen.qml" line="823"/>
         <source>Rotated CCW</source>
         <translation type="unfinished">CCW biratua</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="818"/>
+        <location filename="../screens/SettingsScreen.qml" line="824"/>
         <source>Horizontal</source>
         <translation type="unfinished">Horizontala</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="823"/>
+        <location filename="../screens/SettingsScreen.qml" line="829"/>
         <source>Detailed list view</source>
         <translation>Xehetasun listaren ikuspegia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="824"/>
+        <location filename="../screens/SettingsScreen.qml" line="830"/>
         <source>Grid view</source>
         <translation>Sarearen ikuspegia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="829"/>
+        <location filename="../screens/SettingsScreen.qml" line="835"/>
         <source>Full color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="830"/>
+        <location filename="../screens/SettingsScreen.qml" line="836"/>
         <source>Tinted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="868"/>
+        <location filename="../screens/SettingsScreen.qml" line="874"/>
         <source>Style B</source>
         <translation type="unfinished">B estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="870"/>
+        <location filename="../screens/SettingsScreen.qml" line="876"/>
         <source>Style C</source>
         <translation type="unfinished">C estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="872"/>
+        <location filename="../screens/SettingsScreen.qml" line="878"/>
         <source>Style D</source>
         <translation type="unfinished">D estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="874"/>
+        <location filename="../screens/SettingsScreen.qml" line="880"/>
         <source>Style E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="876"/>
+        <location filename="../screens/SettingsScreen.qml" line="882"/>
         <source>Style A</source>
         <translation type="unfinished">A estiloa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="917"/>
+        <location filename="../screens/SettingsScreen.qml" line="923"/>
         <source>PAL (50 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="919"/>
+        <location filename="../screens/SettingsScreen.qml" line="925"/>
         <source>480i (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="920"/>
+        <location filename="../screens/SettingsScreen.qml" line="926"/>
         <source>NTSC (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1905"/>
+        <location filename="../screens/SettingsScreen.qml" line="1911"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2118,47 +2150,47 @@ Français - Wilfried</source>
         <translation type="vanished">Lehenetsia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="892"/>
+        <location filename="../screens/SettingsScreen.qml" line="898"/>
         <source>Off</source>
         <translation type="unfinished">Desaktibatuta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="894"/>
+        <location filename="../screens/SettingsScreen.qml" line="900"/>
         <source>1 second (testing)</source>
         <translation type="unfinished">segundu 1 (frogatzen)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="896"/>
+        <location filename="../screens/SettingsScreen.qml" line="902"/>
         <source>1 minute</source>
         <translation type="unfinished">minutu 1</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="898"/>
+        <location filename="../screens/SettingsScreen.qml" line="904"/>
         <source>2 minutes</source>
         <translation type="unfinished">2 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="900"/>
+        <location filename="../screens/SettingsScreen.qml" line="906"/>
         <source>5 minutes</source>
         <translation type="unfinished">5 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="902"/>
+        <location filename="../screens/SettingsScreen.qml" line="908"/>
         <source>10 minutes</source>
         <translation type="unfinished">10 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="904"/>
+        <location filename="../screens/SettingsScreen.qml" line="910"/>
         <source>15 minutes</source>
         <translation type="unfinished">15 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="906"/>
+        <location filename="../screens/SettingsScreen.qml" line="912"/>
         <source>30 minutes</source>
         <translation type="unfinished">30 minutu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="907"/>
+        <location filename="../screens/SettingsScreen.qml" line="913"/>
         <source>%1 seconds</source>
         <translation type="unfinished">%1 segundu</translation>
     </message>
@@ -2168,93 +2200,93 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="108"/>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="855"/>
+        <location filename="../screens/SettingsScreen.qml" line="861"/>
         <source>Nord</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="852"/>
+        <location filename="../screens/SettingsScreen.qml" line="858"/>
         <source>Dracula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="859"/>
+        <location filename="../screens/SettingsScreen.qml" line="865"/>
         <source>Synthwave &apos;84</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="846"/>
+        <location filename="../screens/SettingsScreen.qml" line="852"/>
         <source>Amber Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="848"/>
+        <location filename="../screens/SettingsScreen.qml" line="854"/>
         <source>Green Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="849"/>
+        <location filename="../screens/SettingsScreen.qml" line="855"/>
         <source>Neo Geo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="850"/>
+        <location filename="../screens/SettingsScreen.qml" line="856"/>
         <source>NES</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="851"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>Virtual Boy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="854"/>
+        <location filename="../screens/SettingsScreen.qml" line="860"/>
         <source>Gruvbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="853"/>
+        <location filename="../screens/SettingsScreen.qml" line="859"/>
         <source>Everforest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="858"/>
+        <location filename="../screens/SettingsScreen.qml" line="864"/>
         <source>Solarized Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="863"/>
         <source>Rosé Pine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="856"/>
+        <location filename="../screens/SettingsScreen.qml" line="862"/>
         <source>Oxocarbon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="860"/>
+        <location filename="../screens/SettingsScreen.qml" line="866"/>
         <source>Flexoki Paper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="861"/>
+        <location filename="../screens/SettingsScreen.qml" line="867"/>
         <source>Solarized Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="847"/>
+        <location filename="../screens/SettingsScreen.qml" line="853"/>
         <source>Game Boy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2304,6 +2336,16 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="269"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="280"/>
         <source>Show systems as a grid of covers, or as a list with details beside it.</source>
         <translation type="unfinished"></translation>
@@ -2324,92 +2366,107 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="324"/>
+        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <source>Shows a code you can scan to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="330"/>
         <source>Uploads the log file and gives you a link to share when reporting a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="927"/>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <source>%1 imported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="933"/>
         <source>Image</source>
         <translation type="unfinished">Irudia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="929"/>
+        <location filename="../screens/SettingsScreen.qml" line="935"/>
         <source>Thumbnail</source>
         <translation type="unfinished">Miniatura</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="931"/>
+        <location filename="../screens/SettingsScreen.qml" line="937"/>
         <source>Box art</source>
         <translation type="unfinished">Kaxaren artelana</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="933"/>
+        <location filename="../screens/SettingsScreen.qml" line="939"/>
         <source>3D box art</source>
         <translation type="unfinished">Kaxaren 3D artelana</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="935"/>
+        <location filename="../screens/SettingsScreen.qml" line="941"/>
         <source>Screenshot</source>
         <translation type="unfinished">Pantaila argazkoa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="937"/>
+        <location filename="../screens/SettingsScreen.qml" line="943"/>
         <source>Wheel</source>
         <translation type="unfinished">Gurpila</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="939"/>
+        <location filename="../screens/SettingsScreen.qml" line="945"/>
         <source>Title screen</source>
         <translation type="unfinished">Izenburu pantaila</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="941"/>
+        <location filename="../screens/SettingsScreen.qml" line="947"/>
         <source>Map</source>
         <translation type="unfinished">Mapa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="943"/>
+        <location filename="../screens/SettingsScreen.qml" line="949"/>
         <source>Marquee</source>
         <translation type="unfinished">Karpa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="945"/>
+        <location filename="../screens/SettingsScreen.qml" line="951"/>
         <source>Fan art</source>
         <translation type="unfinished">Fan artelana</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="947"/>
+        <location filename="../screens/SettingsScreen.qml" line="953"/>
         <source>Box side</source>
         <translation type="unfinished">Kaxa alboa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="949"/>
+        <location filename="../screens/SettingsScreen.qml" line="955"/>
         <source>Box back</source>
         <translation type="unfinished">Kaxa atzekaldea</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="355"/>
+        <location filename="../screens/SettingsScreen.qml" line="361"/>
         <source>Settings</source>
         <translation>Ezarpenak</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="843"/>
+        <location filename="../screens/SettingsScreen.qml" line="849"/>
         <source>Zaparoo Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="844"/>
+        <location filename="../screens/SettingsScreen.qml" line="850"/>
         <source>Zaparoo Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="845"/>
+        <location filename="../screens/SettingsScreen.qml" line="851"/>
         <source>Classic Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1887"/>
+        <location filename="../screens/SettingsScreen.qml" line="1893"/>
         <source>No settings available on this platform</source>
         <translation>Ez dago ezarpenik plataforma honetan</translation>
     </message>
@@ -2443,6 +2500,31 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/StatusLine.qml" line="105"/>
+        <source>Importing paused: game running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Import failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Imported %1 of %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/StatusLine.qml" line="248"/>
         <location filename="../components/StatusLine.qml" line="271"/>
         <source>%1%</source>
@@ -2464,9 +2546,8 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping…</source>
-        <translation type="unfinished">Scrapeatzen...</translation>
+        <translation type="obsolete">Scrapeatzen...</translation>
     </message>
     <message>
         <source>%1 / %2</source>
@@ -2480,16 +2561,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="105"/>
-        <source>Scraping paused: game running</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="106"/>
-        <source>Scraping: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2508,16 +2579,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scraped %1 of %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -2146,7 +2146,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1911"/>
+        <location filename="../screens/SettingsScreen.qml" line="1913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2466,7 +2466,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1893"/>
+        <location filename="../screens/SettingsScreen.qml" line="1895"/>
         <source>No settings available on this platform</source>
         <translation>Ez dago ezarpenik plataforma honetan</translation>
     </message>

--- a/src/ui/translations/frontend_eu.ts
+++ b/src/ui/translations/frontend_eu.ts
@@ -2033,6 +2033,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
         <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
@@ -2338,11 +2343,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Get metadata</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_fr.ts
+++ b/src/ui/translations/frontend_fr.ts
@@ -2151,7 +2151,7 @@ Français - Wilfried</translation>
         <translation>NTSC (60 Hz)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1911"/>
+        <location filename="../screens/SettingsScreen.qml" line="1913"/>
         <source>Loading settings…</source>
         <translation>Chargement des réglages…</translation>
     </message>
@@ -2481,7 +2481,7 @@ Français - Wilfried</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1893"/>
+        <location filename="../screens/SettingsScreen.qml" line="1895"/>
         <source>No settings available on this platform</source>
         <translation>Aucun réglage disponible sur cette plateforme</translation>
     </message>

--- a/src/ui/translations/frontend_fr.ts
+++ b/src/ui/translations/frontend_fr.ts
@@ -396,49 +396,6 @@ Français - Wilfried</translation>
     </message>
 </context>
 <context>
-    <name>FirstRunIndexModal</name>
-    <message>
-        <source>First-time setup</source>
-        <translation type="vanished">Configuration initiale</translation>
-    </message>
-    <message>
-        <source>Indexing paused</source>
-        <translation type="vanished">Indexation en pause</translation>
-    </message>
-    <message>
-        <source>Optimizing database - almost done</source>
-        <translation type="vanished">Optimisation de la base de données - presque terminé</translation>
-    </message>
-    <message>
-        <source>Zaparoo needs to scan your games before you can use the frontend. This usually takes a few minutes.</source>
-        <translation type="vanished">Zaparoo doit analyser vos jeux avant de pouvoir utiliser le frontend. Cela prend généralement quelques minutes.</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2 - %3</source>
-        <translation type="vanished">Étape %1 sur %2 - %3</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2</source>
-        <translation type="vanished">Étape %1 sur %2</translation>
-    </message>
-    <message>
-        <source>Preparing…</source>
-        <translation type="vanished">Préparation…</translation>
-    </message>
-    <message>
-        <source>Done. %1 files indexed.</source>
-        <translation type="vanished">Terminé. %1 fichiers indexés.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Annuler</translation>
-    </message>
-    <message>
-        <source>Start scan</source>
-        <translation type="vanished">Lancer l&apos;analyse</translation>
-    </message>
-</context>
-<context>
     <name>GameInfoModal</name>
     <message>
         <location filename="../components/GameInfoModal.qml" line="153"/>
@@ -559,6 +516,26 @@ Français - Wilfried</translation>
         <translation>Favoris</translation>
     </message>
     <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>Updating the media database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>No games found yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Your games appear here as Core finds them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Update media database in Settings &gt; Library.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Recently Played</source>
         <translation type="vanished">Joués récemment</translation>
     </message>
@@ -592,35 +569,44 @@ Français - Wilfried</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
-        <translation>Aucun système disponible. Lancez Mettre à jour la base de données média depuis les Réglages.</translation>
+        <translation type="vanished">Aucun système disponible. Lancez Mettre à jour la base de données média depuis les Réglages.</translation>
     </message>
 </context>
 <context>
     <name>IndexSetupModal</name>
     <message>
         <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Start</source>
+        <translation type="unfinished">Démarrer</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Change</source>
+        <translation type="unfinished">Modifier</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="51"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="47"/>
+        <location filename="../components/IndexSetupModal.qml" line="53"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="115"/>
+        <location filename="../components/IndexSetupModal.qml" line="121"/>
         <source>Update media database</source>
         <translation type="unfinished">Mettre à jour la base de données média</translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="124"/>
+        <location filename="../components/IndexSetupModal.qml" line="130"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="137"/>
+        <location filename="../components/IndexSetupModal.qml" line="143"/>
         <source>Start update</source>
         <translation type="unfinished"></translation>
     </message>
@@ -702,29 +688,29 @@ Français - Wilfried</translation>
         <translation type="vanished">Lancer le core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
-        <location filename="../app/Main.qml" line="2330"/>
-        <location filename="../app/Main.qml" line="2393"/>
-        <location filename="../app/Main.qml" line="2699"/>
-        <location filename="../app/Main.qml" line="3741"/>
-        <location filename="../app/Main.qml" line="3784"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
+        <location filename="../app/Main.qml" line="2341"/>
+        <location filename="../app/Main.qml" line="2410"/>
+        <location filename="../app/Main.qml" line="2716"/>
+        <location filename="../app/Main.qml" line="3795"/>
+        <location filename="../app/Main.qml" line="3838"/>
         <source>Change launcher</source>
         <translation>Modifier le lanceur</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Remove from favorites</source>
         <translation>Retirer des favoris</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Add to favorites</source>
         <translation>Ajouter aux favoris</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2264"/>
-        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2266"/>
+        <location filename="../app/Main.qml" line="2346"/>
         <source>Write to NFC token</source>
         <translation>Écrire sur un badge NFC</translation>
     </message>
@@ -733,8 +719,8 @@ Français - Wilfried</translation>
         <translation type="vanished">QR code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
-        <location filename="../app/Main.qml" line="2308"/>
+        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2319"/>
         <source>Launch game</source>
         <translation>Lancer le jeu</translation>
     </message>
@@ -744,41 +730,64 @@ Français - Wilfried</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1070"/>
-        <location filename="../app/Main.qml" line="3417"/>
-        <location filename="../app/Main.qml" line="3464"/>
-        <location filename="../app/Main.qml" line="3474"/>
+        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3518"/>
+        <location filename="../app/Main.qml" line="3528"/>
         <source>View</source>
         <translation>Afficher</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4848"/>
+        <location filename="../app/Main.qml" line="3153"/>
+        <source>Get metadata failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3154"/>
+        <source>Could not start getting metadata. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3156"/>
+        <source>Source list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3157"/>
+        <source>Could not load the list of metadata sources. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3307"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="4902"/>
         <source>Loading systems…</source>
         <translation>Chargement des systèmes…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4855"/>
+        <location filename="../app/Main.qml" line="4909"/>
         <source>Loading favorites…</source>
         <translation>Chargement des favoris…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4850"/>
+        <location filename="../app/Main.qml" line="4904"/>
         <source>Loading games…</source>
         <translation>Chargement des jeux…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2183"/>
-        <location filename="../app/Main.qml" line="2218"/>
+        <location filename="../app/Main.qml" line="2185"/>
+        <location filename="../app/Main.qml" line="2220"/>
         <source>Update media database</source>
         <translation>Mettre à jour la base de données média</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2186"/>
-        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
-        <translation>Scraper les métadonnées</translation>
+        <translation type="vanished">Scraper les métadonnées</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2179"/>
         <source>Unhide</source>
         <translation>Afficher</translation>
     </message>
@@ -788,58 +797,58 @@ Français - Wilfried</translation>
         <translation type="unfinished">Réglages</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2096"/>
+        <location filename="../app/Main.qml" line="2098"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2153"/>
+        <location filename="../app/Main.qml" line="2155"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2179"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Hide</source>
         <translation>Masquer</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2258"/>
-        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2323"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
-        <location filename="../app/Main.qml" line="2346"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2280"/>
+        <location filename="../app/Main.qml" line="2357"/>
+        <location filename="../app/Main.qml" line="2451"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3507"/>
+        <location filename="../app/Main.qml" line="2395"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3561"/>
         <source>Default</source>
         <translation>Par défaut</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2395"/>
         <source>Current: %1</source>
         <translation>Actuel&#xa0;: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2230"/>
-        <location filename="../app/Main.qml" line="2238"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="2164"/>
+        <location filename="../app/Main.qml" line="2215"/>
+        <location filename="../app/Main.qml" line="2232"/>
+        <location filename="../app/Main.qml" line="2240"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3454"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
@@ -868,45 +877,46 @@ Français - Wilfried</translation>
         <translation type="unfinished">Quitter</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2173"/>
-        <location filename="../app/Main.qml" line="2282"/>
-        <location filename="../app/Main.qml" line="2301"/>
-        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2284"/>
+        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2361"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2268"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2270"/>
+        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2807"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2461"/>
+        <location filename="../app/Main.qml" line="2478"/>
         <source>Move</source>
         <translation type="unfinished">Déplacer</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2667"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1032"/>
-        <location filename="../app/Main.qml" line="3043"/>
-        <location filename="../app/Main.qml" line="3065"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3131"/>
+        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3174"/>
         <source>OK</source>
         <translation type="unfinished">OK</translation>
     </message>
@@ -921,232 +931,230 @@ Français - Wilfried</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="2188"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2293"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2807"/>
+        <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Scan this code to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3132"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3098"/>
+        <location filename="../app/Main.qml" line="3141"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3099"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3101"/>
+        <location filename="../app/Main.qml" line="3144"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3147"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3105"/>
+        <location filename="../app/Main.qml" line="3148"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3107"/>
+        <location filename="../app/Main.qml" line="3150"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3151"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3110"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3111"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3113"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3114"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3116"/>
+        <location filename="../app/Main.qml" line="3159"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3120"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3122"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3123"/>
+        <location filename="../app/Main.qml" line="3166"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3125"/>
+        <location filename="../app/Main.qml" line="3168"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3126"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3128"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3129"/>
+        <location filename="../app/Main.qml" line="3172"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3253"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3269"/>
+        <location filename="../app/Main.qml" line="3323"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3278"/>
+        <location filename="../app/Main.qml" line="3332"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3307"/>
+        <location filename="../app/Main.qml" line="3361"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3446"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3460"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3432"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3486"/>
         <source>Favorites</source>
         <translation type="unfinished">Favoris</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3482"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3415"/>
-        <location filename="../app/Main.qml" line="3461"/>
+        <location filename="../app/Main.qml" line="3469"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3436"/>
+        <location filename="../app/Main.qml" line="3490"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3445"/>
+        <location filename="../app/Main.qml" line="3499"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3449"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3503"/>
+        <location filename="../app/Main.qml" line="3525"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3489"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3485"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3492"/>
+        <location filename="../app/Main.qml" line="3546"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3511"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3565"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3515"/>
+        <location filename="../app/Main.qml" line="3569"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1155,24 +1163,24 @@ Français - Wilfried</translation>
         <translation type="vanished">Enregistrement du lanceur</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3708"/>
+        <location filename="../app/Main.qml" line="3762"/>
         <source>Saving…</source>
         <translation>Enregistrement…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3119"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Launcher update failed</source>
         <translation>Échec de la mise à jour du lanceur</translation>
     </message>
@@ -1181,11 +1189,11 @@ Français - Wilfried</translation>
         <translation type="vanished">Erreur&#xa0;: %1</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
-        <location filename="../app/Main.qml" line="3318"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="2910"/>
+        <location filename="../app/Main.qml" line="3372"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Retry</source>
         <translation>Réessayer</translation>
     </message>
@@ -1194,22 +1202,22 @@ Français - Wilfried</translation>
         <translation type="vanished">Annuler</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4852"/>
+        <location filename="../app/Main.qml" line="4906"/>
         <source>Loading game…</source>
         <translation>Chargement du jeu…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4857"/>
+        <location filename="../app/Main.qml" line="4911"/>
         <source>Loading recently played…</source>
         <translation>Chargement des jeux récents…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4859"/>
+        <location filename="../app/Main.qml" line="4913"/>
         <source>Loading settings…</source>
         <translation>Chargement des réglages…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4861"/>
+        <location filename="../app/Main.qml" line="4915"/>
         <source>Loading…</source>
         <translation>Chargement…</translation>
     </message>
@@ -1217,7 +1225,7 @@ Français - Wilfried</translation>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Writing failed</source>
         <translation>Échec de l&apos;écriture</translation>
     </message>
@@ -1226,82 +1234,83 @@ Français - Wilfried</translation>
         <translation type="vanished">Placez une carte inscriptible près du lecteur</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="936"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
         <source>Update Zaparoo Core</source>
         <translation>Mettre à jour Zaparoo Core</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="943"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation>Ce frontend nécessite Zaparoo Core %1 ou plus récent. Vous utilisez la version %2. Certaines fonctionnalités peuvent ne pas fonctionner tant que la mise à jour n&apos;est pas effectuée.</translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="1365"/>
         <source>OK</source>
         <translation>OK</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="535"/>
+        <location filename="../app/MainLayout.qml" line="541"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Hold a writable token near the reader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
         <source>Are you sure you want to exit?</source>
         <translation>Êtes-vous sûr de vouloir quitter&#xa0;?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1387"/>
+        <location filename="../app/MainLayout.qml" line="1409"/>
         <source>Select</source>
         <translation>Sélectionner</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1283"/>
-        <location filename="../app/MainLayout.qml" line="1297"/>
-        <location filename="../app/MainLayout.qml" line="1312"/>
-        <location filename="../app/MainLayout.qml" line="1323"/>
-        <location filename="../app/MainLayout.qml" line="1349"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1321"/>
+        <location filename="../app/MainLayout.qml" line="1332"/>
+        <location filename="../app/MainLayout.qml" line="1358"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1425"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1339"/>
+        <location filename="../app/MainLayout.qml" line="1391"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1308"/>
+        <location filename="../app/MainLayout.qml" line="1317"/>
         <source>Done</source>
         <translation>Terminé</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1338"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
         <source>I understand</source>
         <translation>J&apos;ai compris</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1376"/>
         <source>Saving…</source>
         <translation type="unfinished">Enregistrement…</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1389"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Adjust</source>
         <translation>Ajuster</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Save</source>
         <translation>Enregistrer</translation>
     </message>
@@ -1310,28 +1319,29 @@ Français - Wilfried</translation>
         <translation type="vanished">Démarrer</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1656"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Scroll</source>
         <translation>Défiler</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1468"/>
-        <location filename="../app/MainLayout.qml" line="1555"/>
-        <location filename="../app/MainLayout.qml" line="1573"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
-        <location filename="../app/MainLayout.qml" line="1724"/>
+        <location filename="../app/MainLayout.qml" line="1500"/>
+        <location filename="../app/MainLayout.qml" line="1587"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1737"/>
+        <location filename="../app/MainLayout.qml" line="1756"/>
         <source>View</source>
         <translation>Afficher</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1374"/>
-        <location filename="../app/MainLayout.qml" line="1454"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1596"/>
-        <location filename="../app/MainLayout.qml" line="1615"/>
-        <location filename="../app/MainLayout.qml" line="1688"/>
+        <location filename="../app/MainLayout.qml" line="1284"/>
+        <location filename="../app/MainLayout.qml" line="1383"/>
+        <location filename="../app/MainLayout.qml" line="1405"/>
+        <location filename="../app/MainLayout.qml" line="1486"/>
+        <location filename="../app/MainLayout.qml" line="1523"/>
+        <location filename="../app/MainLayout.qml" line="1572"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1647"/>
+        <location filename="../app/MainLayout.qml" line="1720"/>
         <source>Move</source>
         <translation>Déplacer</translation>
     </message>
@@ -1341,8 +1351,8 @@ Français - Wilfried</translation>
         <translation>Zaparoo Frontend</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="531"/>
-        <location filename="../app/MainLayout.qml" line="533"/>
+        <location filename="../app/MainLayout.qml" line="537"/>
+        <location filename="../app/MainLayout.qml" line="539"/>
         <source>Favorites</source>
         <translation>Favoris</translation>
     </message>
@@ -1351,36 +1361,36 @@ Français - Wilfried</translation>
         <translation type="vanished">Joués récemment</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="916"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation>Quitter et redémarrer Zaparoo Frontend&#xa0;?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="917"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation>Pour appliquer ce réglage, le frontend doit être redémarré.</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1096"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation>Quitter Zaparoo Frontend&#xa0;?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1417"/>
+        <location filename="../app/MainLayout.qml" line="1449"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1421"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1496"/>
-        <location filename="../app/MainLayout.qml" line="1545"/>
-        <location filename="../app/MainLayout.qml" line="1601"/>
-        <location filename="../app/MainLayout.qml" line="1693"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1528"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1633"/>
+        <location filename="../app/MainLayout.qml" line="1725"/>
         <source>Open</source>
         <translation>Ouvrir</translation>
     </message>
@@ -1389,46 +1399,47 @@ Français - Wilfried</translation>
         <translation type="vanished">Quitter</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1477"/>
-        <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1513"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1559"/>
-        <location filename="../app/MainLayout.qml" line="1577"/>
-        <location filename="../app/MainLayout.qml" line="1589"/>
-        <location filename="../app/MainLayout.qml" line="1605"/>
-        <location filename="../app/MainLayout.qml" line="1639"/>
-        <location filename="../app/MainLayout.qml" line="1660"/>
-        <location filename="../app/MainLayout.qml" line="1669"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
-        <location filename="../app/MainLayout.qml" line="1728"/>
+        <location filename="../app/MainLayout.qml" line="1413"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1561"/>
+        <location filename="../app/MainLayout.qml" line="1591"/>
+        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1621"/>
+        <location filename="../app/MainLayout.qml" line="1637"/>
+        <location filename="../app/MainLayout.qml" line="1671"/>
+        <location filename="../app/MainLayout.qml" line="1692"/>
+        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1741"/>
+        <location filename="../app/MainLayout.qml" line="1760"/>
         <source>Back</source>
         <translation>Retour</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1464"/>
-        <location filename="../app/MainLayout.qml" line="1499"/>
-        <location filename="../app/MainLayout.qml" line="1550"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1531"/>
+        <location filename="../app/MainLayout.qml" line="1582"/>
+        <location filename="../app/MainLayout.qml" line="1730"/>
         <source>Options</source>
         <translation>Options</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1509"/>
-        <location filename="../app/MainLayout.qml" line="1567"/>
-        <location filename="../app/MainLayout.qml" line="1716"/>
+        <location filename="../app/MainLayout.qml" line="1328"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1541"/>
+        <location filename="../app/MainLayout.qml" line="1599"/>
+        <location filename="../app/MainLayout.qml" line="1748"/>
         <source>Retry</source>
         <translation>Réessayer</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1624"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Change</source>
         <translation>Modifier</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1630"/>
+        <location filename="../app/MainLayout.qml" line="1662"/>
         <source>Toggle</source>
         <translation>Basculer</translation>
     </message>
@@ -1493,12 +1504,12 @@ Français - Wilfried</translation>
 <context>
     <name>QrCodeModal</name>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="23"/>
+        <location filename="../components/QrCodeModal.qml" line="19"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="43"/>
+        <location filename="../components/QrCodeModal.qml" line="20"/>
         <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1528,44 +1539,72 @@ Français - Wilfried</translation>
 <context>
     <name>ScrapeSetupModal</name>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="67"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Start</source>
+        <translation type="unfinished">Démarrer</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Toggle</source>
+        <translation type="unfinished">Basculer</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Change</source>
+        <translation type="unfinished">Modifier</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="89"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="69"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="91"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="171"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="193"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
+        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <source>Loading sources…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <source>Replace existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <source>Start import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scrape metadata</source>
-        <translation type="unfinished">Scraper les métadonnées</translation>
+        <translation type="obsolete">Scraper les métadonnées</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="185"/>
-        <source>Loading scrapers…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="196"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="222"/>
         <source>Re-scrape existing</source>
-        <translation type="unfinished">Re-scraper l&apos;existant</translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
-        <source>Start scrape</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">Re-scraper l&apos;existant</translation>
     </message>
 </context>
 <context>
@@ -1576,17 +1615,17 @@ Français - Wilfried</translation>
         <translation>Rien ici</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="36"/>
         <source>Loading…</source>
         <translation>Chargement…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="37"/>
         <source>Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="79"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="85"/>
         <source>Failed to load</source>
         <translation>Échec du chargement</translation>
     </message>
@@ -1596,8 +1635,8 @@ Français - Wilfried</translation>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="114"/>
         <location filename="../screens/SettingsScreen.qml" line="205"/>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
-        <location filename="../screens/SettingsScreen.qml" line="972"/>
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="978"/>
         <source>Language</source>
         <translation>Langue</translation>
     </message>
@@ -1617,19 +1656,19 @@ Français - Wilfried</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="165"/>
-        <location filename="../screens/SettingsScreen.qml" line="999"/>
+        <location filename="../screens/SettingsScreen.qml" line="1005"/>
         <source>Orientation</source>
         <translation>Orientation</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="225"/>
-        <location filename="../screens/SettingsScreen.qml" line="1051"/>
+        <location filename="../screens/SettingsScreen.qml" line="1057"/>
         <source>Button style</source>
         <translation>Style des boutons</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="1060"/>
+        <location filename="../screens/SettingsScreen.qml" line="1066"/>
         <source>Screensaver</source>
         <translation>Économiseur d&apos;écran</translation>
     </message>
@@ -1639,26 +1678,25 @@ Français - Wilfried</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="291"/>
-        <location filename="../screens/SettingsScreen.qml" line="1069"/>
+        <location filename="../screens/SettingsScreen.qml" line="1075"/>
         <source>Preferred artwork</source>
         <translation>Illustration préférée</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Scrape metadata</source>
-        <translation>Scraper les métadonnées</translation>
+        <translation type="vanished">Scraper les métadonnées</translation>
     </message>
     <message>
         <source>Re-scrape existing</source>
         <translation type="vanished">Re-scraper l&apos;existant</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <location filename="../screens/SettingsScreen.qml" line="323"/>
         <source>Debug logging</source>
         <translation>Journalisation de débogage</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="323"/>
+        <location filename="../screens/SettingsScreen.qml" line="329"/>
         <source>Upload log file</source>
         <translation>Envoyer le fichier journal</translation>
     </message>
@@ -1669,7 +1707,7 @@ Français - Wilfried</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="217"/>
-        <location filename="../screens/SettingsScreen.qml" line="981"/>
+        <location filename="../screens/SettingsScreen.qml" line="987"/>
         <source>Clock format</source>
         <translation>Format de l&apos;heure</translation>
     </message>
@@ -1684,13 +1722,13 @@ Français - Wilfried</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="158"/>
-        <location filename="../screens/SettingsScreen.qml" line="963"/>
+        <location filename="../screens/SettingsScreen.qml" line="969"/>
         <source>Interface resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="129"/>
-        <location filename="../screens/SettingsScreen.qml" line="1035"/>
+        <location filename="../screens/SettingsScreen.qml" line="1041"/>
         <source>Color scheme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1706,7 +1744,7 @@ Français - Wilfried</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <location filename="../screens/SettingsScreen.qml" line="1078"/>
+        <location filename="../screens/SettingsScreen.qml" line="1084"/>
         <source>Video standard</source>
         <translation>Standard vidéo</translation>
     </message>
@@ -1717,7 +1755,7 @@ Français - Wilfried</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="135"/>
-        <location filename="../screens/SettingsScreen.qml" line="1026"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
         <source>System logos</source>
         <translation>Logos des systèmes</translation>
     </message>
@@ -1738,19 +1776,19 @@ Français - Wilfried</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="90"/>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="120"/>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="211"/>
-        <location filename="../screens/SettingsScreen.qml" line="990"/>
+        <location filename="../screens/SettingsScreen.qml" line="996"/>
         <source>Region</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1760,35 +1798,34 @@ Français - Wilfried</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Optimizing</source>
         <translation>Optimisation</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>Paused</source>
         <translation>En pause</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>In progress</source>
         <translation>En cours</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>%1 indexed</source>
         <translation>%1 indexés</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>%1 scraped</source>
-        <translation>%1 scrapés</translation>
+        <translation type="vanished">%1 scrapés</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
@@ -1797,117 +1834,117 @@ Français - Wilfried</translation>
         <translation type="vanished">Démarrer</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Upload</source>
         <translation>Envoyer</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="650"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Open</source>
         <translation>Ouvrir</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>%1 × %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Automatic (Recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="717"/>
         <source>%1 (Animations off)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="758"/>
         <source>English</source>
         <translation>Anglais</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="760"/>
         <source>Italian</source>
         <translation>Italien</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="756"/>
+        <location filename="../screens/SettingsScreen.qml" line="762"/>
         <source>Spanish</source>
         <translation>Espagnol</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="758"/>
+        <location filename="../screens/SettingsScreen.qml" line="764"/>
         <source>Basque</source>
         <translation>Basque</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="760"/>
+        <location filename="../screens/SettingsScreen.qml" line="766"/>
         <source>German</source>
         <translation>Allemand</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="762"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Greek</source>
         <translation>Grec</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="764"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Japanese</source>
         <translation>Japonais</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="766"/>
+        <location filename="../screens/SettingsScreen.qml" line="772"/>
         <source>Korean</source>
         <translation>Coréen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Dutch</source>
         <translation>Néerlandais</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="776"/>
         <source>Romanian</source>
         <translation>Roumain</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="778"/>
         <source>Slovak</source>
         <translation>Slovaque</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="774"/>
+        <location filename="../screens/SettingsScreen.qml" line="780"/>
         <source>Ukrainian</source>
         <translation>Ukrainien</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="776"/>
+        <location filename="../screens/SettingsScreen.qml" line="782"/>
         <source>Chinese (Simplified)</source>
         <translation>Chinois (simplifié)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="778"/>
+        <location filename="../screens/SettingsScreen.qml" line="784"/>
         <source>Chinese (Traditional)</source>
         <translation>Chinois (traditionnel)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="780"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Hebrew</source>
         <translation>Hébreu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="782"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Arabic</source>
         <translation>Arabe</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="784"/>
+        <location filename="../screens/SettingsScreen.qml" line="790"/>
         <source>Hindi</source>
         <translation>Hindi</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>French</source>
         <translation>Français</translation>
     </message>
@@ -1916,37 +1953,37 @@ Français - Wilfried</translation>
         <translation type="vanished">Auto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="792"/>
+        <location filename="../screens/SettingsScreen.qml" line="798"/>
         <source>12-hour</source>
         <translation>12 heures</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="794"/>
+        <location filename="../screens/SettingsScreen.qml" line="800"/>
         <source>24-hour</source>
         <translation>24 heures</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="805"/>
+        <location filename="../screens/SettingsScreen.qml" line="811"/>
         <source>Americas</source>
         <translation>Amériques</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="807"/>
+        <location filename="../screens/SettingsScreen.qml" line="813"/>
         <source>Europe</source>
         <translation>Europe</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="809"/>
+        <location filename="../screens/SettingsScreen.qml" line="815"/>
         <source>Japan</source>
         <translation>Japon</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
-        <location filename="../screens/SettingsScreen.qml" line="787"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
-        <location filename="../screens/SettingsScreen.qml" line="810"/>
-        <location filename="../screens/SettingsScreen.qml" line="877"/>
-        <location filename="../screens/SettingsScreen.qml" line="925"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="793"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
+        <location filename="../screens/SettingsScreen.qml" line="816"/>
+        <location filename="../screens/SettingsScreen.qml" line="883"/>
+        <location filename="../screens/SettingsScreen.qml" line="931"/>
         <source>Automatic</source>
         <translation>Automatique</translation>
     </message>
@@ -2001,19 +2038,14 @@ Français - Wilfried</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Downloads box art, descriptions, and tags for your games. Choose a source and which systems.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
-        <location filename="../screens/SettingsScreen.qml" line="1008"/>
+        <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="285"/>
-        <location filename="../screens/SettingsScreen.qml" line="1017"/>
+        <location filename="../screens/SettingsScreen.qml" line="1023"/>
         <source>Games layout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2028,93 +2060,93 @@ Français - Wilfried</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <location filename="../screens/SettingsScreen.qml" line="324"/>
         <source>Writes extra detail to the log file to help track down a problem. Restarts the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Configure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="815"/>
+        <location filename="../screens/SettingsScreen.qml" line="821"/>
         <source>Rotated CW</source>
         <translation>Rotation horaire</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="817"/>
+        <location filename="../screens/SettingsScreen.qml" line="823"/>
         <source>Rotated CCW</source>
         <translation>Rotation antihoraire</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="818"/>
+        <location filename="../screens/SettingsScreen.qml" line="824"/>
         <source>Horizontal</source>
         <translation>Horizontal</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="823"/>
+        <location filename="../screens/SettingsScreen.qml" line="829"/>
         <source>Detailed list view</source>
         <translation>Vue liste détaillée</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="824"/>
+        <location filename="../screens/SettingsScreen.qml" line="830"/>
         <source>Grid view</source>
         <translation>Vue en grille</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="829"/>
+        <location filename="../screens/SettingsScreen.qml" line="835"/>
         <source>Full color</source>
         <translation>Couleur intégrale</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="830"/>
+        <location filename="../screens/SettingsScreen.qml" line="836"/>
         <source>Tinted</source>
         <translation>Teinté</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="868"/>
+        <location filename="../screens/SettingsScreen.qml" line="874"/>
         <source>Style B</source>
         <translation>Style B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="870"/>
+        <location filename="../screens/SettingsScreen.qml" line="876"/>
         <source>Style C</source>
         <translation>Style C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="872"/>
+        <location filename="../screens/SettingsScreen.qml" line="878"/>
         <source>Style D</source>
         <translation>Style D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="874"/>
+        <location filename="../screens/SettingsScreen.qml" line="880"/>
         <source>Style E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="876"/>
+        <location filename="../screens/SettingsScreen.qml" line="882"/>
         <source>Style A</source>
         <translation>Style A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="917"/>
+        <location filename="../screens/SettingsScreen.qml" line="923"/>
         <source>PAL (50 Hz)</source>
         <translation>PAL (50 Hz)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="919"/>
+        <location filename="../screens/SettingsScreen.qml" line="925"/>
         <source>480i (60 Hz)</source>
         <translation>480i (60 Hz)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="920"/>
+        <location filename="../screens/SettingsScreen.qml" line="926"/>
         <source>NTSC (60 Hz)</source>
         <translation>NTSC (60 Hz)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1905"/>
+        <location filename="../screens/SettingsScreen.qml" line="1911"/>
         <source>Loading settings…</source>
         <translation>Chargement des réglages…</translation>
     </message>
@@ -2123,47 +2155,47 @@ Français - Wilfried</translation>
         <translation type="vanished">Par défaut</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="892"/>
+        <location filename="../screens/SettingsScreen.qml" line="898"/>
         <source>Off</source>
         <translation>Désactivé</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="894"/>
+        <location filename="../screens/SettingsScreen.qml" line="900"/>
         <source>1 second (testing)</source>
         <translation>1 seconde (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="896"/>
+        <location filename="../screens/SettingsScreen.qml" line="902"/>
         <source>1 minute</source>
         <translation>1 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="898"/>
+        <location filename="../screens/SettingsScreen.qml" line="904"/>
         <source>2 minutes</source>
         <translation>2 minutes</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="900"/>
+        <location filename="../screens/SettingsScreen.qml" line="906"/>
         <source>5 minutes</source>
         <translation>5 minutes</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="902"/>
+        <location filename="../screens/SettingsScreen.qml" line="908"/>
         <source>10 minutes</source>
         <translation>10 minutes</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="904"/>
+        <location filename="../screens/SettingsScreen.qml" line="910"/>
         <source>15 minutes</source>
         <translation>15 minutes</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="906"/>
+        <location filename="../screens/SettingsScreen.qml" line="912"/>
         <source>30 minutes</source>
         <translation>30 minutes</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="907"/>
+        <location filename="../screens/SettingsScreen.qml" line="913"/>
         <source>%1 seconds</source>
         <translation>%1 secondes</translation>
     </message>
@@ -2173,19 +2205,19 @@ Français - Wilfried</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Display</source>
         <translation>Affichage</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="108"/>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Controls</source>
         <translation>Commandes</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Library</source>
         <translation>Bibliothèque</translation>
     </message>
@@ -2194,82 +2226,82 @@ Français - Wilfried</translation>
         <translation type="vanished">Assistance</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="855"/>
+        <location filename="../screens/SettingsScreen.qml" line="861"/>
         <source>Nord</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="852"/>
+        <location filename="../screens/SettingsScreen.qml" line="858"/>
         <source>Dracula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="859"/>
+        <location filename="../screens/SettingsScreen.qml" line="865"/>
         <source>Synthwave &apos;84</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="846"/>
+        <location filename="../screens/SettingsScreen.qml" line="852"/>
         <source>Amber Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="848"/>
+        <location filename="../screens/SettingsScreen.qml" line="854"/>
         <source>Green Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="849"/>
+        <location filename="../screens/SettingsScreen.qml" line="855"/>
         <source>Neo Geo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="850"/>
+        <location filename="../screens/SettingsScreen.qml" line="856"/>
         <source>NES</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="851"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>Virtual Boy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="854"/>
+        <location filename="../screens/SettingsScreen.qml" line="860"/>
         <source>Gruvbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="853"/>
+        <location filename="../screens/SettingsScreen.qml" line="859"/>
         <source>Everforest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="858"/>
+        <location filename="../screens/SettingsScreen.qml" line="864"/>
         <source>Solarized Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="863"/>
         <source>Rosé Pine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="856"/>
+        <location filename="../screens/SettingsScreen.qml" line="862"/>
         <source>Oxocarbon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="860"/>
+        <location filename="../screens/SettingsScreen.qml" line="866"/>
         <source>Flexoki Paper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="861"/>
+        <location filename="../screens/SettingsScreen.qml" line="867"/>
         <source>Solarized Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="847"/>
+        <location filename="../screens/SettingsScreen.qml" line="853"/>
         <source>Game Boy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2319,6 +2351,16 @@ Français - Wilfried</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="269"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="280"/>
         <source>Show systems as a grid of covers, or as a list with details beside it.</source>
         <translation type="unfinished"></translation>
@@ -2339,92 +2381,107 @@ Français - Wilfried</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="324"/>
+        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <source>Shows a code you can scan to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="330"/>
         <source>Uploads the log file and gives you a link to share when reporting a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="927"/>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <source>%1 imported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="933"/>
         <source>Image</source>
         <translation>Image</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="929"/>
+        <location filename="../screens/SettingsScreen.qml" line="935"/>
         <source>Thumbnail</source>
         <translation>Vignette</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="931"/>
+        <location filename="../screens/SettingsScreen.qml" line="937"/>
         <source>Box art</source>
         <translation>Box art</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="933"/>
+        <location filename="../screens/SettingsScreen.qml" line="939"/>
         <source>3D box art</source>
         <translation>3D box art</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="935"/>
+        <location filename="../screens/SettingsScreen.qml" line="941"/>
         <source>Screenshot</source>
         <translation>Capture d&apos;écran</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="937"/>
+        <location filename="../screens/SettingsScreen.qml" line="943"/>
         <source>Wheel</source>
         <translation>Wheel</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="939"/>
+        <location filename="../screens/SettingsScreen.qml" line="945"/>
         <source>Title screen</source>
         <translation>Écran-titre</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="941"/>
+        <location filename="../screens/SettingsScreen.qml" line="947"/>
         <source>Map</source>
         <translation>Carte</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="943"/>
+        <location filename="../screens/SettingsScreen.qml" line="949"/>
         <source>Marquee</source>
         <translation>Marquee</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="945"/>
+        <location filename="../screens/SettingsScreen.qml" line="951"/>
         <source>Fan art</source>
         <translation>Fan art</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="947"/>
+        <location filename="../screens/SettingsScreen.qml" line="953"/>
         <source>Box side</source>
         <translation>Tranche de boîtier</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="949"/>
+        <location filename="../screens/SettingsScreen.qml" line="955"/>
         <source>Box back</source>
         <translation>Dos de la jaquette</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="355"/>
+        <location filename="../screens/SettingsScreen.qml" line="361"/>
         <source>Settings</source>
         <translation>Réglages</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="843"/>
+        <location filename="../screens/SettingsScreen.qml" line="849"/>
         <source>Zaparoo Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="844"/>
+        <location filename="../screens/SettingsScreen.qml" line="850"/>
         <source>Zaparoo Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="845"/>
+        <location filename="../screens/SettingsScreen.qml" line="851"/>
         <source>Classic Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1887"/>
+        <location filename="../screens/SettingsScreen.qml" line="1893"/>
         <source>No settings available on this platform</source>
         <translation>Aucun réglage disponible sur cette plateforme</translation>
     </message>
@@ -2458,6 +2515,31 @@ Français - Wilfried</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/StatusLine.qml" line="105"/>
+        <source>Importing paused: game running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Import failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Imported %1 of %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/StatusLine.qml" line="248"/>
         <location filename="../components/StatusLine.qml" line="271"/>
         <source>%1%</source>
@@ -2479,9 +2561,8 @@ Français - Wilfried</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="106"/>
         <source>Scraping…</source>
-        <translation type="unfinished">Scraping…</translation>
+        <translation type="obsolete">Scraping…</translation>
     </message>
     <message>
         <source>%1 / %2</source>
@@ -2495,16 +2576,6 @@ Français - Wilfried</translation>
     <message>
         <location filename="../components/StatusLine.qml" line="102"/>
         <source>Optimizing database: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="105"/>
-        <source>Scraping paused: game running</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="106"/>
-        <source>Scraping: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -2523,16 +2594,6 @@ Français - Wilfried</translation>
     <message>
         <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scraped %1 of %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_fr.ts
+++ b/src/ui/translations/frontend_fr.ts
@@ -35,8 +35,8 @@
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="212"/>
-        <source>Commercial licensing: legal@zaparoo.org</source>
-        <translation>Licences commerciales&#xa0;: legal@zaparoo.org</translation>
+        <source>Commercial licensing: legal@zaparoo.com</source>
+        <translation>Licences commerciales&#xa0;: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="223"/>
@@ -230,8 +230,8 @@ Français - Wilfried</translation>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="116"/>
-        <source>Contact: legal@zaparoo.org</source>
-        <translation>Contact&#xa0;: legal@zaparoo.org</translation>
+        <source>Contact: legal@zaparoo.com</source>
+        <translation>Contact&#xa0;: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="127"/>
@@ -1569,27 +1569,27 @@ Français - Wilfried</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
-        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <source>Documentation: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="225"/>
         <source>Loading sources…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="262"/>
         <source>Replace existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="276"/>
         <source>Start import</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1598,7 +1598,7 @@ Français - Wilfried</translation>
         <translation type="obsolete">Scraper les métadonnées</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="249"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_fr.ts
+++ b/src/ui/translations/frontend_fr.ts
@@ -2038,6 +2038,11 @@ Français - Wilfried</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
         <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
@@ -2353,11 +2358,6 @@ Français - Wilfried</translation>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Get metadata</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -35,8 +35,8 @@
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="212"/>
-        <source>Commercial licensing: legal@zaparoo.org</source>
-        <translation>רישוי מסחרי: legal@zaparoo.org</translation>
+        <source>Commercial licensing: legal@zaparoo.com</source>
+        <translation>רישוי מסחרי: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="223"/>
@@ -227,8 +227,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="116"/>
-        <source>Contact: legal@zaparoo.org</source>
-        <translation>יצירת קשר: legal@zaparoo.org</translation>
+        <source>Contact: legal@zaparoo.com</source>
+        <translation>יצירת קשר: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="127"/>
@@ -1530,27 +1530,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
-        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <source>Documentation: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="225"/>
         <source>Loading sources…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="262"/>
         <source>Replace existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="276"/>
         <source>Start import</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1559,7 +1559,7 @@ Français - Wilfried</source>
         <translation type="obsolete">איסוף מטא-נתונים</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="249"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -389,45 +389,6 @@ Français - Wilfried</source>
     </message>
 </context>
 <context>
-    <name>FirstRunIndexModal</name>
-    <message>
-        <source>First-time setup</source>
-        <translation type="vanished">הגדרה ראשונית</translation>
-    </message>
-    <message>
-        <source>Optimizing database - almost done</source>
-        <translation type="vanished">מבצע אופטימיזציה למסד הנתונים - כמעט סיים</translation>
-    </message>
-    <message>
-        <source>Indexing paused</source>
-        <translation type="vanished">יצירת האינדקס הושהתה</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2 - %3</source>
-        <translation type="vanished">שלב %1 מתוך %2 - %3</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2</source>
-        <translation type="vanished">שלב %1 מתוך %2</translation>
-    </message>
-    <message>
-        <source>Preparing…</source>
-        <translation type="vanished">מכין…</translation>
-    </message>
-    <message>
-        <source>Done. %1 files indexed.</source>
-        <translation type="vanished">הושלם. %1 קבצים אונדקסו.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">ביטול</translation>
-    </message>
-    <message>
-        <source>Start scan</source>
-        <translation type="vanished">התחל סריקה</translation>
-    </message>
-</context>
-<context>
     <name>GameInfoModal</name>
     <message>
         <location filename="../components/GameInfoModal.qml" line="153"/>
@@ -540,6 +501,26 @@ Français - Wilfried</source>
         <translation>מועדפים</translation>
     </message>
     <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>Updating the media database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>No games found yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Your games appear here as Core finds them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Update media database in Settings &gt; Library.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Recently Played</source>
         <translation type="vanished">שוחקו לאחרונה</translation>
     </message>
@@ -569,35 +550,44 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
-        <translation>אין מערכות זמינות. הפעילו &quot;עדכון מסד נתוני מדיה&quot; מההגדרות.</translation>
+        <translation type="vanished">אין מערכות זמינות. הפעילו &quot;עדכון מסד נתוני מדיה&quot; מההגדרות.</translation>
     </message>
 </context>
 <context>
     <name>IndexSetupModal</name>
     <message>
         <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Start</source>
+        <translation type="unfinished">התחל</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Change</source>
+        <translation type="unfinished">שינוי</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="51"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="47"/>
+        <location filename="../components/IndexSetupModal.qml" line="53"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="115"/>
+        <location filename="../components/IndexSetupModal.qml" line="121"/>
         <source>Update media database</source>
         <translation type="unfinished">עדכון מסד נתוני המדיה</translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="124"/>
+        <location filename="../components/IndexSetupModal.qml" line="130"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="137"/>
+        <location filename="../components/IndexSetupModal.qml" line="143"/>
         <source>Start update</source>
         <translation type="unfinished"></translation>
     </message>
@@ -675,30 +665,28 @@ Français - Wilfried</source>
         <translation type="vanished">הפעל את הליבה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
-        <location filename="../app/Main.qml" line="2330"/>
-        <location filename="../app/Main.qml" line="2393"/>
-        <location filename="../app/Main.qml" line="2699"/>
-        <location filename="../app/Main.qml" line="3741"/>
-        <location filename="../app/Main.qml" line="3784"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
+        <location filename="../app/Main.qml" line="2341"/>
+        <location filename="../app/Main.qml" line="2410"/>
+        <location filename="../app/Main.qml" line="2716"/>
+        <location filename="../app/Main.qml" line="3795"/>
+        <location filename="../app/Main.qml" line="3838"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2183"/>
-        <location filename="../app/Main.qml" line="2218"/>
+        <location filename="../app/Main.qml" line="2185"/>
+        <location filename="../app/Main.qml" line="2220"/>
         <source>Update media database</source>
         <translation type="unfinished">עדכון מסד נתוני המדיה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2186"/>
-        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
-        <translation type="unfinished">איסוף מטא-נתונים</translation>
+        <translation type="obsolete">איסוף מטא-נתונים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2179"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
@@ -708,53 +696,53 @@ Français - Wilfried</source>
         <translation type="unfinished">הגדרות</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2096"/>
+        <location filename="../app/Main.qml" line="2098"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2153"/>
+        <location filename="../app/Main.qml" line="2155"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2179"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
-        <location filename="../app/Main.qml" line="2308"/>
+        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2319"/>
         <source>Launch game</source>
         <translation>הפעל משחק</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2258"/>
-        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2323"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
-        <location filename="../app/Main.qml" line="2346"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2280"/>
+        <location filename="../app/Main.qml" line="2357"/>
+        <location filename="../app/Main.qml" line="2451"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Remove from favorites</source>
         <translation>הסר מהמועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Add to favorites</source>
         <translation>הוסף למועדפים</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2264"/>
-        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2266"/>
+        <location filename="../app/Main.qml" line="2346"/>
         <source>Write to NFC token</source>
         <translation>כתוב לטוקן NFC</translation>
     </message>
@@ -763,70 +751,95 @@ Français - Wilfried</source>
         <translation type="vanished">קוד QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3507"/>
+        <location filename="../app/Main.qml" line="2395"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3561"/>
         <source>Default</source>
         <translation type="unfinished">ברירת מחדל</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2395"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2230"/>
-        <location filename="../app/Main.qml" line="2238"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="2164"/>
+        <location filename="../app/Main.qml" line="2215"/>
+        <location filename="../app/Main.qml" line="2232"/>
+        <location filename="../app/Main.qml" line="2240"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3454"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3432"/>
+        <location filename="../app/Main.qml" line="3153"/>
+        <source>Get metadata failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3154"/>
+        <source>Could not start getting metadata. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3156"/>
+        <source>Source list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3157"/>
+        <source>Could not load the list of metadata sources. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3307"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3486"/>
         <source>Favorites</source>
         <translation type="unfinished">מועדפים</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1070"/>
-        <location filename="../app/Main.qml" line="3417"/>
-        <location filename="../app/Main.qml" line="3464"/>
-        <location filename="../app/Main.qml" line="3474"/>
+        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3518"/>
+        <location filename="../app/Main.qml" line="3528"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3445"/>
+        <location filename="../app/Main.qml" line="3499"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3460"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3511"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3565"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3482"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3515"/>
+        <location filename="../app/Main.qml" line="3569"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3436"/>
+        <location filename="../app/Main.qml" line="3490"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -851,50 +864,51 @@ Français - Wilfried</source>
         <translation type="unfinished">יציאה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2173"/>
-        <location filename="../app/Main.qml" line="2282"/>
-        <location filename="../app/Main.qml" line="2301"/>
-        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2284"/>
+        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2361"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2268"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2270"/>
+        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2807"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2461"/>
+        <location filename="../app/Main.qml" line="2478"/>
         <source>Move</source>
         <translation type="unfinished">הזזה</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2667"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1032"/>
-        <location filename="../app/Main.qml" line="3043"/>
-        <location filename="../app/Main.qml" line="3065"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3131"/>
+        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3174"/>
         <source>OK</source>
         <translation type="unfinished">אישור</translation>
     </message>
@@ -909,225 +923,223 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="2188"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2293"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2807"/>
+        <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Scan this code to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3132"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3098"/>
+        <location filename="../app/Main.qml" line="3141"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3099"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3101"/>
+        <location filename="../app/Main.qml" line="3144"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3147"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3105"/>
+        <location filename="../app/Main.qml" line="3148"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3107"/>
+        <location filename="../app/Main.qml" line="3150"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3151"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3110"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3111"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3113"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3114"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3116"/>
+        <location filename="../app/Main.qml" line="3159"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3120"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3122"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3123"/>
+        <location filename="../app/Main.qml" line="3166"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3125"/>
+        <location filename="../app/Main.qml" line="3168"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3126"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3128"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3129"/>
+        <location filename="../app/Main.qml" line="3172"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3253"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3269"/>
+        <location filename="../app/Main.qml" line="3323"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3278"/>
+        <location filename="../app/Main.qml" line="3332"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3307"/>
+        <location filename="../app/Main.qml" line="3361"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3446"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3415"/>
-        <location filename="../app/Main.qml" line="3461"/>
+        <location filename="../app/Main.qml" line="3469"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3449"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3503"/>
+        <location filename="../app/Main.qml" line="3525"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3489"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3485"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3492"/>
+        <location filename="../app/Main.qml" line="3546"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3708"/>
+        <location filename="../app/Main.qml" line="3762"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3119"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
-        <location filename="../app/Main.qml" line="3318"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="2910"/>
+        <location filename="../app/Main.qml" line="3372"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Retry</source>
         <translation type="unfinished">נסה שוב</translation>
     </message>
@@ -1136,37 +1148,37 @@ Français - Wilfried</source>
         <translation type="obsolete">ביטול</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4848"/>
+        <location filename="../app/Main.qml" line="4902"/>
         <source>Loading systems…</source>
         <translation>טוען מערכות…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4850"/>
+        <location filename="../app/Main.qml" line="4904"/>
         <source>Loading games…</source>
         <translation>טוען משחקים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4852"/>
+        <location filename="../app/Main.qml" line="4906"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4855"/>
+        <location filename="../app/Main.qml" line="4909"/>
         <source>Loading favorites…</source>
         <translation>טוען מועדפים…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4857"/>
+        <location filename="../app/Main.qml" line="4911"/>
         <source>Loading recently played…</source>
         <translation>טוען את הפריטים ששוחקו לאחרונה…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4859"/>
+        <location filename="../app/Main.qml" line="4913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4861"/>
+        <location filename="../app/Main.qml" line="4915"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>
@@ -1174,7 +1186,7 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Writing failed</source>
         <translation>הכתיבה נכשלה</translation>
     </message>
@@ -1188,8 +1200,8 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="531"/>
-        <location filename="../app/MainLayout.qml" line="533"/>
+        <location filename="../app/MainLayout.qml" line="537"/>
+        <location filename="../app/MainLayout.qml" line="539"/>
         <source>Favorites</source>
         <translation type="unfinished">מועדפים</translation>
     </message>
@@ -1198,128 +1210,130 @@ Français - Wilfried</source>
         <translation type="obsolete">שוחקו לאחרונה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="916"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="917"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="936"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="943"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="1365"/>
         <source>OK</source>
         <translation type="unfinished">אישור</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="535"/>
+        <location filename="../app/MainLayout.qml" line="541"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Hold a writable token near the reader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1096"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
         <source>Are you sure you want to exit?</source>
         <translation>האם אתה בטוח שברצונך לצאת?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1374"/>
-        <location filename="../app/MainLayout.qml" line="1454"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1596"/>
-        <location filename="../app/MainLayout.qml" line="1615"/>
-        <location filename="../app/MainLayout.qml" line="1688"/>
+        <location filename="../app/MainLayout.qml" line="1284"/>
+        <location filename="../app/MainLayout.qml" line="1383"/>
+        <location filename="../app/MainLayout.qml" line="1405"/>
+        <location filename="../app/MainLayout.qml" line="1486"/>
+        <location filename="../app/MainLayout.qml" line="1523"/>
+        <location filename="../app/MainLayout.qml" line="1572"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1647"/>
+        <location filename="../app/MainLayout.qml" line="1720"/>
         <source>Move</source>
         <translation>הזזה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1387"/>
+        <location filename="../app/MainLayout.qml" line="1409"/>
         <source>Select</source>
         <translation>בחירה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1283"/>
-        <location filename="../app/MainLayout.qml" line="1297"/>
-        <location filename="../app/MainLayout.qml" line="1312"/>
-        <location filename="../app/MainLayout.qml" line="1323"/>
-        <location filename="../app/MainLayout.qml" line="1349"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1321"/>
+        <location filename="../app/MainLayout.qml" line="1332"/>
+        <location filename="../app/MainLayout.qml" line="1358"/>
         <source>Close</source>
         <translation>סגור</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1425"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1339"/>
+        <location filename="../app/MainLayout.qml" line="1391"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1308"/>
+        <location filename="../app/MainLayout.qml" line="1317"/>
         <source>Done</source>
         <translation>הושלם</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1509"/>
-        <location filename="../app/MainLayout.qml" line="1567"/>
-        <location filename="../app/MainLayout.qml" line="1716"/>
+        <location filename="../app/MainLayout.qml" line="1328"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1541"/>
+        <location filename="../app/MainLayout.qml" line="1599"/>
+        <location filename="../app/MainLayout.qml" line="1748"/>
         <source>Retry</source>
         <translation>נסה שוב</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1338"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
         <source>I understand</source>
         <translation>הבנתי</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1376"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1389"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1417"/>
+        <location filename="../app/MainLayout.qml" line="1449"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1421"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1328,11 +1342,11 @@ Français - Wilfried</source>
         <translation type="vanished">התחל</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1496"/>
-        <location filename="../app/MainLayout.qml" line="1545"/>
-        <location filename="../app/MainLayout.qml" line="1601"/>
-        <location filename="../app/MainLayout.qml" line="1693"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1528"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1633"/>
+        <location filename="../app/MainLayout.qml" line="1725"/>
         <source>Open</source>
         <translation>פתח</translation>
     </message>
@@ -1341,28 +1355,29 @@ Français - Wilfried</source>
         <translation type="vanished">יציאה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1477"/>
-        <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1513"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1559"/>
-        <location filename="../app/MainLayout.qml" line="1577"/>
-        <location filename="../app/MainLayout.qml" line="1589"/>
-        <location filename="../app/MainLayout.qml" line="1605"/>
-        <location filename="../app/MainLayout.qml" line="1639"/>
-        <location filename="../app/MainLayout.qml" line="1660"/>
-        <location filename="../app/MainLayout.qml" line="1669"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
-        <location filename="../app/MainLayout.qml" line="1728"/>
+        <location filename="../app/MainLayout.qml" line="1413"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1561"/>
+        <location filename="../app/MainLayout.qml" line="1591"/>
+        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1621"/>
+        <location filename="../app/MainLayout.qml" line="1637"/>
+        <location filename="../app/MainLayout.qml" line="1671"/>
+        <location filename="../app/MainLayout.qml" line="1692"/>
+        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1741"/>
+        <location filename="../app/MainLayout.qml" line="1760"/>
         <source>Back</source>
         <translation>חזרה</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1468"/>
-        <location filename="../app/MainLayout.qml" line="1555"/>
-        <location filename="../app/MainLayout.qml" line="1573"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
-        <location filename="../app/MainLayout.qml" line="1724"/>
+        <location filename="../app/MainLayout.qml" line="1500"/>
+        <location filename="../app/MainLayout.qml" line="1587"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1737"/>
+        <location filename="../app/MainLayout.qml" line="1756"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1371,25 +1386,25 @@ Français - Wilfried</source>
         <translation type="vanished">עמוד</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1464"/>
-        <location filename="../app/MainLayout.qml" line="1499"/>
-        <location filename="../app/MainLayout.qml" line="1550"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1531"/>
+        <location filename="../app/MainLayout.qml" line="1582"/>
+        <location filename="../app/MainLayout.qml" line="1730"/>
         <source>Options</source>
         <translation>אפשרויות</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1624"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Change</source>
         <translation>שינוי</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1630"/>
+        <location filename="../app/MainLayout.qml" line="1662"/>
         <source>Toggle</source>
         <translation>החלף</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1656"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Scroll</source>
         <translation>גלילה</translation>
     </message>
@@ -1450,12 +1465,12 @@ Français - Wilfried</source>
 <context>
     <name>QrCodeModal</name>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="23"/>
+        <location filename="../components/QrCodeModal.qml" line="19"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="43"/>
+        <location filename="../components/QrCodeModal.qml" line="20"/>
         <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1485,43 +1500,67 @@ Français - Wilfried</source>
 <context>
     <name>ScrapeSetupModal</name>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="67"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Start</source>
+        <translation type="unfinished">התחל</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Toggle</source>
+        <translation type="unfinished">החלף</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Change</source>
+        <translation type="unfinished">שינוי</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="89"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="69"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="91"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="171"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="193"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
+        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <source>Loading sources…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <source>Replace existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <source>Start import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scrape metadata</source>
-        <translation type="unfinished">איסוף מטא-נתונים</translation>
+        <translation type="obsolete">איסוף מטא-נתונים</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="185"/>
-        <source>Loading scrapers…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="196"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
         <source>Systems</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="222"/>
-        <source>Re-scrape existing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
-        <source>Start scrape</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1533,17 +1572,17 @@ Français - Wilfried</source>
         <translation>אין כאן כלום</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="36"/>
         <source>Loading…</source>
         <translation>טוען…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="37"/>
         <source>Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="79"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="85"/>
         <source>Failed to load</source>
         <translation>הטעינה נכשלה</translation>
     </message>
@@ -1557,14 +1596,14 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="114"/>
         <location filename="../screens/SettingsScreen.qml" line="205"/>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
-        <location filename="../screens/SettingsScreen.qml" line="972"/>
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="978"/>
         <source>Language</source>
         <translation>שפה</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="165"/>
-        <location filename="../screens/SettingsScreen.qml" line="999"/>
+        <location filename="../screens/SettingsScreen.qml" line="1005"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1574,25 +1613,25 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="225"/>
-        <location filename="../screens/SettingsScreen.qml" line="1051"/>
+        <location filename="../screens/SettingsScreen.qml" line="1057"/>
         <source>Button style</source>
         <translation>סגנון כפתורים</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="1060"/>
+        <location filename="../screens/SettingsScreen.qml" line="1066"/>
         <source>Screensaver</source>
         <translation>שומר מסך</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Library</source>
         <translation>ספרייה</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="291"/>
-        <location filename="../screens/SettingsScreen.qml" line="1069"/>
+        <location filename="../screens/SettingsScreen.qml" line="1075"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1602,9 +1641,8 @@ Français - Wilfried</source>
         <translation>עדכון מסד נתוני המדיה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Scrape metadata</source>
-        <translation>איסוף מטא-נתונים</translation>
+        <translation type="vanished">איסוף מטא-נתונים</translation>
     </message>
     <message>
         <source>Advanced</source>
@@ -1616,12 +1654,12 @@ Français - Wilfried</source>
         <translation>תמיכת עכבר</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <location filename="../screens/SettingsScreen.qml" line="323"/>
         <source>Debug logging</source>
         <translation>רישום ניפוי שגיאות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="323"/>
+        <location filename="../screens/SettingsScreen.qml" line="329"/>
         <source>Upload log file</source>
         <translation>העלאת קובץ יומן</translation>
     </message>
@@ -1632,7 +1670,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="217"/>
-        <location filename="../screens/SettingsScreen.qml" line="981"/>
+        <location filename="../screens/SettingsScreen.qml" line="987"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1653,7 +1691,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <location filename="../screens/SettingsScreen.qml" line="1078"/>
+        <location filename="../screens/SettingsScreen.qml" line="1084"/>
         <source>Video standard</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1664,7 +1702,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="135"/>
-        <location filename="../screens/SettingsScreen.qml" line="1026"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
         <source>System logos</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1684,35 +1722,34 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Optimizing</source>
         <translation>מבצע אופטימיזציה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>Paused</source>
         <translation>מושהה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>In progress</source>
         <translation>בתהליך</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>%1 indexed</source>
         <translation>%1 אונדקסו</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>%1 scraped</source>
-        <translation>%1 נאספו</translation>
+        <translation type="vanished">%1 נאספו</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Cancel</source>
         <translation>ביטול</translation>
     </message>
@@ -1721,12 +1758,12 @@ Français - Wilfried</source>
         <translation type="vanished">התחל</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Upload</source>
         <translation>העלאה</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="650"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Open</source>
         <translation>פתח</translation>
     </message>
@@ -1735,92 +1772,92 @@ Français - Wilfried</source>
         <translation type="vanished">ברירת מחדל</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="758"/>
         <source>English</source>
         <translation>אנגלית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="760"/>
         <source>Italian</source>
         <translation>איטלקית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="756"/>
+        <location filename="../screens/SettingsScreen.qml" line="762"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="758"/>
+        <location filename="../screens/SettingsScreen.qml" line="764"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="760"/>
+        <location filename="../screens/SettingsScreen.qml" line="766"/>
         <source>German</source>
         <translation>גרמנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="762"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Greek</source>
         <translation>יוונית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="764"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Japanese</source>
         <translation>יפנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="766"/>
+        <location filename="../screens/SettingsScreen.qml" line="772"/>
         <source>Korean</source>
         <translation>קוריאנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Dutch</source>
         <translation>הולנדית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="776"/>
         <source>Romanian</source>
         <translation>רומנית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="778"/>
         <source>Slovak</source>
         <translation>סלובקית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="774"/>
+        <location filename="../screens/SettingsScreen.qml" line="780"/>
         <source>Ukrainian</source>
         <translation>אוקראינית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="776"/>
+        <location filename="../screens/SettingsScreen.qml" line="782"/>
         <source>Chinese (Simplified)</source>
         <translation>סינית (מפושטת)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="778"/>
+        <location filename="../screens/SettingsScreen.qml" line="784"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="780"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Hebrew</source>
         <translation>עברית</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="782"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="784"/>
+        <location filename="../screens/SettingsScreen.qml" line="790"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>French</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1829,127 +1866,127 @@ Français - Wilfried</source>
         <translation type="vanished">אוטומטי</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="792"/>
+        <location filename="../screens/SettingsScreen.qml" line="798"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="794"/>
+        <location filename="../screens/SettingsScreen.qml" line="800"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="805"/>
+        <location filename="../screens/SettingsScreen.qml" line="811"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="807"/>
+        <location filename="../screens/SettingsScreen.qml" line="813"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="809"/>
+        <location filename="../screens/SettingsScreen.qml" line="815"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
-        <location filename="../screens/SettingsScreen.qml" line="787"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
-        <location filename="../screens/SettingsScreen.qml" line="810"/>
-        <location filename="../screens/SettingsScreen.qml" line="877"/>
-        <location filename="../screens/SettingsScreen.qml" line="925"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="793"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
+        <location filename="../screens/SettingsScreen.qml" line="816"/>
+        <location filename="../screens/SettingsScreen.qml" line="883"/>
+        <location filename="../screens/SettingsScreen.qml" line="931"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="158"/>
-        <location filename="../screens/SettingsScreen.qml" line="963"/>
+        <location filename="../screens/SettingsScreen.qml" line="969"/>
         <source>Interface resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="129"/>
-        <location filename="../screens/SettingsScreen.qml" line="1035"/>
+        <location filename="../screens/SettingsScreen.qml" line="1041"/>
         <source>Color scheme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>%1 × %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Automatic (Recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="717"/>
         <source>%1 (Animations off)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="815"/>
+        <location filename="../screens/SettingsScreen.qml" line="821"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="817"/>
+        <location filename="../screens/SettingsScreen.qml" line="823"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="818"/>
+        <location filename="../screens/SettingsScreen.qml" line="824"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="823"/>
+        <location filename="../screens/SettingsScreen.qml" line="829"/>
         <source>Detailed list view</source>
         <translation>תצוגת רשימה מפורטת</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="824"/>
+        <location filename="../screens/SettingsScreen.qml" line="830"/>
         <source>Grid view</source>
         <translation>תצוגת רשת</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="829"/>
+        <location filename="../screens/SettingsScreen.qml" line="835"/>
         <source>Full color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="830"/>
+        <location filename="../screens/SettingsScreen.qml" line="836"/>
         <source>Tinted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="855"/>
+        <location filename="../screens/SettingsScreen.qml" line="861"/>
         <source>Nord</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="852"/>
+        <location filename="../screens/SettingsScreen.qml" line="858"/>
         <source>Dracula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="90"/>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="120"/>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="211"/>
-        <location filename="../screens/SettingsScreen.qml" line="990"/>
+        <location filename="../screens/SettingsScreen.qml" line="996"/>
         <source>Region</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1959,72 +1996,72 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="859"/>
+        <location filename="../screens/SettingsScreen.qml" line="865"/>
         <source>Synthwave &apos;84</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="846"/>
+        <location filename="../screens/SettingsScreen.qml" line="852"/>
         <source>Amber Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="848"/>
+        <location filename="../screens/SettingsScreen.qml" line="854"/>
         <source>Green Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="849"/>
+        <location filename="../screens/SettingsScreen.qml" line="855"/>
         <source>Neo Geo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="850"/>
+        <location filename="../screens/SettingsScreen.qml" line="856"/>
         <source>NES</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="851"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>Virtual Boy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="854"/>
+        <location filename="../screens/SettingsScreen.qml" line="860"/>
         <source>Gruvbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="853"/>
+        <location filename="../screens/SettingsScreen.qml" line="859"/>
         <source>Everforest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="858"/>
+        <location filename="../screens/SettingsScreen.qml" line="864"/>
         <source>Solarized Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="863"/>
         <source>Rosé Pine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="856"/>
+        <location filename="../screens/SettingsScreen.qml" line="862"/>
         <source>Oxocarbon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="860"/>
+        <location filename="../screens/SettingsScreen.qml" line="866"/>
         <source>Flexoki Paper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="861"/>
+        <location filename="../screens/SettingsScreen.qml" line="867"/>
         <source>Solarized Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="847"/>
+        <location filename="../screens/SettingsScreen.qml" line="853"/>
         <source>Game Boy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2079,19 +2116,14 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Downloads box art, descriptions, and tags for your games. Choose a source and which systems.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
-        <location filename="../screens/SettingsScreen.qml" line="1008"/>
+        <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="285"/>
-        <location filename="../screens/SettingsScreen.qml" line="1017"/>
+        <location filename="../screens/SettingsScreen.qml" line="1023"/>
         <source>Games layout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2106,103 +2138,103 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <location filename="../screens/SettingsScreen.qml" line="324"/>
         <source>Writes extra detail to the log file to help track down a problem. Restarts the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Configure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="868"/>
+        <location filename="../screens/SettingsScreen.qml" line="874"/>
         <source>Style B</source>
         <translation>סגנון B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="870"/>
+        <location filename="../screens/SettingsScreen.qml" line="876"/>
         <source>Style C</source>
         <translation>סגנון C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="872"/>
+        <location filename="../screens/SettingsScreen.qml" line="878"/>
         <source>Style D</source>
         <translation>סגנון D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="874"/>
+        <location filename="../screens/SettingsScreen.qml" line="880"/>
         <source>Style E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="876"/>
+        <location filename="../screens/SettingsScreen.qml" line="882"/>
         <source>Style A</source>
         <translation>סגנון A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="892"/>
+        <location filename="../screens/SettingsScreen.qml" line="898"/>
         <source>Off</source>
         <translation>כבוי</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="894"/>
+        <location filename="../screens/SettingsScreen.qml" line="900"/>
         <source>1 second (testing)</source>
         <translation>שנייה אחת (לבדיקה)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="896"/>
+        <location filename="../screens/SettingsScreen.qml" line="902"/>
         <source>1 minute</source>
         <translation>דקה אחת</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="898"/>
+        <location filename="../screens/SettingsScreen.qml" line="904"/>
         <source>2 minutes</source>
         <translation>2 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="900"/>
+        <location filename="../screens/SettingsScreen.qml" line="906"/>
         <source>5 minutes</source>
         <translation>5 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="902"/>
+        <location filename="../screens/SettingsScreen.qml" line="908"/>
         <source>10 minutes</source>
         <translation>10 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="904"/>
+        <location filename="../screens/SettingsScreen.qml" line="910"/>
         <source>15 minutes</source>
         <translation>15 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="906"/>
+        <location filename="../screens/SettingsScreen.qml" line="912"/>
         <source>30 minutes</source>
         <translation>30 דקות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="907"/>
+        <location filename="../screens/SettingsScreen.qml" line="913"/>
         <source>%1 seconds</source>
         <translation>%1 שניות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="917"/>
+        <location filename="../screens/SettingsScreen.qml" line="923"/>
         <source>PAL (50 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="919"/>
+        <location filename="../screens/SettingsScreen.qml" line="925"/>
         <source>480i (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="920"/>
+        <location filename="../screens/SettingsScreen.qml" line="926"/>
         <source>NTSC (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1905"/>
+        <location filename="../screens/SettingsScreen.qml" line="1911"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2212,13 +2244,13 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="108"/>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2268,6 +2300,16 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="269"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="280"/>
         <source>Show systems as a grid of covers, or as a list with details beside it.</source>
         <translation type="unfinished"></translation>
@@ -2288,92 +2330,107 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="324"/>
+        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <source>Shows a code you can scan to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="330"/>
         <source>Uploads the log file and gives you a link to share when reporting a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="843"/>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <source>%1 imported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="849"/>
         <source>Zaparoo Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="844"/>
+        <location filename="../screens/SettingsScreen.qml" line="850"/>
         <source>Zaparoo Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="845"/>
+        <location filename="../screens/SettingsScreen.qml" line="851"/>
         <source>Classic Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="927"/>
+        <location filename="../screens/SettingsScreen.qml" line="933"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="929"/>
+        <location filename="../screens/SettingsScreen.qml" line="935"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="931"/>
+        <location filename="../screens/SettingsScreen.qml" line="937"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="933"/>
+        <location filename="../screens/SettingsScreen.qml" line="939"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="935"/>
+        <location filename="../screens/SettingsScreen.qml" line="941"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="937"/>
+        <location filename="../screens/SettingsScreen.qml" line="943"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="939"/>
+        <location filename="../screens/SettingsScreen.qml" line="945"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="941"/>
+        <location filename="../screens/SettingsScreen.qml" line="947"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="943"/>
+        <location filename="../screens/SettingsScreen.qml" line="949"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="945"/>
+        <location filename="../screens/SettingsScreen.qml" line="951"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="947"/>
+        <location filename="../screens/SettingsScreen.qml" line="953"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="949"/>
+        <location filename="../screens/SettingsScreen.qml" line="955"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="355"/>
+        <location filename="../screens/SettingsScreen.qml" line="361"/>
         <source>Settings</source>
         <translation>הגדרות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1887"/>
+        <location filename="../screens/SettingsScreen.qml" line="1893"/>
         <source>No settings available on this platform</source>
         <translation>אין הגדרות זמינות בפלטפורמה זו</translation>
     </message>
@@ -2412,9 +2469,33 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/StatusLine.qml" line="105"/>
+        <source>Importing paused: game running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Import failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Imported %1 of %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scraping…</source>
-        <translation type="unfinished">אוסף נתונים…</translation>
+        <translation type="obsolete">אוסף נתונים…</translation>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
@@ -2443,16 +2524,6 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="105"/>
-        <source>Scraping paused: game running</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="106"/>
-        <source>Scraping: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>%1 files</source>
         <translation type="obsolete">%1 קבצים</translation>
     </message>
@@ -2468,16 +2539,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scraped %1 of %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -2239,7 +2239,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1911"/>
+        <location filename="../screens/SettingsScreen.qml" line="1913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2430,7 +2430,7 @@ Français - Wilfried</source>
         <translation>הגדרות</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1893"/>
+        <location filename="../screens/SettingsScreen.qml" line="1895"/>
         <source>No settings available on this platform</source>
         <translation>אין הגדרות זמינות בפלטפורמה זו</translation>
     </message>

--- a/src/ui/translations/frontend_he.ts
+++ b/src/ui/translations/frontend_he.ts
@@ -2116,6 +2116,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
         <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
@@ -2302,11 +2307,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Get metadata</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -35,8 +35,8 @@
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="212"/>
-        <source>Commercial licensing: legal@zaparoo.org</source>
-        <translation>व्यावसायिक लाइसेंसिंग: legal@zaparoo.org</translation>
+        <source>Commercial licensing: legal@zaparoo.com</source>
+        <translation>व्यावसायिक लाइसेंसिंग: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="223"/>
@@ -227,8 +227,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="116"/>
-        <source>Contact: legal@zaparoo.org</source>
-        <translation>संपर्क: legal@zaparoo.org</translation>
+        <source>Contact: legal@zaparoo.com</source>
+        <translation>संपर्क: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="127"/>
@@ -1530,27 +1530,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
-        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <source>Documentation: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="225"/>
         <source>Loading sources…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="262"/>
         <source>Replace existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="276"/>
         <source>Start import</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1559,7 +1559,7 @@ Français - Wilfried</source>
         <translation type="obsolete">मेटाडेटा स्क्रैप करें</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="249"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -2239,7 +2239,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1911"/>
+        <location filename="../screens/SettingsScreen.qml" line="1913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2430,7 +2430,7 @@ Français - Wilfried</source>
         <translation>सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1893"/>
+        <location filename="../screens/SettingsScreen.qml" line="1895"/>
         <source>No settings available on this platform</source>
         <translation>इस प्लेटफ़ॉर्म पर कोई सेटिंग उपलब्ध नहीं है</translation>
     </message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -2116,6 +2116,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
         <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
@@ -2302,11 +2307,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Get metadata</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_hi.ts
+++ b/src/ui/translations/frontend_hi.ts
@@ -389,45 +389,6 @@ Français - Wilfried</source>
     </message>
 </context>
 <context>
-    <name>FirstRunIndexModal</name>
-    <message>
-        <source>First-time setup</source>
-        <translation type="vanished">पहली बार सेटअप</translation>
-    </message>
-    <message>
-        <source>Optimizing database - almost done</source>
-        <translation type="vanished">डेटाबेस अनुकूलित किया जा रहा है - लगभग पूरा</translation>
-    </message>
-    <message>
-        <source>Indexing paused</source>
-        <translation type="vanished">इंडेक्सिंग रोकी गई</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2 - %3</source>
-        <translation type="vanished">%2 में से चरण %1 - %3</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2</source>
-        <translation type="vanished">%2 में से चरण %1</translation>
-    </message>
-    <message>
-        <source>Preparing…</source>
-        <translation type="vanished">तैयार किया जा रहा है…</translation>
-    </message>
-    <message>
-        <source>Done. %1 files indexed.</source>
-        <translation type="vanished">पूरा हुआ। %1 फ़ाइलें इंडेक्स की गईं।</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">रद्द करें</translation>
-    </message>
-    <message>
-        <source>Start scan</source>
-        <translation type="vanished">स्कैन शुरू करें</translation>
-    </message>
-</context>
-<context>
     <name>GameInfoModal</name>
     <message>
         <location filename="../components/GameInfoModal.qml" line="153"/>
@@ -540,6 +501,26 @@ Français - Wilfried</source>
         <translation>पसंदीदा</translation>
     </message>
     <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>Updating the media database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>No games found yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Your games appear here as Core finds them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Update media database in Settings &gt; Library.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Recently Played</source>
         <translation type="vanished">हाल ही में खेले गए</translation>
     </message>
@@ -569,35 +550,44 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
-        <translation>कोई सिस्टम उपलब्ध नहीं है। सेटिंग्स से मीडिया डेटाबेस अपडेट चलाएँ।</translation>
+        <translation type="vanished">कोई सिस्टम उपलब्ध नहीं है। सेटिंग्स से मीडिया डेटाबेस अपडेट चलाएँ।</translation>
     </message>
 </context>
 <context>
     <name>IndexSetupModal</name>
     <message>
         <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Start</source>
+        <translation type="unfinished">शुरू करें</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Change</source>
+        <translation type="unfinished">बदलें</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="51"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="47"/>
+        <location filename="../components/IndexSetupModal.qml" line="53"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="115"/>
+        <location filename="../components/IndexSetupModal.qml" line="121"/>
         <source>Update media database</source>
         <translation type="unfinished">मीडिया डेटाबेस अपडेट करें</translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="124"/>
+        <location filename="../components/IndexSetupModal.qml" line="130"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="137"/>
+        <location filename="../components/IndexSetupModal.qml" line="143"/>
         <source>Start update</source>
         <translation type="unfinished"></translation>
     </message>
@@ -675,30 +665,28 @@ Français - Wilfried</source>
         <translation type="vanished">कोर चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
-        <location filename="../app/Main.qml" line="2330"/>
-        <location filename="../app/Main.qml" line="2393"/>
-        <location filename="../app/Main.qml" line="2699"/>
-        <location filename="../app/Main.qml" line="3741"/>
-        <location filename="../app/Main.qml" line="3784"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
+        <location filename="../app/Main.qml" line="2341"/>
+        <location filename="../app/Main.qml" line="2410"/>
+        <location filename="../app/Main.qml" line="2716"/>
+        <location filename="../app/Main.qml" line="3795"/>
+        <location filename="../app/Main.qml" line="3838"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2183"/>
-        <location filename="../app/Main.qml" line="2218"/>
+        <location filename="../app/Main.qml" line="2185"/>
+        <location filename="../app/Main.qml" line="2220"/>
         <source>Update media database</source>
         <translation type="unfinished">मीडिया डेटाबेस अपडेट करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2186"/>
-        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
-        <translation type="unfinished">मेटाडेटा स्क्रैप करें</translation>
+        <translation type="obsolete">मेटाडेटा स्क्रैप करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2179"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
@@ -708,53 +696,53 @@ Français - Wilfried</source>
         <translation type="unfinished">सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2096"/>
+        <location filename="../app/Main.qml" line="2098"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2153"/>
+        <location filename="../app/Main.qml" line="2155"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2179"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
-        <location filename="../app/Main.qml" line="2308"/>
+        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2319"/>
         <source>Launch game</source>
         <translation>गेम चलाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2258"/>
-        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2323"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
-        <location filename="../app/Main.qml" line="2346"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2280"/>
+        <location filename="../app/Main.qml" line="2357"/>
+        <location filename="../app/Main.qml" line="2451"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Remove from favorites</source>
         <translation>पसंदीदा से हटाएँ</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Add to favorites</source>
         <translation>पसंदीदा में जोड़ें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2264"/>
-        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2266"/>
+        <location filename="../app/Main.qml" line="2346"/>
         <source>Write to NFC token</source>
         <translation>NFC टोकन पर लिखें</translation>
     </message>
@@ -763,70 +751,95 @@ Français - Wilfried</source>
         <translation type="vanished">QR कोड</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3507"/>
+        <location filename="../app/Main.qml" line="2395"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3561"/>
         <source>Default</source>
         <translation type="unfinished">डिफ़ॉल्ट</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2395"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2230"/>
-        <location filename="../app/Main.qml" line="2238"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="2164"/>
+        <location filename="../app/Main.qml" line="2215"/>
+        <location filename="../app/Main.qml" line="2232"/>
+        <location filename="../app/Main.qml" line="2240"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3454"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3432"/>
+        <location filename="../app/Main.qml" line="3153"/>
+        <source>Get metadata failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3154"/>
+        <source>Could not start getting metadata. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3156"/>
+        <source>Source list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3157"/>
+        <source>Could not load the list of metadata sources. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3307"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3486"/>
         <source>Favorites</source>
         <translation type="unfinished">पसंदीदा</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1070"/>
-        <location filename="../app/Main.qml" line="3417"/>
-        <location filename="../app/Main.qml" line="3464"/>
-        <location filename="../app/Main.qml" line="3474"/>
+        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3518"/>
+        <location filename="../app/Main.qml" line="3528"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3445"/>
+        <location filename="../app/Main.qml" line="3499"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3460"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3511"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3565"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3482"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3515"/>
+        <location filename="../app/Main.qml" line="3569"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3436"/>
+        <location filename="../app/Main.qml" line="3490"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -851,50 +864,51 @@ Français - Wilfried</source>
         <translation type="unfinished">बंद करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2173"/>
-        <location filename="../app/Main.qml" line="2282"/>
-        <location filename="../app/Main.qml" line="2301"/>
-        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2284"/>
+        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2361"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2268"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2270"/>
+        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2807"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2461"/>
+        <location filename="../app/Main.qml" line="2478"/>
         <source>Move</source>
         <translation type="unfinished">स्थानांतरित करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2667"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1032"/>
-        <location filename="../app/Main.qml" line="3043"/>
-        <location filename="../app/Main.qml" line="3065"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3131"/>
+        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3174"/>
         <source>OK</source>
         <translation type="unfinished">ठीक है</translation>
     </message>
@@ -909,225 +923,223 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="2188"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2293"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2807"/>
+        <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Scan this code to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3132"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3098"/>
+        <location filename="../app/Main.qml" line="3141"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3099"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3101"/>
+        <location filename="../app/Main.qml" line="3144"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3147"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3105"/>
+        <location filename="../app/Main.qml" line="3148"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3107"/>
+        <location filename="../app/Main.qml" line="3150"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3151"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3110"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3111"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3113"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3114"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3116"/>
+        <location filename="../app/Main.qml" line="3159"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3120"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3122"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3123"/>
+        <location filename="../app/Main.qml" line="3166"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3125"/>
+        <location filename="../app/Main.qml" line="3168"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3126"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3128"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3129"/>
+        <location filename="../app/Main.qml" line="3172"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3253"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3269"/>
+        <location filename="../app/Main.qml" line="3323"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3278"/>
+        <location filename="../app/Main.qml" line="3332"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3307"/>
+        <location filename="../app/Main.qml" line="3361"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3446"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3415"/>
-        <location filename="../app/Main.qml" line="3461"/>
+        <location filename="../app/Main.qml" line="3469"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3449"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3503"/>
+        <location filename="../app/Main.qml" line="3525"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3489"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3485"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3492"/>
+        <location filename="../app/Main.qml" line="3546"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3708"/>
+        <location filename="../app/Main.qml" line="3762"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3119"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
-        <location filename="../app/Main.qml" line="3318"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="2910"/>
+        <location filename="../app/Main.qml" line="3372"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Retry</source>
         <translation type="unfinished">फिर से प्रयास करें</translation>
     </message>
@@ -1136,37 +1148,37 @@ Français - Wilfried</source>
         <translation type="obsolete">रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4848"/>
+        <location filename="../app/Main.qml" line="4902"/>
         <source>Loading systems…</source>
         <translation>सिस्टम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4850"/>
+        <location filename="../app/Main.qml" line="4904"/>
         <source>Loading games…</source>
         <translation>गेम लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4852"/>
+        <location filename="../app/Main.qml" line="4906"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4855"/>
+        <location filename="../app/Main.qml" line="4909"/>
         <source>Loading favorites…</source>
         <translation>पसंदीदा लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4857"/>
+        <location filename="../app/Main.qml" line="4911"/>
         <source>Loading recently played…</source>
         <translation>हाल ही में खेले गए लोड हो रहे हैं…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4859"/>
+        <location filename="../app/Main.qml" line="4913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4861"/>
+        <location filename="../app/Main.qml" line="4915"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>
@@ -1174,7 +1186,7 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Writing failed</source>
         <translation>लिखना विफल हुआ</translation>
     </message>
@@ -1188,8 +1200,8 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="531"/>
-        <location filename="../app/MainLayout.qml" line="533"/>
+        <location filename="../app/MainLayout.qml" line="537"/>
+        <location filename="../app/MainLayout.qml" line="539"/>
         <source>Favorites</source>
         <translation type="unfinished">पसंदीदा</translation>
     </message>
@@ -1198,128 +1210,130 @@ Français - Wilfried</source>
         <translation type="obsolete">हाल ही में खेले गए</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="916"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="917"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="936"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="943"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="1365"/>
         <source>OK</source>
         <translation type="unfinished">ठीक है</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="535"/>
+        <location filename="../app/MainLayout.qml" line="541"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Hold a writable token near the reader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1096"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
         <source>Are you sure you want to exit?</source>
         <translation>क्या आप वाकई बाहर निकलना चाहते हैं?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1374"/>
-        <location filename="../app/MainLayout.qml" line="1454"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1596"/>
-        <location filename="../app/MainLayout.qml" line="1615"/>
-        <location filename="../app/MainLayout.qml" line="1688"/>
+        <location filename="../app/MainLayout.qml" line="1284"/>
+        <location filename="../app/MainLayout.qml" line="1383"/>
+        <location filename="../app/MainLayout.qml" line="1405"/>
+        <location filename="../app/MainLayout.qml" line="1486"/>
+        <location filename="../app/MainLayout.qml" line="1523"/>
+        <location filename="../app/MainLayout.qml" line="1572"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1647"/>
+        <location filename="../app/MainLayout.qml" line="1720"/>
         <source>Move</source>
         <translation>स्थानांतरित करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1387"/>
+        <location filename="../app/MainLayout.qml" line="1409"/>
         <source>Select</source>
         <translation>चुनें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1283"/>
-        <location filename="../app/MainLayout.qml" line="1297"/>
-        <location filename="../app/MainLayout.qml" line="1312"/>
-        <location filename="../app/MainLayout.qml" line="1323"/>
-        <location filename="../app/MainLayout.qml" line="1349"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1321"/>
+        <location filename="../app/MainLayout.qml" line="1332"/>
+        <location filename="../app/MainLayout.qml" line="1358"/>
         <source>Close</source>
         <translation>बंद करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1425"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1339"/>
+        <location filename="../app/MainLayout.qml" line="1391"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1308"/>
+        <location filename="../app/MainLayout.qml" line="1317"/>
         <source>Done</source>
         <translation>पूरा</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1509"/>
-        <location filename="../app/MainLayout.qml" line="1567"/>
-        <location filename="../app/MainLayout.qml" line="1716"/>
+        <location filename="../app/MainLayout.qml" line="1328"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1541"/>
+        <location filename="../app/MainLayout.qml" line="1599"/>
+        <location filename="../app/MainLayout.qml" line="1748"/>
         <source>Retry</source>
         <translation>फिर से प्रयास करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1338"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
         <source>I understand</source>
         <translation>मैं समझ गया</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1376"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1389"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1417"/>
+        <location filename="../app/MainLayout.qml" line="1449"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1421"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1328,11 +1342,11 @@ Français - Wilfried</source>
         <translation type="vanished">शुरू करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1496"/>
-        <location filename="../app/MainLayout.qml" line="1545"/>
-        <location filename="../app/MainLayout.qml" line="1601"/>
-        <location filename="../app/MainLayout.qml" line="1693"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1528"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1633"/>
+        <location filename="../app/MainLayout.qml" line="1725"/>
         <source>Open</source>
         <translation>खोलें</translation>
     </message>
@@ -1341,28 +1355,29 @@ Français - Wilfried</source>
         <translation type="vanished">बंद करें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1477"/>
-        <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1513"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1559"/>
-        <location filename="../app/MainLayout.qml" line="1577"/>
-        <location filename="../app/MainLayout.qml" line="1589"/>
-        <location filename="../app/MainLayout.qml" line="1605"/>
-        <location filename="../app/MainLayout.qml" line="1639"/>
-        <location filename="../app/MainLayout.qml" line="1660"/>
-        <location filename="../app/MainLayout.qml" line="1669"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
-        <location filename="../app/MainLayout.qml" line="1728"/>
+        <location filename="../app/MainLayout.qml" line="1413"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1561"/>
+        <location filename="../app/MainLayout.qml" line="1591"/>
+        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1621"/>
+        <location filename="../app/MainLayout.qml" line="1637"/>
+        <location filename="../app/MainLayout.qml" line="1671"/>
+        <location filename="../app/MainLayout.qml" line="1692"/>
+        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1741"/>
+        <location filename="../app/MainLayout.qml" line="1760"/>
         <source>Back</source>
         <translation>वापस</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1468"/>
-        <location filename="../app/MainLayout.qml" line="1555"/>
-        <location filename="../app/MainLayout.qml" line="1573"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
-        <location filename="../app/MainLayout.qml" line="1724"/>
+        <location filename="../app/MainLayout.qml" line="1500"/>
+        <location filename="../app/MainLayout.qml" line="1587"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1737"/>
+        <location filename="../app/MainLayout.qml" line="1756"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1371,25 +1386,25 @@ Français - Wilfried</source>
         <translation type="vanished">पृष्ठ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1464"/>
-        <location filename="../app/MainLayout.qml" line="1499"/>
-        <location filename="../app/MainLayout.qml" line="1550"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1531"/>
+        <location filename="../app/MainLayout.qml" line="1582"/>
+        <location filename="../app/MainLayout.qml" line="1730"/>
         <source>Options</source>
         <translation>विकल्प</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1624"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Change</source>
         <translation>बदलें</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1630"/>
+        <location filename="../app/MainLayout.qml" line="1662"/>
         <source>Toggle</source>
         <translation>टॉगल</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1656"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Scroll</source>
         <translation>स्क्रॉल</translation>
     </message>
@@ -1450,12 +1465,12 @@ Français - Wilfried</source>
 <context>
     <name>QrCodeModal</name>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="23"/>
+        <location filename="../components/QrCodeModal.qml" line="19"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="43"/>
+        <location filename="../components/QrCodeModal.qml" line="20"/>
         <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1485,43 +1500,67 @@ Français - Wilfried</source>
 <context>
     <name>ScrapeSetupModal</name>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="67"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Start</source>
+        <translation type="unfinished">शुरू करें</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Toggle</source>
+        <translation type="unfinished">टॉगल</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Change</source>
+        <translation type="unfinished">बदलें</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="89"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="69"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="91"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="171"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="193"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
+        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <source>Loading sources…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <source>Replace existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <source>Start import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scrape metadata</source>
-        <translation type="unfinished">मेटाडेटा स्क्रैप करें</translation>
+        <translation type="obsolete">मेटाडेटा स्क्रैप करें</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="185"/>
-        <source>Loading scrapers…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="196"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
         <source>Systems</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="222"/>
-        <source>Re-scrape existing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
-        <source>Start scrape</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1533,17 +1572,17 @@ Français - Wilfried</source>
         <translation>यहाँ कुछ नहीं है</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="36"/>
         <source>Loading…</source>
         <translation>लोड हो रहा है…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="37"/>
         <source>Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="79"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="85"/>
         <source>Failed to load</source>
         <translation>लोड करने में विफल</translation>
     </message>
@@ -1557,14 +1596,14 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="114"/>
         <location filename="../screens/SettingsScreen.qml" line="205"/>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
-        <location filename="../screens/SettingsScreen.qml" line="972"/>
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="978"/>
         <source>Language</source>
         <translation>भाषा</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="165"/>
-        <location filename="../screens/SettingsScreen.qml" line="999"/>
+        <location filename="../screens/SettingsScreen.qml" line="1005"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1574,25 +1613,25 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="225"/>
-        <location filename="../screens/SettingsScreen.qml" line="1051"/>
+        <location filename="../screens/SettingsScreen.qml" line="1057"/>
         <source>Button style</source>
         <translation>बटन शैली</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="1060"/>
+        <location filename="../screens/SettingsScreen.qml" line="1066"/>
         <source>Screensaver</source>
         <translation>स्क्रीनसेवर</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Library</source>
         <translation>लाइब्रेरी</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="291"/>
-        <location filename="../screens/SettingsScreen.qml" line="1069"/>
+        <location filename="../screens/SettingsScreen.qml" line="1075"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1602,9 +1641,8 @@ Français - Wilfried</source>
         <translation>मीडिया डेटाबेस अपडेट करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Scrape metadata</source>
-        <translation>मेटाडेटा स्क्रैप करें</translation>
+        <translation type="vanished">मेटाडेटा स्क्रैप करें</translation>
     </message>
     <message>
         <source>Advanced</source>
@@ -1616,12 +1654,12 @@ Français - Wilfried</source>
         <translation>माउस समर्थन</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <location filename="../screens/SettingsScreen.qml" line="323"/>
         <source>Debug logging</source>
         <translation>डीबग लॉगिंग</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="323"/>
+        <location filename="../screens/SettingsScreen.qml" line="329"/>
         <source>Upload log file</source>
         <translation>लॉग फ़ाइल अपलोड करें</translation>
     </message>
@@ -1632,7 +1670,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="217"/>
-        <location filename="../screens/SettingsScreen.qml" line="981"/>
+        <location filename="../screens/SettingsScreen.qml" line="987"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1653,7 +1691,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <location filename="../screens/SettingsScreen.qml" line="1078"/>
+        <location filename="../screens/SettingsScreen.qml" line="1084"/>
         <source>Video standard</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1664,7 +1702,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="135"/>
-        <location filename="../screens/SettingsScreen.qml" line="1026"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
         <source>System logos</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1684,35 +1722,34 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Optimizing</source>
         <translation>अनुकूलित किया जा रहा है</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>Paused</source>
         <translation>रोक दिया गया</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>In progress</source>
         <translation>प्रगति पर</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>%1 indexed</source>
         <translation>%1 इंडेक्स किए गए</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>%1 scraped</source>
-        <translation>%1 स्क्रैप किए गए</translation>
+        <translation type="vanished">%1 स्क्रैप किए गए</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Cancel</source>
         <translation>रद्द करें</translation>
     </message>
@@ -1721,12 +1758,12 @@ Français - Wilfried</source>
         <translation type="vanished">शुरू करें</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Upload</source>
         <translation>अपलोड</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="650"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Open</source>
         <translation>खोलें</translation>
     </message>
@@ -1735,92 +1772,92 @@ Français - Wilfried</source>
         <translation type="vanished">डिफ़ॉल्ट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="758"/>
         <source>English</source>
         <translation>अंग्रेज़ी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="760"/>
         <source>Italian</source>
         <translation>इतालवी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="756"/>
+        <location filename="../screens/SettingsScreen.qml" line="762"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="758"/>
+        <location filename="../screens/SettingsScreen.qml" line="764"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="760"/>
+        <location filename="../screens/SettingsScreen.qml" line="766"/>
         <source>German</source>
         <translation>जर्मन</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="762"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Greek</source>
         <translation>ग्रीक</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="764"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Japanese</source>
         <translation>जापानी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="766"/>
+        <location filename="../screens/SettingsScreen.qml" line="772"/>
         <source>Korean</source>
         <translation>कोरियाई</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Dutch</source>
         <translation>डच</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="776"/>
         <source>Romanian</source>
         <translation>रोमानियाई</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="778"/>
         <source>Slovak</source>
         <translation>स्लोवाक</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="774"/>
+        <location filename="../screens/SettingsScreen.qml" line="780"/>
         <source>Ukrainian</source>
         <translation>यूक्रेनी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="776"/>
+        <location filename="../screens/SettingsScreen.qml" line="782"/>
         <source>Chinese (Simplified)</source>
         <translation>चीनी (सरलीकृत)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="778"/>
+        <location filename="../screens/SettingsScreen.qml" line="784"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="780"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Hebrew</source>
         <translation>हिब्रू</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="782"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Arabic</source>
         <translation>अरबी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="784"/>
+        <location filename="../screens/SettingsScreen.qml" line="790"/>
         <source>Hindi</source>
         <translation>हिंदी</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>French</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1829,127 +1866,127 @@ Français - Wilfried</source>
         <translation type="vanished">स्वचालित</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="792"/>
+        <location filename="../screens/SettingsScreen.qml" line="798"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="794"/>
+        <location filename="../screens/SettingsScreen.qml" line="800"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="805"/>
+        <location filename="../screens/SettingsScreen.qml" line="811"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="807"/>
+        <location filename="../screens/SettingsScreen.qml" line="813"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="809"/>
+        <location filename="../screens/SettingsScreen.qml" line="815"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
-        <location filename="../screens/SettingsScreen.qml" line="787"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
-        <location filename="../screens/SettingsScreen.qml" line="810"/>
-        <location filename="../screens/SettingsScreen.qml" line="877"/>
-        <location filename="../screens/SettingsScreen.qml" line="925"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="793"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
+        <location filename="../screens/SettingsScreen.qml" line="816"/>
+        <location filename="../screens/SettingsScreen.qml" line="883"/>
+        <location filename="../screens/SettingsScreen.qml" line="931"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="158"/>
-        <location filename="../screens/SettingsScreen.qml" line="963"/>
+        <location filename="../screens/SettingsScreen.qml" line="969"/>
         <source>Interface resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="129"/>
-        <location filename="../screens/SettingsScreen.qml" line="1035"/>
+        <location filename="../screens/SettingsScreen.qml" line="1041"/>
         <source>Color scheme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>%1 × %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Automatic (Recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="717"/>
         <source>%1 (Animations off)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="815"/>
+        <location filename="../screens/SettingsScreen.qml" line="821"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="817"/>
+        <location filename="../screens/SettingsScreen.qml" line="823"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="818"/>
+        <location filename="../screens/SettingsScreen.qml" line="824"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="823"/>
+        <location filename="../screens/SettingsScreen.qml" line="829"/>
         <source>Detailed list view</source>
         <translation>विस्तृत सूची दृश्य</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="824"/>
+        <location filename="../screens/SettingsScreen.qml" line="830"/>
         <source>Grid view</source>
         <translation>ग्रिड दृश्य</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="829"/>
+        <location filename="../screens/SettingsScreen.qml" line="835"/>
         <source>Full color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="830"/>
+        <location filename="../screens/SettingsScreen.qml" line="836"/>
         <source>Tinted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="855"/>
+        <location filename="../screens/SettingsScreen.qml" line="861"/>
         <source>Nord</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="852"/>
+        <location filename="../screens/SettingsScreen.qml" line="858"/>
         <source>Dracula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="90"/>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="120"/>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="211"/>
-        <location filename="../screens/SettingsScreen.qml" line="990"/>
+        <location filename="../screens/SettingsScreen.qml" line="996"/>
         <source>Region</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1959,72 +1996,72 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="859"/>
+        <location filename="../screens/SettingsScreen.qml" line="865"/>
         <source>Synthwave &apos;84</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="846"/>
+        <location filename="../screens/SettingsScreen.qml" line="852"/>
         <source>Amber Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="848"/>
+        <location filename="../screens/SettingsScreen.qml" line="854"/>
         <source>Green Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="849"/>
+        <location filename="../screens/SettingsScreen.qml" line="855"/>
         <source>Neo Geo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="850"/>
+        <location filename="../screens/SettingsScreen.qml" line="856"/>
         <source>NES</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="851"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>Virtual Boy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="854"/>
+        <location filename="../screens/SettingsScreen.qml" line="860"/>
         <source>Gruvbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="853"/>
+        <location filename="../screens/SettingsScreen.qml" line="859"/>
         <source>Everforest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="858"/>
+        <location filename="../screens/SettingsScreen.qml" line="864"/>
         <source>Solarized Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="863"/>
         <source>Rosé Pine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="856"/>
+        <location filename="../screens/SettingsScreen.qml" line="862"/>
         <source>Oxocarbon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="860"/>
+        <location filename="../screens/SettingsScreen.qml" line="866"/>
         <source>Flexoki Paper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="861"/>
+        <location filename="../screens/SettingsScreen.qml" line="867"/>
         <source>Solarized Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="847"/>
+        <location filename="../screens/SettingsScreen.qml" line="853"/>
         <source>Game Boy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2079,19 +2116,14 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Downloads box art, descriptions, and tags for your games. Choose a source and which systems.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
-        <location filename="../screens/SettingsScreen.qml" line="1008"/>
+        <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="285"/>
-        <location filename="../screens/SettingsScreen.qml" line="1017"/>
+        <location filename="../screens/SettingsScreen.qml" line="1023"/>
         <source>Games layout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2106,103 +2138,103 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <location filename="../screens/SettingsScreen.qml" line="324"/>
         <source>Writes extra detail to the log file to help track down a problem. Restarts the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Configure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="868"/>
+        <location filename="../screens/SettingsScreen.qml" line="874"/>
         <source>Style B</source>
         <translation>शैली B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="870"/>
+        <location filename="../screens/SettingsScreen.qml" line="876"/>
         <source>Style C</source>
         <translation>शैली C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="872"/>
+        <location filename="../screens/SettingsScreen.qml" line="878"/>
         <source>Style D</source>
         <translation>शैली D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="874"/>
+        <location filename="../screens/SettingsScreen.qml" line="880"/>
         <source>Style E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="876"/>
+        <location filename="../screens/SettingsScreen.qml" line="882"/>
         <source>Style A</source>
         <translation>शैली A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="892"/>
+        <location filename="../screens/SettingsScreen.qml" line="898"/>
         <source>Off</source>
         <translation>बंद</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="894"/>
+        <location filename="../screens/SettingsScreen.qml" line="900"/>
         <source>1 second (testing)</source>
         <translation>1 सेकंड (परीक्षण)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="896"/>
+        <location filename="../screens/SettingsScreen.qml" line="902"/>
         <source>1 minute</source>
         <translation>1 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="898"/>
+        <location filename="../screens/SettingsScreen.qml" line="904"/>
         <source>2 minutes</source>
         <translation>2 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="900"/>
+        <location filename="../screens/SettingsScreen.qml" line="906"/>
         <source>5 minutes</source>
         <translation>5 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="902"/>
+        <location filename="../screens/SettingsScreen.qml" line="908"/>
         <source>10 minutes</source>
         <translation>10 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="904"/>
+        <location filename="../screens/SettingsScreen.qml" line="910"/>
         <source>15 minutes</source>
         <translation>15 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="906"/>
+        <location filename="../screens/SettingsScreen.qml" line="912"/>
         <source>30 minutes</source>
         <translation>30 मिनट</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="907"/>
+        <location filename="../screens/SettingsScreen.qml" line="913"/>
         <source>%1 seconds</source>
         <translation>%1 सेकंड</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="917"/>
+        <location filename="../screens/SettingsScreen.qml" line="923"/>
         <source>PAL (50 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="919"/>
+        <location filename="../screens/SettingsScreen.qml" line="925"/>
         <source>480i (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="920"/>
+        <location filename="../screens/SettingsScreen.qml" line="926"/>
         <source>NTSC (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1905"/>
+        <location filename="../screens/SettingsScreen.qml" line="1911"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2212,13 +2244,13 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="108"/>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2268,6 +2300,16 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="269"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="280"/>
         <source>Show systems as a grid of covers, or as a list with details beside it.</source>
         <translation type="unfinished"></translation>
@@ -2288,92 +2330,107 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="324"/>
+        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <source>Shows a code you can scan to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="330"/>
         <source>Uploads the log file and gives you a link to share when reporting a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="843"/>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <source>%1 imported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="849"/>
         <source>Zaparoo Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="844"/>
+        <location filename="../screens/SettingsScreen.qml" line="850"/>
         <source>Zaparoo Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="845"/>
+        <location filename="../screens/SettingsScreen.qml" line="851"/>
         <source>Classic Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="927"/>
+        <location filename="../screens/SettingsScreen.qml" line="933"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="929"/>
+        <location filename="../screens/SettingsScreen.qml" line="935"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="931"/>
+        <location filename="../screens/SettingsScreen.qml" line="937"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="933"/>
+        <location filename="../screens/SettingsScreen.qml" line="939"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="935"/>
+        <location filename="../screens/SettingsScreen.qml" line="941"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="937"/>
+        <location filename="../screens/SettingsScreen.qml" line="943"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="939"/>
+        <location filename="../screens/SettingsScreen.qml" line="945"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="941"/>
+        <location filename="../screens/SettingsScreen.qml" line="947"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="943"/>
+        <location filename="../screens/SettingsScreen.qml" line="949"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="945"/>
+        <location filename="../screens/SettingsScreen.qml" line="951"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="947"/>
+        <location filename="../screens/SettingsScreen.qml" line="953"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="949"/>
+        <location filename="../screens/SettingsScreen.qml" line="955"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="355"/>
+        <location filename="../screens/SettingsScreen.qml" line="361"/>
         <source>Settings</source>
         <translation>सेटिंग्स</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1887"/>
+        <location filename="../screens/SettingsScreen.qml" line="1893"/>
         <source>No settings available on this platform</source>
         <translation>इस प्लेटफ़ॉर्म पर कोई सेटिंग उपलब्ध नहीं है</translation>
     </message>
@@ -2412,9 +2469,33 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/StatusLine.qml" line="105"/>
+        <source>Importing paused: game running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Import failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Imported %1 of %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scraping…</source>
-        <translation type="unfinished">स्क्रैपिंग…</translation>
+        <translation type="obsolete">स्क्रैपिंग…</translation>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
@@ -2443,16 +2524,6 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="105"/>
-        <source>Scraping paused: game running</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="106"/>
-        <source>Scraping: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>%1 files</source>
         <translation type="obsolete">%1 फ़ाइलें</translation>
     </message>
@@ -2468,16 +2539,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scraped %1 of %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -389,45 +389,6 @@ Français - Wilfried</source>
     </message>
 </context>
 <context>
-    <name>FirstRunIndexModal</name>
-    <message>
-        <source>First-time setup</source>
-        <translation type="vanished">Configurazione iniziale</translation>
-    </message>
-    <message>
-        <source>Indexing paused</source>
-        <translation type="vanished">Indicizzazione in pausa</translation>
-    </message>
-    <message>
-        <source>Optimizing database - almost done</source>
-        <translation type="vanished">Ottimizzazione database - quasi finito</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2 - %3</source>
-        <translation type="vanished">Passo %1 di %2 - %3</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2</source>
-        <translation type="vanished">Passo %1 di %2</translation>
-    </message>
-    <message>
-        <source>Preparing…</source>
-        <translation type="vanished">Preparazione…</translation>
-    </message>
-    <message>
-        <source>Done. %1 files indexed.</source>
-        <translation type="vanished">Fatto. %1 file indicizzati.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Annulla</translation>
-    </message>
-    <message>
-        <source>Start scan</source>
-        <translation type="vanished">Avvia scansione</translation>
-    </message>
-</context>
-<context>
     <name>GameInfoModal</name>
     <message>
         <location filename="../components/GameInfoModal.qml" line="153"/>
@@ -540,6 +501,26 @@ Français - Wilfried</source>
         <translation>Preferiti</translation>
     </message>
     <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>Updating the media database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>No games found yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Your games appear here as Core finds them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Update media database in Settings &gt; Library.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Recently Played</source>
         <translation type="vanished">Giocati di recente</translation>
     </message>
@@ -569,35 +550,44 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
-        <translation>Nessun sistema disponibile. Esegui Aggiorna database multimediale dalle Impostazioni.</translation>
+        <translation type="vanished">Nessun sistema disponibile. Esegui Aggiorna database multimediale dalle Impostazioni.</translation>
     </message>
 </context>
 <context>
     <name>IndexSetupModal</name>
     <message>
         <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Start</source>
+        <translation type="unfinished">Avvia</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Change</source>
+        <translation type="unfinished">Cambia</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="51"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="47"/>
+        <location filename="../components/IndexSetupModal.qml" line="53"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="115"/>
+        <location filename="../components/IndexSetupModal.qml" line="121"/>
         <source>Update media database</source>
         <translation type="unfinished">Aggiorna database multimediale</translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="124"/>
+        <location filename="../components/IndexSetupModal.qml" line="130"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="137"/>
+        <location filename="../components/IndexSetupModal.qml" line="143"/>
         <source>Start update</source>
         <translation type="unfinished"></translation>
     </message>
@@ -675,29 +665,29 @@ Français - Wilfried</source>
         <translation type="vanished">Avvia core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
-        <location filename="../app/Main.qml" line="2330"/>
-        <location filename="../app/Main.qml" line="2393"/>
-        <location filename="../app/Main.qml" line="2699"/>
-        <location filename="../app/Main.qml" line="3741"/>
-        <location filename="../app/Main.qml" line="3784"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
+        <location filename="../app/Main.qml" line="2341"/>
+        <location filename="../app/Main.qml" line="2410"/>
+        <location filename="../app/Main.qml" line="2716"/>
+        <location filename="../app/Main.qml" line="3795"/>
+        <location filename="../app/Main.qml" line="3838"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Remove from favorites</source>
         <translation>Rimuovi dai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Add to favorites</source>
         <translation>Aggiungi ai preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2264"/>
-        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2266"/>
+        <location filename="../app/Main.qml" line="2346"/>
         <source>Write to NFC token</source>
         <translation>Scrivi sul token NFC</translation>
     </message>
@@ -706,53 +696,76 @@ Français - Wilfried</source>
         <translation type="vanished">Codice QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
-        <location filename="../app/Main.qml" line="2308"/>
+        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2319"/>
         <source>Launch game</source>
         <translation>Avvia gioco</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1070"/>
-        <location filename="../app/Main.qml" line="3417"/>
-        <location filename="../app/Main.qml" line="3464"/>
-        <location filename="../app/Main.qml" line="3474"/>
+        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3518"/>
+        <location filename="../app/Main.qml" line="3528"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3153"/>
+        <source>Get metadata failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3154"/>
+        <source>Could not start getting metadata. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3156"/>
+        <source>Source list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3157"/>
+        <source>Could not load the list of metadata sources. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3307"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4848"/>
+        <location filename="../app/Main.qml" line="4902"/>
         <source>Loading systems…</source>
         <translation>Caricamento sistemi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4855"/>
+        <location filename="../app/Main.qml" line="4909"/>
         <source>Loading favorites…</source>
         <translation>Caricamento preferiti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4850"/>
+        <location filename="../app/Main.qml" line="4904"/>
         <source>Loading games…</source>
         <translation>Caricamento giochi…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2183"/>
-        <location filename="../app/Main.qml" line="2218"/>
+        <location filename="../app/Main.qml" line="2185"/>
+        <location filename="../app/Main.qml" line="2220"/>
         <source>Update media database</source>
         <translation type="unfinished">Aggiorna database multimediale</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2186"/>
-        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
-        <translation type="unfinished">Recupera metadati</translation>
+        <translation type="obsolete">Recupera metadati</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2179"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
@@ -762,90 +775,90 @@ Français - Wilfried</source>
         <translation type="unfinished">Impostazioni</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2096"/>
+        <location filename="../app/Main.qml" line="2098"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2153"/>
+        <location filename="../app/Main.qml" line="2155"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2179"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2258"/>
-        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2323"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
-        <location filename="../app/Main.qml" line="2346"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2280"/>
+        <location filename="../app/Main.qml" line="2357"/>
+        <location filename="../app/Main.qml" line="2451"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3507"/>
+        <location filename="../app/Main.qml" line="2395"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3561"/>
         <source>Default</source>
         <translation type="unfinished">Predefinito</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2395"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2230"/>
-        <location filename="../app/Main.qml" line="2238"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="2164"/>
+        <location filename="../app/Main.qml" line="2215"/>
+        <location filename="../app/Main.qml" line="2232"/>
+        <location filename="../app/Main.qml" line="2240"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3454"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3445"/>
+        <location filename="../app/Main.qml" line="3499"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3460"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3511"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3565"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3482"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3515"/>
+        <location filename="../app/Main.qml" line="3569"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3436"/>
+        <location filename="../app/Main.qml" line="3490"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -870,45 +883,46 @@ Français - Wilfried</source>
         <translation type="unfinished">Esci</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2173"/>
-        <location filename="../app/Main.qml" line="2282"/>
-        <location filename="../app/Main.qml" line="2301"/>
-        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2284"/>
+        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2361"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2268"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2270"/>
+        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2807"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2461"/>
+        <location filename="../app/Main.qml" line="2478"/>
         <source>Move</source>
         <translation type="unfinished">Muovi</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2667"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1032"/>
-        <location filename="../app/Main.qml" line="3043"/>
-        <location filename="../app/Main.qml" line="3065"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3131"/>
+        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3174"/>
         <source>OK</source>
         <translation type="unfinished">Va bene</translation>
     </message>
@@ -923,226 +937,224 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="2188"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2293"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2807"/>
+        <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Scan this code to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3132"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3098"/>
+        <location filename="../app/Main.qml" line="3141"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3099"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3101"/>
+        <location filename="../app/Main.qml" line="3144"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3147"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3105"/>
+        <location filename="../app/Main.qml" line="3148"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3107"/>
+        <location filename="../app/Main.qml" line="3150"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3151"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3110"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3111"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3113"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3114"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3116"/>
+        <location filename="../app/Main.qml" line="3159"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3120"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3122"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3123"/>
+        <location filename="../app/Main.qml" line="3166"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3125"/>
+        <location filename="../app/Main.qml" line="3168"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3126"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3128"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3129"/>
+        <location filename="../app/Main.qml" line="3172"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3253"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3269"/>
+        <location filename="../app/Main.qml" line="3323"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3278"/>
+        <location filename="../app/Main.qml" line="3332"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3307"/>
+        <location filename="../app/Main.qml" line="3361"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3446"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3432"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3486"/>
         <source>Favorites</source>
         <translation type="unfinished">Preferiti</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3415"/>
-        <location filename="../app/Main.qml" line="3461"/>
+        <location filename="../app/Main.qml" line="3469"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3449"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3503"/>
+        <location filename="../app/Main.qml" line="3525"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3489"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3485"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3492"/>
+        <location filename="../app/Main.qml" line="3546"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3708"/>
+        <location filename="../app/Main.qml" line="3762"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3119"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
-        <location filename="../app/Main.qml" line="3318"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="2910"/>
+        <location filename="../app/Main.qml" line="3372"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Retry</source>
         <translation type="unfinished">Riprova</translation>
     </message>
@@ -1151,22 +1163,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Annulla</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4852"/>
+        <location filename="../app/Main.qml" line="4906"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4857"/>
+        <location filename="../app/Main.qml" line="4911"/>
         <source>Loading recently played…</source>
         <translation>Caricamento recenti…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4859"/>
+        <location filename="../app/Main.qml" line="4913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4861"/>
+        <location filename="../app/Main.qml" line="4915"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>
@@ -1174,7 +1186,7 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Writing failed</source>
         <translation>Scrittura non riuscita</translation>
     </message>
@@ -1183,82 +1195,83 @@ Français - Wilfried</source>
         <translation type="vanished">Avvicina una scheda scrivibile al lettore</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="936"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="943"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="1365"/>
         <source>OK</source>
         <translation type="unfinished">Va bene</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="535"/>
+        <location filename="../app/MainLayout.qml" line="541"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Hold a writable token near the reader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
         <source>Are you sure you want to exit?</source>
         <translation>Sei sicuro di voler uscire?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1387"/>
+        <location filename="../app/MainLayout.qml" line="1409"/>
         <source>Select</source>
         <translation>Seleziona</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1283"/>
-        <location filename="../app/MainLayout.qml" line="1297"/>
-        <location filename="../app/MainLayout.qml" line="1312"/>
-        <location filename="../app/MainLayout.qml" line="1323"/>
-        <location filename="../app/MainLayout.qml" line="1349"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1321"/>
+        <location filename="../app/MainLayout.qml" line="1332"/>
+        <location filename="../app/MainLayout.qml" line="1358"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1425"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1339"/>
+        <location filename="../app/MainLayout.qml" line="1391"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1308"/>
+        <location filename="../app/MainLayout.qml" line="1317"/>
         <source>Done</source>
         <translation>Fatto</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1338"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
         <source>I understand</source>
         <translation>Ho capito</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1376"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1389"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1267,28 +1280,29 @@ Français - Wilfried</source>
         <translation type="vanished">Avvia</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1656"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Scroll</source>
         <translation>Scorri</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1468"/>
-        <location filename="../app/MainLayout.qml" line="1555"/>
-        <location filename="../app/MainLayout.qml" line="1573"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
-        <location filename="../app/MainLayout.qml" line="1724"/>
+        <location filename="../app/MainLayout.qml" line="1500"/>
+        <location filename="../app/MainLayout.qml" line="1587"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1737"/>
+        <location filename="../app/MainLayout.qml" line="1756"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1374"/>
-        <location filename="../app/MainLayout.qml" line="1454"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1596"/>
-        <location filename="../app/MainLayout.qml" line="1615"/>
-        <location filename="../app/MainLayout.qml" line="1688"/>
+        <location filename="../app/MainLayout.qml" line="1284"/>
+        <location filename="../app/MainLayout.qml" line="1383"/>
+        <location filename="../app/MainLayout.qml" line="1405"/>
+        <location filename="../app/MainLayout.qml" line="1486"/>
+        <location filename="../app/MainLayout.qml" line="1523"/>
+        <location filename="../app/MainLayout.qml" line="1572"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1647"/>
+        <location filename="../app/MainLayout.qml" line="1720"/>
         <source>Move</source>
         <translation>Muovi</translation>
     </message>
@@ -1298,8 +1312,8 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="531"/>
-        <location filename="../app/MainLayout.qml" line="533"/>
+        <location filename="../app/MainLayout.qml" line="537"/>
+        <location filename="../app/MainLayout.qml" line="539"/>
         <source>Favorites</source>
         <translation type="unfinished">Preferiti</translation>
     </message>
@@ -1308,36 +1322,36 @@ Français - Wilfried</source>
         <translation type="obsolete">Giocati di recente</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="916"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="917"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1096"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1417"/>
+        <location filename="../app/MainLayout.qml" line="1449"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1421"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1496"/>
-        <location filename="../app/MainLayout.qml" line="1545"/>
-        <location filename="../app/MainLayout.qml" line="1601"/>
-        <location filename="../app/MainLayout.qml" line="1693"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1528"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1633"/>
+        <location filename="../app/MainLayout.qml" line="1725"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
@@ -1346,19 +1360,20 @@ Français - Wilfried</source>
         <translation type="vanished">Esci</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1477"/>
-        <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1513"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1559"/>
-        <location filename="../app/MainLayout.qml" line="1577"/>
-        <location filename="../app/MainLayout.qml" line="1589"/>
-        <location filename="../app/MainLayout.qml" line="1605"/>
-        <location filename="../app/MainLayout.qml" line="1639"/>
-        <location filename="../app/MainLayout.qml" line="1660"/>
-        <location filename="../app/MainLayout.qml" line="1669"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
-        <location filename="../app/MainLayout.qml" line="1728"/>
+        <location filename="../app/MainLayout.qml" line="1413"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1561"/>
+        <location filename="../app/MainLayout.qml" line="1591"/>
+        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1621"/>
+        <location filename="../app/MainLayout.qml" line="1637"/>
+        <location filename="../app/MainLayout.qml" line="1671"/>
+        <location filename="../app/MainLayout.qml" line="1692"/>
+        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1741"/>
+        <location filename="../app/MainLayout.qml" line="1760"/>
         <source>Back</source>
         <translation>Indietro</translation>
     </message>
@@ -1367,29 +1382,29 @@ Français - Wilfried</source>
         <translation type="vanished">Pagina</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1464"/>
-        <location filename="../app/MainLayout.qml" line="1499"/>
-        <location filename="../app/MainLayout.qml" line="1550"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1531"/>
+        <location filename="../app/MainLayout.qml" line="1582"/>
+        <location filename="../app/MainLayout.qml" line="1730"/>
         <source>Options</source>
         <translation>Opzioni</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1509"/>
-        <location filename="../app/MainLayout.qml" line="1567"/>
-        <location filename="../app/MainLayout.qml" line="1716"/>
+        <location filename="../app/MainLayout.qml" line="1328"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1541"/>
+        <location filename="../app/MainLayout.qml" line="1599"/>
+        <location filename="../app/MainLayout.qml" line="1748"/>
         <source>Retry</source>
         <translation>Riprova</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1624"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Change</source>
         <translation>Cambia</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1630"/>
+        <location filename="../app/MainLayout.qml" line="1662"/>
         <source>Toggle</source>
         <translation>Alterna</translation>
     </message>
@@ -1450,12 +1465,12 @@ Français - Wilfried</source>
 <context>
     <name>QrCodeModal</name>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="23"/>
+        <location filename="../components/QrCodeModal.qml" line="19"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="43"/>
+        <location filename="../components/QrCodeModal.qml" line="20"/>
         <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1485,43 +1500,67 @@ Français - Wilfried</source>
 <context>
     <name>ScrapeSetupModal</name>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="67"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Start</source>
+        <translation type="unfinished">Avvia</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Toggle</source>
+        <translation type="unfinished">Alterna</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Change</source>
+        <translation type="unfinished">Cambia</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="89"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="69"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="91"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="171"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="193"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
+        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <source>Loading sources…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <source>Replace existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <source>Start import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scrape metadata</source>
-        <translation type="unfinished">Recupera metadati</translation>
+        <translation type="obsolete">Recupera metadati</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="185"/>
-        <source>Loading scrapers…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="196"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
         <source>Systems</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="222"/>
-        <source>Re-scrape existing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
-        <source>Start scrape</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1533,17 +1572,17 @@ Français - Wilfried</source>
         <translation>Niente qui</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="36"/>
         <source>Loading…</source>
         <translation>Caricamento…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="37"/>
         <source>Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="79"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="85"/>
         <source>Failed to load</source>
         <translation>Caricamento non riuscito</translation>
     </message>
@@ -1553,8 +1592,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="114"/>
         <location filename="../screens/SettingsScreen.qml" line="205"/>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
-        <location filename="../screens/SettingsScreen.qml" line="972"/>
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="978"/>
         <source>Language</source>
         <translation>Lingua</translation>
     </message>
@@ -1578,50 +1617,49 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="165"/>
-        <location filename="../screens/SettingsScreen.qml" line="999"/>
+        <location filename="../screens/SettingsScreen.qml" line="1005"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="225"/>
-        <location filename="../screens/SettingsScreen.qml" line="1051"/>
+        <location filename="../screens/SettingsScreen.qml" line="1057"/>
         <source>Button style</source>
         <translation>Stile pulsanti</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="1060"/>
+        <location filename="../screens/SettingsScreen.qml" line="1066"/>
         <source>Screensaver</source>
         <translation>Salvaschermo</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Library</source>
         <translation>Libreria</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="291"/>
-        <location filename="../screens/SettingsScreen.qml" line="1069"/>
+        <location filename="../screens/SettingsScreen.qml" line="1075"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Scrape metadata</source>
-        <translation>Recupera metadati</translation>
+        <translation type="vanished">Recupera metadati</translation>
     </message>
     <message>
         <source>Advanced</source>
         <translation type="vanished">Avanzate</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <location filename="../screens/SettingsScreen.qml" line="323"/>
         <source>Debug logging</source>
         <translation>Log di debug</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="323"/>
+        <location filename="../screens/SettingsScreen.qml" line="329"/>
         <source>Upload log file</source>
         <translation>Carica file di log</translation>
     </message>
@@ -1632,7 +1670,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="217"/>
-        <location filename="../screens/SettingsScreen.qml" line="981"/>
+        <location filename="../screens/SettingsScreen.qml" line="987"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1643,13 +1681,13 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="158"/>
-        <location filename="../screens/SettingsScreen.qml" line="963"/>
+        <location filename="../screens/SettingsScreen.qml" line="969"/>
         <source>Interface resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="129"/>
-        <location filename="../screens/SettingsScreen.qml" line="1035"/>
+        <location filename="../screens/SettingsScreen.qml" line="1041"/>
         <source>Color scheme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1665,7 +1703,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <location filename="../screens/SettingsScreen.qml" line="1078"/>
+        <location filename="../screens/SettingsScreen.qml" line="1084"/>
         <source>Video standard</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1676,7 +1714,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="135"/>
-        <location filename="../screens/SettingsScreen.qml" line="1026"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
         <source>System logos</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1697,19 +1735,19 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="90"/>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="120"/>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="211"/>
-        <location filename="../screens/SettingsScreen.qml" line="990"/>
+        <location filename="../screens/SettingsScreen.qml" line="996"/>
         <source>Region</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1719,35 +1757,34 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Optimizing</source>
         <translation>Ottimizzazione</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>Paused</source>
         <translation>In pausa</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>In progress</source>
         <translation>In corso</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>%1 indexed</source>
         <translation>%1 indicizzati</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>%1 scraped</source>
-        <translation>%1 recuperati</translation>
+        <translation type="vanished">%1 recuperati</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
@@ -1756,117 +1793,117 @@ Français - Wilfried</source>
         <translation type="vanished">Avvia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Upload</source>
         <translation>Carica</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="650"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Open</source>
         <translation>Apri</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>%1 × %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Automatic (Recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="717"/>
         <source>%1 (Animations off)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="758"/>
         <source>English</source>
         <translation>Inglese</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="760"/>
         <source>Italian</source>
         <translation>Italiano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="756"/>
+        <location filename="../screens/SettingsScreen.qml" line="762"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="758"/>
+        <location filename="../screens/SettingsScreen.qml" line="764"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="760"/>
+        <location filename="../screens/SettingsScreen.qml" line="766"/>
         <source>German</source>
         <translation>Tedesco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="762"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Greek</source>
         <translation>Greco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="764"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Japanese</source>
         <translation>Giapponese</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="766"/>
+        <location filename="../screens/SettingsScreen.qml" line="772"/>
         <source>Korean</source>
         <translation>Coreano</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Dutch</source>
         <translation>Olandese</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="776"/>
         <source>Romanian</source>
         <translation>Rumeno</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="778"/>
         <source>Slovak</source>
         <translation>Slovacco</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="774"/>
+        <location filename="../screens/SettingsScreen.qml" line="780"/>
         <source>Ukrainian</source>
         <translation>Ucraino</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="776"/>
+        <location filename="../screens/SettingsScreen.qml" line="782"/>
         <source>Chinese (Simplified)</source>
         <translation>Cinese (semplificato)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="778"/>
+        <location filename="../screens/SettingsScreen.qml" line="784"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="780"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Hebrew</source>
         <translation>Ebraico</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="782"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="784"/>
+        <location filename="../screens/SettingsScreen.qml" line="790"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>French</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1875,37 +1912,37 @@ Français - Wilfried</source>
         <translation type="vanished">Automatico</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="792"/>
+        <location filename="../screens/SettingsScreen.qml" line="798"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="794"/>
+        <location filename="../screens/SettingsScreen.qml" line="800"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="805"/>
+        <location filename="../screens/SettingsScreen.qml" line="811"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="807"/>
+        <location filename="../screens/SettingsScreen.qml" line="813"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="809"/>
+        <location filename="../screens/SettingsScreen.qml" line="815"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
-        <location filename="../screens/SettingsScreen.qml" line="787"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
-        <location filename="../screens/SettingsScreen.qml" line="810"/>
-        <location filename="../screens/SettingsScreen.qml" line="877"/>
-        <location filename="../screens/SettingsScreen.qml" line="925"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="793"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
+        <location filename="../screens/SettingsScreen.qml" line="816"/>
+        <location filename="../screens/SettingsScreen.qml" line="883"/>
+        <location filename="../screens/SettingsScreen.qml" line="931"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1960,19 +1997,14 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Downloads box art, descriptions, and tags for your games. Choose a source and which systems.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
-        <location filename="../screens/SettingsScreen.qml" line="1008"/>
+        <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="285"/>
-        <location filename="../screens/SettingsScreen.qml" line="1017"/>
+        <location filename="../screens/SettingsScreen.qml" line="1023"/>
         <source>Games layout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1987,93 +2019,93 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <location filename="../screens/SettingsScreen.qml" line="324"/>
         <source>Writes extra detail to the log file to help track down a problem. Restarts the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Configure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="815"/>
+        <location filename="../screens/SettingsScreen.qml" line="821"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="817"/>
+        <location filename="../screens/SettingsScreen.qml" line="823"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="818"/>
+        <location filename="../screens/SettingsScreen.qml" line="824"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="823"/>
+        <location filename="../screens/SettingsScreen.qml" line="829"/>
         <source>Detailed list view</source>
         <translation>Vista elenco dettagliata</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="824"/>
+        <location filename="../screens/SettingsScreen.qml" line="830"/>
         <source>Grid view</source>
         <translation>Vista griglia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="829"/>
+        <location filename="../screens/SettingsScreen.qml" line="835"/>
         <source>Full color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="830"/>
+        <location filename="../screens/SettingsScreen.qml" line="836"/>
         <source>Tinted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="868"/>
+        <location filename="../screens/SettingsScreen.qml" line="874"/>
         <source>Style B</source>
         <translation>Stile B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="870"/>
+        <location filename="../screens/SettingsScreen.qml" line="876"/>
         <source>Style C</source>
         <translation>Stile C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="872"/>
+        <location filename="../screens/SettingsScreen.qml" line="878"/>
         <source>Style D</source>
         <translation>Stile D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="874"/>
+        <location filename="../screens/SettingsScreen.qml" line="880"/>
         <source>Style E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="876"/>
+        <location filename="../screens/SettingsScreen.qml" line="882"/>
         <source>Style A</source>
         <translation>Stile A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="917"/>
+        <location filename="../screens/SettingsScreen.qml" line="923"/>
         <source>PAL (50 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="919"/>
+        <location filename="../screens/SettingsScreen.qml" line="925"/>
         <source>480i (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="920"/>
+        <location filename="../screens/SettingsScreen.qml" line="926"/>
         <source>NTSC (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1905"/>
+        <location filename="../screens/SettingsScreen.qml" line="1911"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2082,47 +2114,47 @@ Français - Wilfried</source>
         <translation type="vanished">Predefinito</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="892"/>
+        <location filename="../screens/SettingsScreen.qml" line="898"/>
         <source>Off</source>
         <translation>Disattivato</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="894"/>
+        <location filename="../screens/SettingsScreen.qml" line="900"/>
         <source>1 second (testing)</source>
         <translation>1 secondo (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="896"/>
+        <location filename="../screens/SettingsScreen.qml" line="902"/>
         <source>1 minute</source>
         <translation>1 minuto</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="898"/>
+        <location filename="../screens/SettingsScreen.qml" line="904"/>
         <source>2 minutes</source>
         <translation>2 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="900"/>
+        <location filename="../screens/SettingsScreen.qml" line="906"/>
         <source>5 minutes</source>
         <translation>5 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="902"/>
+        <location filename="../screens/SettingsScreen.qml" line="908"/>
         <source>10 minutes</source>
         <translation>10 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="904"/>
+        <location filename="../screens/SettingsScreen.qml" line="910"/>
         <source>15 minutes</source>
         <translation>15 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="906"/>
+        <location filename="../screens/SettingsScreen.qml" line="912"/>
         <source>30 minutes</source>
         <translation>30 minuti</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="907"/>
+        <location filename="../screens/SettingsScreen.qml" line="913"/>
         <source>%1 seconds</source>
         <translation>%1 secondi</translation>
     </message>
@@ -2132,93 +2164,93 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="108"/>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="855"/>
+        <location filename="../screens/SettingsScreen.qml" line="861"/>
         <source>Nord</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="852"/>
+        <location filename="../screens/SettingsScreen.qml" line="858"/>
         <source>Dracula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="859"/>
+        <location filename="../screens/SettingsScreen.qml" line="865"/>
         <source>Synthwave &apos;84</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="846"/>
+        <location filename="../screens/SettingsScreen.qml" line="852"/>
         <source>Amber Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="848"/>
+        <location filename="../screens/SettingsScreen.qml" line="854"/>
         <source>Green Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="849"/>
+        <location filename="../screens/SettingsScreen.qml" line="855"/>
         <source>Neo Geo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="850"/>
+        <location filename="../screens/SettingsScreen.qml" line="856"/>
         <source>NES</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="851"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>Virtual Boy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="854"/>
+        <location filename="../screens/SettingsScreen.qml" line="860"/>
         <source>Gruvbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="853"/>
+        <location filename="../screens/SettingsScreen.qml" line="859"/>
         <source>Everforest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="858"/>
+        <location filename="../screens/SettingsScreen.qml" line="864"/>
         <source>Solarized Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="863"/>
         <source>Rosé Pine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="856"/>
+        <location filename="../screens/SettingsScreen.qml" line="862"/>
         <source>Oxocarbon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="860"/>
+        <location filename="../screens/SettingsScreen.qml" line="866"/>
         <source>Flexoki Paper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="861"/>
+        <location filename="../screens/SettingsScreen.qml" line="867"/>
         <source>Solarized Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="847"/>
+        <location filename="../screens/SettingsScreen.qml" line="853"/>
         <source>Game Boy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2268,6 +2300,16 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="269"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="280"/>
         <source>Show systems as a grid of covers, or as a list with details beside it.</source>
         <translation type="unfinished"></translation>
@@ -2288,92 +2330,107 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="324"/>
+        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <source>Shows a code you can scan to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="330"/>
         <source>Uploads the log file and gives you a link to share when reporting a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="927"/>
-        <source>Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="929"/>
-        <source>Thumbnail</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="931"/>
-        <source>Box art</source>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <source>%1 imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="933"/>
-        <source>3D box art</source>
+        <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="935"/>
-        <source>Screenshot</source>
+        <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="937"/>
-        <source>Wheel</source>
+        <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="939"/>
-        <source>Title screen</source>
+        <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="941"/>
-        <source>Map</source>
+        <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="943"/>
-        <source>Marquee</source>
+        <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="945"/>
-        <source>Fan art</source>
+        <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="947"/>
-        <source>Box side</source>
+        <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="949"/>
+        <source>Marquee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="951"/>
+        <source>Fan art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="953"/>
+        <source>Box side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="955"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="355"/>
+        <location filename="../screens/SettingsScreen.qml" line="361"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="843"/>
+        <location filename="../screens/SettingsScreen.qml" line="849"/>
         <source>Zaparoo Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="844"/>
+        <location filename="../screens/SettingsScreen.qml" line="850"/>
         <source>Zaparoo Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="845"/>
+        <location filename="../screens/SettingsScreen.qml" line="851"/>
         <source>Classic Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1887"/>
+        <location filename="../screens/SettingsScreen.qml" line="1893"/>
         <source>No settings available on this platform</source>
         <translation>Nessuna impostazione disponibile su questa piattaforma</translation>
     </message>
@@ -2412,9 +2469,33 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/StatusLine.qml" line="105"/>
+        <source>Importing paused: game running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Import failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Imported %1 of %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scraping…</source>
-        <translation type="unfinished">Recupero metadati…</translation>
+        <translation type="obsolete">Recupero metadati…</translation>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
@@ -2443,16 +2524,6 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="105"/>
-        <source>Scraping paused: game running</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="106"/>
-        <source>Scraping: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>%1 files</source>
         <translation type="obsolete">%1 file</translation>
     </message>
@@ -2468,16 +2539,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scraped %1 of %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -2110,7 +2110,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1911"/>
+        <location filename="../screens/SettingsScreen.qml" line="1913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2430,7 +2430,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1893"/>
+        <location filename="../screens/SettingsScreen.qml" line="1895"/>
         <source>No settings available on this platform</source>
         <translation>Nessuna impostazione disponibile su questa piattaforma</translation>
     </message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -1997,6 +1997,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
         <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
@@ -2302,11 +2307,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Get metadata</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_it.ts
+++ b/src/ui/translations/frontend_it.ts
@@ -35,8 +35,8 @@
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="212"/>
-        <source>Commercial licensing: legal@zaparoo.org</source>
-        <translation>Licenze commerciali: legal@zaparoo.org</translation>
+        <source>Commercial licensing: legal@zaparoo.com</source>
+        <translation>Licenze commerciali: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="223"/>
@@ -227,8 +227,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="116"/>
-        <source>Contact: legal@zaparoo.org</source>
-        <translation>Contatto: legal@zaparoo.org</translation>
+        <source>Contact: legal@zaparoo.com</source>
+        <translation>Contatto: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="127"/>
@@ -1530,27 +1530,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
-        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <source>Documentation: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="225"/>
         <source>Loading sources…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="262"/>
         <source>Replace existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="276"/>
         <source>Start import</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1559,7 +1559,7 @@ Français - Wilfried</source>
         <translation type="obsolete">Recupera metadati</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="249"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -2108,7 +2108,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1911"/>
+        <location filename="../screens/SettingsScreen.qml" line="1913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2428,7 +2428,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1893"/>
+        <location filename="../screens/SettingsScreen.qml" line="1895"/>
         <source>No settings available on this platform</source>
         <translation>このプラットフォームでは設定項目がありません</translation>
     </message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -387,45 +387,6 @@ Français - Wilfried</source>
     </message>
 </context>
 <context>
-    <name>FirstRunIndexModal</name>
-    <message>
-        <source>First-time setup</source>
-        <translation type="vanished">初回セットアップ</translation>
-    </message>
-    <message>
-        <source>Indexing paused</source>
-        <translation type="vanished">インデックス作成を一時停止</translation>
-    </message>
-    <message>
-        <source>Optimizing database - almost done</source>
-        <translation type="vanished">データベースを最適化中 - もうすぐ完了</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2 - %3</source>
-        <translation type="vanished">ステップ %1 / %2 - %3</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2</source>
-        <translation type="vanished">ステップ %1 / %2</translation>
-    </message>
-    <message>
-        <source>Preparing…</source>
-        <translation type="vanished">準備中…</translation>
-    </message>
-    <message>
-        <source>Done. %1 files indexed.</source>
-        <translation type="vanished">完了。%1 ファイルをインデックスしました。</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">キャンセル</translation>
-    </message>
-    <message>
-        <source>Start scan</source>
-        <translation type="vanished">スキャン開始</translation>
-    </message>
-</context>
-<context>
     <name>GameInfoModal</name>
     <message>
         <location filename="../components/GameInfoModal.qml" line="153"/>
@@ -538,6 +499,26 @@ Français - Wilfried</source>
         <translation>お気に入り</translation>
     </message>
     <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>Updating the media database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>No games found yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Your games appear here as Core finds them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Update media database in Settings &gt; Library.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Recently Played</source>
         <translation type="vanished">最近プレイしたゲーム</translation>
     </message>
@@ -567,35 +548,44 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
-        <translation>利用可能なシステムがありません。設定からメディアデータベースの更新を実行してください。</translation>
+        <translation type="vanished">利用可能なシステムがありません。設定からメディアデータベースの更新を実行してください。</translation>
     </message>
 </context>
 <context>
     <name>IndexSetupModal</name>
     <message>
         <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Start</source>
+        <translation type="unfinished">開始</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Change</source>
+        <translation type="unfinished">変更</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="51"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="47"/>
+        <location filename="../components/IndexSetupModal.qml" line="53"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="115"/>
+        <location filename="../components/IndexSetupModal.qml" line="121"/>
         <source>Update media database</source>
         <translation type="unfinished">メディアデータベースを更新</translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="124"/>
+        <location filename="../components/IndexSetupModal.qml" line="130"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="137"/>
+        <location filename="../components/IndexSetupModal.qml" line="143"/>
         <source>Start update</source>
         <translation type="unfinished"></translation>
     </message>
@@ -673,29 +663,29 @@ Français - Wilfried</source>
         <translation type="vanished">コアを起動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
-        <location filename="../app/Main.qml" line="2330"/>
-        <location filename="../app/Main.qml" line="2393"/>
-        <location filename="../app/Main.qml" line="2699"/>
-        <location filename="../app/Main.qml" line="3741"/>
-        <location filename="../app/Main.qml" line="3784"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
+        <location filename="../app/Main.qml" line="2341"/>
+        <location filename="../app/Main.qml" line="2410"/>
+        <location filename="../app/Main.qml" line="2716"/>
+        <location filename="../app/Main.qml" line="3795"/>
+        <location filename="../app/Main.qml" line="3838"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Remove from favorites</source>
         <translation>お気に入りから削除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Add to favorites</source>
         <translation>お気に入りに追加</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2264"/>
-        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2266"/>
+        <location filename="../app/Main.qml" line="2346"/>
         <source>Write to NFC token</source>
         <translation>NFC トークンに書き込む</translation>
     </message>
@@ -704,53 +694,76 @@ Français - Wilfried</source>
         <translation type="vanished">QR コード</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
-        <location filename="../app/Main.qml" line="2308"/>
+        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2319"/>
         <source>Launch game</source>
         <translation>ゲームを起動</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1070"/>
-        <location filename="../app/Main.qml" line="3417"/>
-        <location filename="../app/Main.qml" line="3464"/>
-        <location filename="../app/Main.qml" line="3474"/>
+        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3518"/>
+        <location filename="../app/Main.qml" line="3528"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3153"/>
+        <source>Get metadata failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3154"/>
+        <source>Could not start getting metadata. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3156"/>
+        <source>Source list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3157"/>
+        <source>Could not load the list of metadata sources. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3307"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4848"/>
+        <location filename="../app/Main.qml" line="4902"/>
         <source>Loading systems…</source>
         <translation>システムを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4855"/>
+        <location filename="../app/Main.qml" line="4909"/>
         <source>Loading favorites…</source>
         <translation>お気に入りを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4850"/>
+        <location filename="../app/Main.qml" line="4904"/>
         <source>Loading games…</source>
         <translation>ゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2183"/>
-        <location filename="../app/Main.qml" line="2218"/>
+        <location filename="../app/Main.qml" line="2185"/>
+        <location filename="../app/Main.qml" line="2220"/>
         <source>Update media database</source>
         <translation type="unfinished">メディアデータベースを更新</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2186"/>
-        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
-        <translation type="unfinished">メタデータをスクレイピング</translation>
+        <translation type="obsolete">メタデータをスクレイピング</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2179"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
@@ -760,90 +773,90 @@ Français - Wilfried</source>
         <translation type="unfinished">設定</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2096"/>
+        <location filename="../app/Main.qml" line="2098"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2153"/>
+        <location filename="../app/Main.qml" line="2155"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2179"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2258"/>
-        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2323"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
-        <location filename="../app/Main.qml" line="2346"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2280"/>
+        <location filename="../app/Main.qml" line="2357"/>
+        <location filename="../app/Main.qml" line="2451"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3507"/>
+        <location filename="../app/Main.qml" line="2395"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3561"/>
         <source>Default</source>
         <translation type="unfinished">デフォルト</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2395"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2230"/>
-        <location filename="../app/Main.qml" line="2238"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="2164"/>
+        <location filename="../app/Main.qml" line="2215"/>
+        <location filename="../app/Main.qml" line="2232"/>
+        <location filename="../app/Main.qml" line="2240"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3454"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3445"/>
+        <location filename="../app/Main.qml" line="3499"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3460"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3511"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3565"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3482"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3515"/>
+        <location filename="../app/Main.qml" line="3569"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3436"/>
+        <location filename="../app/Main.qml" line="3490"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -868,45 +881,46 @@ Français - Wilfried</source>
         <translation type="unfinished">終了</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2173"/>
-        <location filename="../app/Main.qml" line="2282"/>
-        <location filename="../app/Main.qml" line="2301"/>
-        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2284"/>
+        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2361"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2268"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2270"/>
+        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2807"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2461"/>
+        <location filename="../app/Main.qml" line="2478"/>
         <source>Move</source>
         <translation type="unfinished">移動</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2667"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1032"/>
-        <location filename="../app/Main.qml" line="3043"/>
-        <location filename="../app/Main.qml" line="3065"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3131"/>
+        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3174"/>
         <source>OK</source>
         <translation type="unfinished">決定</translation>
     </message>
@@ -921,226 +935,224 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="2188"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2293"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2807"/>
+        <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Scan this code to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3132"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3098"/>
+        <location filename="../app/Main.qml" line="3141"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3099"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3101"/>
+        <location filename="../app/Main.qml" line="3144"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3147"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3105"/>
+        <location filename="../app/Main.qml" line="3148"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3107"/>
+        <location filename="../app/Main.qml" line="3150"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3151"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3110"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3111"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3113"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3114"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3116"/>
+        <location filename="../app/Main.qml" line="3159"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3120"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3122"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3123"/>
+        <location filename="../app/Main.qml" line="3166"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3125"/>
+        <location filename="../app/Main.qml" line="3168"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3126"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3128"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3129"/>
+        <location filename="../app/Main.qml" line="3172"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3253"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3269"/>
+        <location filename="../app/Main.qml" line="3323"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3278"/>
+        <location filename="../app/Main.qml" line="3332"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3307"/>
+        <location filename="../app/Main.qml" line="3361"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3446"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3432"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3486"/>
         <source>Favorites</source>
         <translation type="unfinished">お気に入り</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3415"/>
-        <location filename="../app/Main.qml" line="3461"/>
+        <location filename="../app/Main.qml" line="3469"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3449"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3503"/>
+        <location filename="../app/Main.qml" line="3525"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3489"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3485"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3492"/>
+        <location filename="../app/Main.qml" line="3546"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3708"/>
+        <location filename="../app/Main.qml" line="3762"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3119"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
-        <location filename="../app/Main.qml" line="3318"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="2910"/>
+        <location filename="../app/Main.qml" line="3372"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Retry</source>
         <translation type="unfinished">再試行</translation>
     </message>
@@ -1149,22 +1161,22 @@ Français - Wilfried</source>
         <translation type="obsolete">キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4852"/>
+        <location filename="../app/Main.qml" line="4906"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4857"/>
+        <location filename="../app/Main.qml" line="4911"/>
         <source>Loading recently played…</source>
         <translation>最近プレイしたゲームを読み込み中…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4859"/>
+        <location filename="../app/Main.qml" line="4913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4861"/>
+        <location filename="../app/Main.qml" line="4915"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>
@@ -1172,7 +1184,7 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Writing failed</source>
         <translation>書き込み失敗</translation>
     </message>
@@ -1181,82 +1193,83 @@ Français - Wilfried</source>
         <translation type="vanished">書き込み可能なカードをリーダーに近づけてください</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="936"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="943"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="1365"/>
         <source>OK</source>
         <translation type="unfinished">決定</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="535"/>
+        <location filename="../app/MainLayout.qml" line="541"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Hold a writable token near the reader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
         <source>Are you sure you want to exit?</source>
         <translation>本当に終了しますか？</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1387"/>
+        <location filename="../app/MainLayout.qml" line="1409"/>
         <source>Select</source>
         <translation>選択</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1283"/>
-        <location filename="../app/MainLayout.qml" line="1297"/>
-        <location filename="../app/MainLayout.qml" line="1312"/>
-        <location filename="../app/MainLayout.qml" line="1323"/>
-        <location filename="../app/MainLayout.qml" line="1349"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1321"/>
+        <location filename="../app/MainLayout.qml" line="1332"/>
+        <location filename="../app/MainLayout.qml" line="1358"/>
         <source>Close</source>
         <translation>閉じる</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1425"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1339"/>
+        <location filename="../app/MainLayout.qml" line="1391"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1308"/>
+        <location filename="../app/MainLayout.qml" line="1317"/>
         <source>Done</source>
         <translation>完了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1338"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
         <source>I understand</source>
         <translation>了解しました</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1376"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1389"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1265,28 +1278,29 @@ Français - Wilfried</source>
         <translation type="vanished">開始</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1656"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Scroll</source>
         <translation>スクロール</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1468"/>
-        <location filename="../app/MainLayout.qml" line="1555"/>
-        <location filename="../app/MainLayout.qml" line="1573"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
-        <location filename="../app/MainLayout.qml" line="1724"/>
+        <location filename="../app/MainLayout.qml" line="1500"/>
+        <location filename="../app/MainLayout.qml" line="1587"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1737"/>
+        <location filename="../app/MainLayout.qml" line="1756"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1374"/>
-        <location filename="../app/MainLayout.qml" line="1454"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1596"/>
-        <location filename="../app/MainLayout.qml" line="1615"/>
-        <location filename="../app/MainLayout.qml" line="1688"/>
+        <location filename="../app/MainLayout.qml" line="1284"/>
+        <location filename="../app/MainLayout.qml" line="1383"/>
+        <location filename="../app/MainLayout.qml" line="1405"/>
+        <location filename="../app/MainLayout.qml" line="1486"/>
+        <location filename="../app/MainLayout.qml" line="1523"/>
+        <location filename="../app/MainLayout.qml" line="1572"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1647"/>
+        <location filename="../app/MainLayout.qml" line="1720"/>
         <source>Move</source>
         <translation>移動</translation>
     </message>
@@ -1296,8 +1310,8 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="531"/>
-        <location filename="../app/MainLayout.qml" line="533"/>
+        <location filename="../app/MainLayout.qml" line="537"/>
+        <location filename="../app/MainLayout.qml" line="539"/>
         <source>Favorites</source>
         <translation type="unfinished">お気に入り</translation>
     </message>
@@ -1306,36 +1320,36 @@ Français - Wilfried</source>
         <translation type="obsolete">最近プレイしたゲーム</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="916"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="917"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1096"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1417"/>
+        <location filename="../app/MainLayout.qml" line="1449"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1421"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1496"/>
-        <location filename="../app/MainLayout.qml" line="1545"/>
-        <location filename="../app/MainLayout.qml" line="1601"/>
-        <location filename="../app/MainLayout.qml" line="1693"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1528"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1633"/>
+        <location filename="../app/MainLayout.qml" line="1725"/>
         <source>Open</source>
         <translation>開く</translation>
     </message>
@@ -1344,19 +1358,20 @@ Français - Wilfried</source>
         <translation type="vanished">終了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1477"/>
-        <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1513"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1559"/>
-        <location filename="../app/MainLayout.qml" line="1577"/>
-        <location filename="../app/MainLayout.qml" line="1589"/>
-        <location filename="../app/MainLayout.qml" line="1605"/>
-        <location filename="../app/MainLayout.qml" line="1639"/>
-        <location filename="../app/MainLayout.qml" line="1660"/>
-        <location filename="../app/MainLayout.qml" line="1669"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
-        <location filename="../app/MainLayout.qml" line="1728"/>
+        <location filename="../app/MainLayout.qml" line="1413"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1561"/>
+        <location filename="../app/MainLayout.qml" line="1591"/>
+        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1621"/>
+        <location filename="../app/MainLayout.qml" line="1637"/>
+        <location filename="../app/MainLayout.qml" line="1671"/>
+        <location filename="../app/MainLayout.qml" line="1692"/>
+        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1741"/>
+        <location filename="../app/MainLayout.qml" line="1760"/>
         <source>Back</source>
         <translation>戻る</translation>
     </message>
@@ -1365,29 +1380,29 @@ Français - Wilfried</source>
         <translation type="vanished">ページ</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1464"/>
-        <location filename="../app/MainLayout.qml" line="1499"/>
-        <location filename="../app/MainLayout.qml" line="1550"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1531"/>
+        <location filename="../app/MainLayout.qml" line="1582"/>
+        <location filename="../app/MainLayout.qml" line="1730"/>
         <source>Options</source>
         <translation>オプション</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1509"/>
-        <location filename="../app/MainLayout.qml" line="1567"/>
-        <location filename="../app/MainLayout.qml" line="1716"/>
+        <location filename="../app/MainLayout.qml" line="1328"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1541"/>
+        <location filename="../app/MainLayout.qml" line="1599"/>
+        <location filename="../app/MainLayout.qml" line="1748"/>
         <source>Retry</source>
         <translation>再試行</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1624"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Change</source>
         <translation>変更</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1630"/>
+        <location filename="../app/MainLayout.qml" line="1662"/>
         <source>Toggle</source>
         <translation>切り替え</translation>
     </message>
@@ -1448,12 +1463,12 @@ Français - Wilfried</source>
 <context>
     <name>QrCodeModal</name>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="23"/>
+        <location filename="../components/QrCodeModal.qml" line="19"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="43"/>
+        <location filename="../components/QrCodeModal.qml" line="20"/>
         <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1483,43 +1498,67 @@ Français - Wilfried</source>
 <context>
     <name>ScrapeSetupModal</name>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="67"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Start</source>
+        <translation type="unfinished">開始</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Toggle</source>
+        <translation type="unfinished">切り替え</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Change</source>
+        <translation type="unfinished">変更</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="89"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="69"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="91"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="171"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="193"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
+        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <source>Loading sources…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <source>Replace existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <source>Start import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scrape metadata</source>
-        <translation type="unfinished">メタデータをスクレイピング</translation>
+        <translation type="obsolete">メタデータをスクレイピング</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="185"/>
-        <source>Loading scrapers…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="196"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
         <source>Systems</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="222"/>
-        <source>Re-scrape existing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
-        <source>Start scrape</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1531,17 +1570,17 @@ Français - Wilfried</source>
         <translation>ここには何もありません</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="36"/>
         <source>Loading…</source>
         <translation>読み込み中…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="37"/>
         <source>Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="79"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="85"/>
         <source>Failed to load</source>
         <translation>読み込みに失敗しました</translation>
     </message>
@@ -1551,8 +1590,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="114"/>
         <location filename="../screens/SettingsScreen.qml" line="205"/>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
-        <location filename="../screens/SettingsScreen.qml" line="972"/>
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="978"/>
         <source>Language</source>
         <translation>言語</translation>
     </message>
@@ -1576,50 +1615,49 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="165"/>
-        <location filename="../screens/SettingsScreen.qml" line="999"/>
+        <location filename="../screens/SettingsScreen.qml" line="1005"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="225"/>
-        <location filename="../screens/SettingsScreen.qml" line="1051"/>
+        <location filename="../screens/SettingsScreen.qml" line="1057"/>
         <source>Button style</source>
         <translation>ボタンスタイル</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="1060"/>
+        <location filename="../screens/SettingsScreen.qml" line="1066"/>
         <source>Screensaver</source>
         <translation>スクリーンセーバー</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Library</source>
         <translation>ライブラリ</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="291"/>
-        <location filename="../screens/SettingsScreen.qml" line="1069"/>
+        <location filename="../screens/SettingsScreen.qml" line="1075"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Scrape metadata</source>
-        <translation>メタデータをスクレイピング</translation>
+        <translation type="vanished">メタデータをスクレイピング</translation>
     </message>
     <message>
         <source>Advanced</source>
         <translation type="vanished">詳細設定</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <location filename="../screens/SettingsScreen.qml" line="323"/>
         <source>Debug logging</source>
         <translation>デバッグログ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="323"/>
+        <location filename="../screens/SettingsScreen.qml" line="329"/>
         <source>Upload log file</source>
         <translation>ログファイルをアップロード</translation>
     </message>
@@ -1630,7 +1668,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="217"/>
-        <location filename="../screens/SettingsScreen.qml" line="981"/>
+        <location filename="../screens/SettingsScreen.qml" line="987"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1641,13 +1679,13 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="158"/>
-        <location filename="../screens/SettingsScreen.qml" line="963"/>
+        <location filename="../screens/SettingsScreen.qml" line="969"/>
         <source>Interface resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="129"/>
-        <location filename="../screens/SettingsScreen.qml" line="1035"/>
+        <location filename="../screens/SettingsScreen.qml" line="1041"/>
         <source>Color scheme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1663,7 +1701,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <location filename="../screens/SettingsScreen.qml" line="1078"/>
+        <location filename="../screens/SettingsScreen.qml" line="1084"/>
         <source>Video standard</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1674,7 +1712,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="135"/>
-        <location filename="../screens/SettingsScreen.qml" line="1026"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
         <source>System logos</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1695,19 +1733,19 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="90"/>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="120"/>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="211"/>
-        <location filename="../screens/SettingsScreen.qml" line="990"/>
+        <location filename="../screens/SettingsScreen.qml" line="996"/>
         <source>Region</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1717,35 +1755,34 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Optimizing</source>
         <translation>最適化中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>Paused</source>
         <translation>一時停止中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>In progress</source>
         <translation>実行中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>%1 indexed</source>
         <translation>%1 件を索引化</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>%1 scraped</source>
-        <translation>%1 件取得済み</translation>
+        <translation type="vanished">%1 件取得済み</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Cancel</source>
         <translation>キャンセル</translation>
     </message>
@@ -1754,117 +1791,117 @@ Français - Wilfried</source>
         <translation type="vanished">開始</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Upload</source>
         <translation>アップロード</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="650"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Open</source>
         <translation>開く</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>%1 × %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Automatic (Recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="717"/>
         <source>%1 (Animations off)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="758"/>
         <source>English</source>
         <translation>英語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="760"/>
         <source>Italian</source>
         <translation>イタリア語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="756"/>
+        <location filename="../screens/SettingsScreen.qml" line="762"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="758"/>
+        <location filename="../screens/SettingsScreen.qml" line="764"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="760"/>
+        <location filename="../screens/SettingsScreen.qml" line="766"/>
         <source>German</source>
         <translation>ドイツ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="762"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Greek</source>
         <translation>ギリシャ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="764"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Japanese</source>
         <translation>日本語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="766"/>
+        <location filename="../screens/SettingsScreen.qml" line="772"/>
         <source>Korean</source>
         <translation>韓国語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Dutch</source>
         <translation>オランダ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="776"/>
         <source>Romanian</source>
         <translation>ルーマニア語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="778"/>
         <source>Slovak</source>
         <translation>スロバキア語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="774"/>
+        <location filename="../screens/SettingsScreen.qml" line="780"/>
         <source>Ukrainian</source>
         <translation>ウクライナ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="776"/>
+        <location filename="../screens/SettingsScreen.qml" line="782"/>
         <source>Chinese (Simplified)</source>
         <translation>中国語（簡体字）</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="778"/>
+        <location filename="../screens/SettingsScreen.qml" line="784"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="780"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Hebrew</source>
         <translation>ヘブライ語</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="782"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="784"/>
+        <location filename="../screens/SettingsScreen.qml" line="790"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>French</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1873,37 +1910,37 @@ Français - Wilfried</source>
         <translation type="vanished">自動</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="792"/>
+        <location filename="../screens/SettingsScreen.qml" line="798"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="794"/>
+        <location filename="../screens/SettingsScreen.qml" line="800"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="805"/>
+        <location filename="../screens/SettingsScreen.qml" line="811"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="807"/>
+        <location filename="../screens/SettingsScreen.qml" line="813"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="809"/>
+        <location filename="../screens/SettingsScreen.qml" line="815"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
-        <location filename="../screens/SettingsScreen.qml" line="787"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
-        <location filename="../screens/SettingsScreen.qml" line="810"/>
-        <location filename="../screens/SettingsScreen.qml" line="877"/>
-        <location filename="../screens/SettingsScreen.qml" line="925"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="793"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
+        <location filename="../screens/SettingsScreen.qml" line="816"/>
+        <location filename="../screens/SettingsScreen.qml" line="883"/>
+        <location filename="../screens/SettingsScreen.qml" line="931"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1958,19 +1995,14 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Downloads box art, descriptions, and tags for your games. Choose a source and which systems.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
-        <location filename="../screens/SettingsScreen.qml" line="1008"/>
+        <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="285"/>
-        <location filename="../screens/SettingsScreen.qml" line="1017"/>
+        <location filename="../screens/SettingsScreen.qml" line="1023"/>
         <source>Games layout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1985,93 +2017,93 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <location filename="../screens/SettingsScreen.qml" line="324"/>
         <source>Writes extra detail to the log file to help track down a problem. Restarts the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Configure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="815"/>
+        <location filename="../screens/SettingsScreen.qml" line="821"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="817"/>
+        <location filename="../screens/SettingsScreen.qml" line="823"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="818"/>
+        <location filename="../screens/SettingsScreen.qml" line="824"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="823"/>
+        <location filename="../screens/SettingsScreen.qml" line="829"/>
         <source>Detailed list view</source>
         <translation>詳細リスト表示</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="824"/>
+        <location filename="../screens/SettingsScreen.qml" line="830"/>
         <source>Grid view</source>
         <translation>グリッド表示</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="829"/>
+        <location filename="../screens/SettingsScreen.qml" line="835"/>
         <source>Full color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="830"/>
+        <location filename="../screens/SettingsScreen.qml" line="836"/>
         <source>Tinted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="868"/>
+        <location filename="../screens/SettingsScreen.qml" line="874"/>
         <source>Style B</source>
         <translation>スタイル B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="870"/>
+        <location filename="../screens/SettingsScreen.qml" line="876"/>
         <source>Style C</source>
         <translation>スタイル C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="872"/>
+        <location filename="../screens/SettingsScreen.qml" line="878"/>
         <source>Style D</source>
         <translation>スタイル D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="874"/>
+        <location filename="../screens/SettingsScreen.qml" line="880"/>
         <source>Style E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="876"/>
+        <location filename="../screens/SettingsScreen.qml" line="882"/>
         <source>Style A</source>
         <translation>スタイル A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="917"/>
+        <location filename="../screens/SettingsScreen.qml" line="923"/>
         <source>PAL (50 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="919"/>
+        <location filename="../screens/SettingsScreen.qml" line="925"/>
         <source>480i (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="920"/>
+        <location filename="../screens/SettingsScreen.qml" line="926"/>
         <source>NTSC (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1905"/>
+        <location filename="../screens/SettingsScreen.qml" line="1911"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2080,47 +2112,47 @@ Français - Wilfried</source>
         <translation type="vanished">デフォルト</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="892"/>
+        <location filename="../screens/SettingsScreen.qml" line="898"/>
         <source>Off</source>
         <translation>オフ</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="894"/>
+        <location filename="../screens/SettingsScreen.qml" line="900"/>
         <source>1 second (testing)</source>
         <translation>1秒（テスト）</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="896"/>
+        <location filename="../screens/SettingsScreen.qml" line="902"/>
         <source>1 minute</source>
         <translation>1分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="898"/>
+        <location filename="../screens/SettingsScreen.qml" line="904"/>
         <source>2 minutes</source>
         <translation>2分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="900"/>
+        <location filename="../screens/SettingsScreen.qml" line="906"/>
         <source>5 minutes</source>
         <translation>5分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="902"/>
+        <location filename="../screens/SettingsScreen.qml" line="908"/>
         <source>10 minutes</source>
         <translation>10分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="904"/>
+        <location filename="../screens/SettingsScreen.qml" line="910"/>
         <source>15 minutes</source>
         <translation>15分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="906"/>
+        <location filename="../screens/SettingsScreen.qml" line="912"/>
         <source>30 minutes</source>
         <translation>30分</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="907"/>
+        <location filename="../screens/SettingsScreen.qml" line="913"/>
         <source>%1 seconds</source>
         <translation>%1秒</translation>
     </message>
@@ -2130,93 +2162,93 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="108"/>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="855"/>
+        <location filename="../screens/SettingsScreen.qml" line="861"/>
         <source>Nord</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="852"/>
+        <location filename="../screens/SettingsScreen.qml" line="858"/>
         <source>Dracula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="859"/>
+        <location filename="../screens/SettingsScreen.qml" line="865"/>
         <source>Synthwave &apos;84</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="846"/>
+        <location filename="../screens/SettingsScreen.qml" line="852"/>
         <source>Amber Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="848"/>
+        <location filename="../screens/SettingsScreen.qml" line="854"/>
         <source>Green Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="849"/>
+        <location filename="../screens/SettingsScreen.qml" line="855"/>
         <source>Neo Geo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="850"/>
+        <location filename="../screens/SettingsScreen.qml" line="856"/>
         <source>NES</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="851"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>Virtual Boy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="854"/>
+        <location filename="../screens/SettingsScreen.qml" line="860"/>
         <source>Gruvbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="853"/>
+        <location filename="../screens/SettingsScreen.qml" line="859"/>
         <source>Everforest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="858"/>
+        <location filename="../screens/SettingsScreen.qml" line="864"/>
         <source>Solarized Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="863"/>
         <source>Rosé Pine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="856"/>
+        <location filename="../screens/SettingsScreen.qml" line="862"/>
         <source>Oxocarbon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="860"/>
+        <location filename="../screens/SettingsScreen.qml" line="866"/>
         <source>Flexoki Paper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="861"/>
+        <location filename="../screens/SettingsScreen.qml" line="867"/>
         <source>Solarized Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="847"/>
+        <location filename="../screens/SettingsScreen.qml" line="853"/>
         <source>Game Boy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2266,6 +2298,16 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="269"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="280"/>
         <source>Show systems as a grid of covers, or as a list with details beside it.</source>
         <translation type="unfinished"></translation>
@@ -2286,92 +2328,107 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="324"/>
+        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <source>Shows a code you can scan to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="330"/>
         <source>Uploads the log file and gives you a link to share when reporting a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="927"/>
-        <source>Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="929"/>
-        <source>Thumbnail</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="931"/>
-        <source>Box art</source>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <source>%1 imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="933"/>
-        <source>3D box art</source>
+        <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="935"/>
-        <source>Screenshot</source>
+        <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="937"/>
-        <source>Wheel</source>
+        <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="939"/>
-        <source>Title screen</source>
+        <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="941"/>
-        <source>Map</source>
+        <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="943"/>
-        <source>Marquee</source>
+        <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="945"/>
-        <source>Fan art</source>
+        <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="947"/>
-        <source>Box side</source>
+        <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="949"/>
+        <source>Marquee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="951"/>
+        <source>Fan art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="953"/>
+        <source>Box side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="955"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="355"/>
+        <location filename="../screens/SettingsScreen.qml" line="361"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="843"/>
+        <location filename="../screens/SettingsScreen.qml" line="849"/>
         <source>Zaparoo Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="844"/>
+        <location filename="../screens/SettingsScreen.qml" line="850"/>
         <source>Zaparoo Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="845"/>
+        <location filename="../screens/SettingsScreen.qml" line="851"/>
         <source>Classic Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1887"/>
+        <location filename="../screens/SettingsScreen.qml" line="1893"/>
         <source>No settings available on this platform</source>
         <translation>このプラットフォームでは設定項目がありません</translation>
     </message>
@@ -2410,9 +2467,33 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/StatusLine.qml" line="105"/>
+        <source>Importing paused: game running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Import failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Imported %1 of %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scraping…</source>
-        <translation type="unfinished">スクレイピング中…</translation>
+        <translation type="obsolete">スクレイピング中…</translation>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
@@ -2441,16 +2522,6 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="105"/>
-        <source>Scraping paused: game running</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="106"/>
-        <source>Scraping: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>%1 files</source>
         <translation type="obsolete">%1 ファイル</translation>
     </message>
@@ -2466,16 +2537,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scraped %1 of %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -1995,6 +1995,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
         <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
@@ -2300,11 +2305,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Get metadata</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_ja.ts
+++ b/src/ui/translations/frontend_ja.ts
@@ -35,8 +35,8 @@
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="212"/>
-        <source>Commercial licensing: legal@zaparoo.org</source>
-        <translation>商用ライセンス: legal@zaparoo.org</translation>
+        <source>Commercial licensing: legal@zaparoo.com</source>
+        <translation>商用ライセンス: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="223"/>
@@ -227,8 +227,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="116"/>
-        <source>Contact: legal@zaparoo.org</source>
-        <translation>連絡先: legal@zaparoo.org</translation>
+        <source>Contact: legal@zaparoo.com</source>
+        <translation>連絡先: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="127"/>
@@ -1528,27 +1528,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
-        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <source>Documentation: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="225"/>
         <source>Loading sources…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="262"/>
         <source>Replace existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="276"/>
         <source>Start import</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1557,7 +1557,7 @@ Français - Wilfried</source>
         <translation type="obsolete">メタデータをスクレイピング</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="249"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -2114,6 +2114,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
         <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
@@ -2300,11 +2305,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Get metadata</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -2237,7 +2237,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1911"/>
+        <location filename="../screens/SettingsScreen.qml" line="1913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2428,7 +2428,7 @@ Français - Wilfried</source>
         <translation>설정</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1893"/>
+        <location filename="../screens/SettingsScreen.qml" line="1895"/>
         <source>No settings available on this platform</source>
         <translation>이 플랫폼에서는 설정을 사용할 수 없습니다</translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -35,8 +35,8 @@
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="212"/>
-        <source>Commercial licensing: legal@zaparoo.org</source>
-        <translation>상업용 라이선스: legal@zaparoo.org</translation>
+        <source>Commercial licensing: legal@zaparoo.com</source>
+        <translation>상업용 라이선스: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="223"/>
@@ -227,8 +227,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="116"/>
-        <source>Contact: legal@zaparoo.org</source>
-        <translation>문의: legal@zaparoo.org</translation>
+        <source>Contact: legal@zaparoo.com</source>
+        <translation>문의: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="127"/>
@@ -1528,27 +1528,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
-        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <source>Documentation: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="225"/>
         <source>Loading sources…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="262"/>
         <source>Replace existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="276"/>
         <source>Start import</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1557,7 +1557,7 @@ Français - Wilfried</source>
         <translation type="obsolete">메타데이터 수집</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="249"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ko.ts
+++ b/src/ui/translations/frontend_ko.ts
@@ -387,45 +387,6 @@ Français - Wilfried</source>
     </message>
 </context>
 <context>
-    <name>FirstRunIndexModal</name>
-    <message>
-        <source>First-time setup</source>
-        <translation type="vanished">최초 설정</translation>
-    </message>
-    <message>
-        <source>Optimizing database - almost done</source>
-        <translation type="vanished">데이터베이스 최적화 중 - 거의 완료됨</translation>
-    </message>
-    <message>
-        <source>Indexing paused</source>
-        <translation type="vanished">인덱싱 일시중지됨</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2 - %3</source>
-        <translation type="vanished">%2 중 %1단계 - %3</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2</source>
-        <translation type="vanished">%2 중 %1단계</translation>
-    </message>
-    <message>
-        <source>Preparing…</source>
-        <translation type="vanished">준비 중…</translation>
-    </message>
-    <message>
-        <source>Done. %1 files indexed.</source>
-        <translation type="vanished">완료. 파일 %1개를 인덱싱했습니다.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">취소</translation>
-    </message>
-    <message>
-        <source>Start scan</source>
-        <translation type="vanished">스캔 시작</translation>
-    </message>
-</context>
-<context>
     <name>GameInfoModal</name>
     <message>
         <location filename="../components/GameInfoModal.qml" line="153"/>
@@ -538,6 +499,26 @@ Français - Wilfried</source>
         <translation>즐겨찾기</translation>
     </message>
     <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>Updating the media database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>No games found yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Your games appear here as Core finds them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Update media database in Settings &gt; Library.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Recently Played</source>
         <translation type="vanished">최근 플레이</translation>
     </message>
@@ -567,35 +548,44 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
-        <translation>사용 가능한 시스템이 없습니다. 설정에서 미디어 데이터베이스 업데이트를 실행하세요.</translation>
+        <translation type="vanished">사용 가능한 시스템이 없습니다. 설정에서 미디어 데이터베이스 업데이트를 실행하세요.</translation>
     </message>
 </context>
 <context>
     <name>IndexSetupModal</name>
     <message>
         <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Start</source>
+        <translation type="unfinished">시작</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Change</source>
+        <translation type="unfinished">변경</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="51"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="47"/>
+        <location filename="../components/IndexSetupModal.qml" line="53"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="115"/>
+        <location filename="../components/IndexSetupModal.qml" line="121"/>
         <source>Update media database</source>
         <translation type="unfinished">미디어 데이터베이스 업데이트</translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="124"/>
+        <location filename="../components/IndexSetupModal.qml" line="130"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="137"/>
+        <location filename="../components/IndexSetupModal.qml" line="143"/>
         <source>Start update</source>
         <translation type="unfinished"></translation>
     </message>
@@ -673,30 +663,28 @@ Français - Wilfried</source>
         <translation type="vanished">코어 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
-        <location filename="../app/Main.qml" line="2330"/>
-        <location filename="../app/Main.qml" line="2393"/>
-        <location filename="../app/Main.qml" line="2699"/>
-        <location filename="../app/Main.qml" line="3741"/>
-        <location filename="../app/Main.qml" line="3784"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
+        <location filename="../app/Main.qml" line="2341"/>
+        <location filename="../app/Main.qml" line="2410"/>
+        <location filename="../app/Main.qml" line="2716"/>
+        <location filename="../app/Main.qml" line="3795"/>
+        <location filename="../app/Main.qml" line="3838"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2183"/>
-        <location filename="../app/Main.qml" line="2218"/>
+        <location filename="../app/Main.qml" line="2185"/>
+        <location filename="../app/Main.qml" line="2220"/>
         <source>Update media database</source>
         <translation type="unfinished">미디어 데이터베이스 업데이트</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2186"/>
-        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
-        <translation type="unfinished">메타데이터 수집</translation>
+        <translation type="obsolete">메타데이터 수집</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2179"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
@@ -706,53 +694,53 @@ Français - Wilfried</source>
         <translation type="unfinished">설정</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2096"/>
+        <location filename="../app/Main.qml" line="2098"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2153"/>
+        <location filename="../app/Main.qml" line="2155"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2179"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
-        <location filename="../app/Main.qml" line="2308"/>
+        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2319"/>
         <source>Launch game</source>
         <translation>게임 실행</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2258"/>
-        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2323"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
-        <location filename="../app/Main.qml" line="2346"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2280"/>
+        <location filename="../app/Main.qml" line="2357"/>
+        <location filename="../app/Main.qml" line="2451"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Remove from favorites</source>
         <translation>즐겨찾기에서 제거</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Add to favorites</source>
         <translation>즐겨찾기에 추가</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2264"/>
-        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2266"/>
+        <location filename="../app/Main.qml" line="2346"/>
         <source>Write to NFC token</source>
         <translation>NFC 토큰에 쓰기</translation>
     </message>
@@ -761,70 +749,95 @@ Français - Wilfried</source>
         <translation type="vanished">QR 코드</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3507"/>
+        <location filename="../app/Main.qml" line="2395"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3561"/>
         <source>Default</source>
         <translation type="unfinished">기본값</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2395"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2230"/>
-        <location filename="../app/Main.qml" line="2238"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="2164"/>
+        <location filename="../app/Main.qml" line="2215"/>
+        <location filename="../app/Main.qml" line="2232"/>
+        <location filename="../app/Main.qml" line="2240"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3454"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3432"/>
+        <location filename="../app/Main.qml" line="3153"/>
+        <source>Get metadata failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3154"/>
+        <source>Could not start getting metadata. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3156"/>
+        <source>Source list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3157"/>
+        <source>Could not load the list of metadata sources. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3307"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3486"/>
         <source>Favorites</source>
         <translation type="unfinished">즐겨찾기</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1070"/>
-        <location filename="../app/Main.qml" line="3417"/>
-        <location filename="../app/Main.qml" line="3464"/>
-        <location filename="../app/Main.qml" line="3474"/>
+        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3518"/>
+        <location filename="../app/Main.qml" line="3528"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3445"/>
+        <location filename="../app/Main.qml" line="3499"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3460"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3511"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3565"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3482"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3515"/>
+        <location filename="../app/Main.qml" line="3569"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3436"/>
+        <location filename="../app/Main.qml" line="3490"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -849,50 +862,51 @@ Français - Wilfried</source>
         <translation type="unfinished">종료</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2173"/>
-        <location filename="../app/Main.qml" line="2282"/>
-        <location filename="../app/Main.qml" line="2301"/>
-        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2284"/>
+        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2361"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2268"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2270"/>
+        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2807"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2461"/>
+        <location filename="../app/Main.qml" line="2478"/>
         <source>Move</source>
         <translation type="unfinished">이동</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2667"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1032"/>
-        <location filename="../app/Main.qml" line="3043"/>
-        <location filename="../app/Main.qml" line="3065"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3131"/>
+        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3174"/>
         <source>OK</source>
         <translation type="unfinished">확인</translation>
     </message>
@@ -907,225 +921,223 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="2188"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2293"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2807"/>
+        <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Scan this code to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3132"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3098"/>
+        <location filename="../app/Main.qml" line="3141"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3099"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3101"/>
+        <location filename="../app/Main.qml" line="3144"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3147"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3105"/>
+        <location filename="../app/Main.qml" line="3148"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3107"/>
+        <location filename="../app/Main.qml" line="3150"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3151"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3110"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3111"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3113"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3114"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3116"/>
+        <location filename="../app/Main.qml" line="3159"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3120"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3122"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3123"/>
+        <location filename="../app/Main.qml" line="3166"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3125"/>
+        <location filename="../app/Main.qml" line="3168"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3126"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3128"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3129"/>
+        <location filename="../app/Main.qml" line="3172"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3253"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3269"/>
+        <location filename="../app/Main.qml" line="3323"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3278"/>
+        <location filename="../app/Main.qml" line="3332"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3307"/>
+        <location filename="../app/Main.qml" line="3361"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3446"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3415"/>
-        <location filename="../app/Main.qml" line="3461"/>
+        <location filename="../app/Main.qml" line="3469"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3449"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3503"/>
+        <location filename="../app/Main.qml" line="3525"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3489"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3485"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3492"/>
+        <location filename="../app/Main.qml" line="3546"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3708"/>
+        <location filename="../app/Main.qml" line="3762"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3119"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
-        <location filename="../app/Main.qml" line="3318"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="2910"/>
+        <location filename="../app/Main.qml" line="3372"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Retry</source>
         <translation type="unfinished">다시 시도</translation>
     </message>
@@ -1134,37 +1146,37 @@ Français - Wilfried</source>
         <translation type="obsolete">취소</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4848"/>
+        <location filename="../app/Main.qml" line="4902"/>
         <source>Loading systems…</source>
         <translation>시스템 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4850"/>
+        <location filename="../app/Main.qml" line="4904"/>
         <source>Loading games…</source>
         <translation>게임 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4852"/>
+        <location filename="../app/Main.qml" line="4906"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4855"/>
+        <location filename="../app/Main.qml" line="4909"/>
         <source>Loading favorites…</source>
         <translation>즐겨찾기 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4857"/>
+        <location filename="../app/Main.qml" line="4911"/>
         <source>Loading recently played…</source>
         <translation>최근 플레이 불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4859"/>
+        <location filename="../app/Main.qml" line="4913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4861"/>
+        <location filename="../app/Main.qml" line="4915"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>
@@ -1172,7 +1184,7 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Writing failed</source>
         <translation>쓰기 실패</translation>
     </message>
@@ -1186,8 +1198,8 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="531"/>
-        <location filename="../app/MainLayout.qml" line="533"/>
+        <location filename="../app/MainLayout.qml" line="537"/>
+        <location filename="../app/MainLayout.qml" line="539"/>
         <source>Favorites</source>
         <translation type="unfinished">즐겨찾기</translation>
     </message>
@@ -1196,128 +1208,130 @@ Français - Wilfried</source>
         <translation type="obsolete">최근 플레이</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="916"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="917"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="936"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="943"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="1365"/>
         <source>OK</source>
         <translation type="unfinished">확인</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="535"/>
+        <location filename="../app/MainLayout.qml" line="541"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Hold a writable token near the reader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1096"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
         <source>Are you sure you want to exit?</source>
         <translation>정말 종료하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1374"/>
-        <location filename="../app/MainLayout.qml" line="1454"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1596"/>
-        <location filename="../app/MainLayout.qml" line="1615"/>
-        <location filename="../app/MainLayout.qml" line="1688"/>
+        <location filename="../app/MainLayout.qml" line="1284"/>
+        <location filename="../app/MainLayout.qml" line="1383"/>
+        <location filename="../app/MainLayout.qml" line="1405"/>
+        <location filename="../app/MainLayout.qml" line="1486"/>
+        <location filename="../app/MainLayout.qml" line="1523"/>
+        <location filename="../app/MainLayout.qml" line="1572"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1647"/>
+        <location filename="../app/MainLayout.qml" line="1720"/>
         <source>Move</source>
         <translation>이동</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1387"/>
+        <location filename="../app/MainLayout.qml" line="1409"/>
         <source>Select</source>
         <translation>선택</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1283"/>
-        <location filename="../app/MainLayout.qml" line="1297"/>
-        <location filename="../app/MainLayout.qml" line="1312"/>
-        <location filename="../app/MainLayout.qml" line="1323"/>
-        <location filename="../app/MainLayout.qml" line="1349"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1321"/>
+        <location filename="../app/MainLayout.qml" line="1332"/>
+        <location filename="../app/MainLayout.qml" line="1358"/>
         <source>Close</source>
         <translation>닫기</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1425"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1339"/>
+        <location filename="../app/MainLayout.qml" line="1391"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1308"/>
+        <location filename="../app/MainLayout.qml" line="1317"/>
         <source>Done</source>
         <translation>완료</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1509"/>
-        <location filename="../app/MainLayout.qml" line="1567"/>
-        <location filename="../app/MainLayout.qml" line="1716"/>
+        <location filename="../app/MainLayout.qml" line="1328"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1541"/>
+        <location filename="../app/MainLayout.qml" line="1599"/>
+        <location filename="../app/MainLayout.qml" line="1748"/>
         <source>Retry</source>
         <translation>다시 시도</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1338"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
         <source>I understand</source>
         <translation>이해했습니다</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1376"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1389"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1417"/>
+        <location filename="../app/MainLayout.qml" line="1449"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1421"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,11 +1340,11 @@ Français - Wilfried</source>
         <translation type="vanished">시작</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1496"/>
-        <location filename="../app/MainLayout.qml" line="1545"/>
-        <location filename="../app/MainLayout.qml" line="1601"/>
-        <location filename="../app/MainLayout.qml" line="1693"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1528"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1633"/>
+        <location filename="../app/MainLayout.qml" line="1725"/>
         <source>Open</source>
         <translation>열기</translation>
     </message>
@@ -1339,28 +1353,29 @@ Français - Wilfried</source>
         <translation type="vanished">종료</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1477"/>
-        <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1513"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1559"/>
-        <location filename="../app/MainLayout.qml" line="1577"/>
-        <location filename="../app/MainLayout.qml" line="1589"/>
-        <location filename="../app/MainLayout.qml" line="1605"/>
-        <location filename="../app/MainLayout.qml" line="1639"/>
-        <location filename="../app/MainLayout.qml" line="1660"/>
-        <location filename="../app/MainLayout.qml" line="1669"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
-        <location filename="../app/MainLayout.qml" line="1728"/>
+        <location filename="../app/MainLayout.qml" line="1413"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1561"/>
+        <location filename="../app/MainLayout.qml" line="1591"/>
+        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1621"/>
+        <location filename="../app/MainLayout.qml" line="1637"/>
+        <location filename="../app/MainLayout.qml" line="1671"/>
+        <location filename="../app/MainLayout.qml" line="1692"/>
+        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1741"/>
+        <location filename="../app/MainLayout.qml" line="1760"/>
         <source>Back</source>
         <translation>뒤로</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1468"/>
-        <location filename="../app/MainLayout.qml" line="1555"/>
-        <location filename="../app/MainLayout.qml" line="1573"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
-        <location filename="../app/MainLayout.qml" line="1724"/>
+        <location filename="../app/MainLayout.qml" line="1500"/>
+        <location filename="../app/MainLayout.qml" line="1587"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1737"/>
+        <location filename="../app/MainLayout.qml" line="1756"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1369,25 +1384,25 @@ Français - Wilfried</source>
         <translation type="vanished">페이지</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1464"/>
-        <location filename="../app/MainLayout.qml" line="1499"/>
-        <location filename="../app/MainLayout.qml" line="1550"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1531"/>
+        <location filename="../app/MainLayout.qml" line="1582"/>
+        <location filename="../app/MainLayout.qml" line="1730"/>
         <source>Options</source>
         <translation>옵션</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1624"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Change</source>
         <translation>변경</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1630"/>
+        <location filename="../app/MainLayout.qml" line="1662"/>
         <source>Toggle</source>
         <translation>전환</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1656"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Scroll</source>
         <translation>스크롤</translation>
     </message>
@@ -1448,12 +1463,12 @@ Français - Wilfried</source>
 <context>
     <name>QrCodeModal</name>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="23"/>
+        <location filename="../components/QrCodeModal.qml" line="19"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="43"/>
+        <location filename="../components/QrCodeModal.qml" line="20"/>
         <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1483,43 +1498,67 @@ Français - Wilfried</source>
 <context>
     <name>ScrapeSetupModal</name>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="67"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Start</source>
+        <translation type="unfinished">시작</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Toggle</source>
+        <translation type="unfinished">전환</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Change</source>
+        <translation type="unfinished">변경</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="89"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="69"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="91"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="171"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="193"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
+        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <source>Loading sources…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <source>Replace existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <source>Start import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scrape metadata</source>
-        <translation type="unfinished">메타데이터 수집</translation>
+        <translation type="obsolete">메타데이터 수집</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="185"/>
-        <source>Loading scrapers…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="196"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
         <source>Systems</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="222"/>
-        <source>Re-scrape existing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
-        <source>Start scrape</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1531,17 +1570,17 @@ Français - Wilfried</source>
         <translation>여기에 아무것도 없습니다</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="36"/>
         <source>Loading…</source>
         <translation>불러오는 중…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="37"/>
         <source>Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="79"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="85"/>
         <source>Failed to load</source>
         <translation>불러오지 못했습니다</translation>
     </message>
@@ -1555,14 +1594,14 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="114"/>
         <location filename="../screens/SettingsScreen.qml" line="205"/>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
-        <location filename="../screens/SettingsScreen.qml" line="972"/>
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="978"/>
         <source>Language</source>
         <translation>언어</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="165"/>
-        <location filename="../screens/SettingsScreen.qml" line="999"/>
+        <location filename="../screens/SettingsScreen.qml" line="1005"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1572,25 +1611,25 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="225"/>
-        <location filename="../screens/SettingsScreen.qml" line="1051"/>
+        <location filename="../screens/SettingsScreen.qml" line="1057"/>
         <source>Button style</source>
         <translation>버튼 스타일</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="1060"/>
+        <location filename="../screens/SettingsScreen.qml" line="1066"/>
         <source>Screensaver</source>
         <translation>화면 보호기</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Library</source>
         <translation>라이브러리</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="291"/>
-        <location filename="../screens/SettingsScreen.qml" line="1069"/>
+        <location filename="../screens/SettingsScreen.qml" line="1075"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1600,9 +1639,8 @@ Français - Wilfried</source>
         <translation>미디어 데이터베이스 업데이트</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Scrape metadata</source>
-        <translation>메타데이터 수집</translation>
+        <translation type="vanished">메타데이터 수집</translation>
     </message>
     <message>
         <source>Advanced</source>
@@ -1614,12 +1652,12 @@ Français - Wilfried</source>
         <translation>마우스 지원</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <location filename="../screens/SettingsScreen.qml" line="323"/>
         <source>Debug logging</source>
         <translation>디버그 로깅</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="323"/>
+        <location filename="../screens/SettingsScreen.qml" line="329"/>
         <source>Upload log file</source>
         <translation>로그 파일 업로드</translation>
     </message>
@@ -1630,7 +1668,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="217"/>
-        <location filename="../screens/SettingsScreen.qml" line="981"/>
+        <location filename="../screens/SettingsScreen.qml" line="987"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1651,7 +1689,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <location filename="../screens/SettingsScreen.qml" line="1078"/>
+        <location filename="../screens/SettingsScreen.qml" line="1084"/>
         <source>Video standard</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1662,7 +1700,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="135"/>
-        <location filename="../screens/SettingsScreen.qml" line="1026"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
         <source>System logos</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1682,35 +1720,34 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Optimizing</source>
         <translation>최적화 중</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>Paused</source>
         <translation>일시중지됨</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>In progress</source>
         <translation>진행 중</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>%1 indexed</source>
         <translation>%1개 인덱싱됨</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>%1 scraped</source>
-        <translation>%1개 수집됨</translation>
+        <translation type="vanished">%1개 수집됨</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Cancel</source>
         <translation>취소</translation>
     </message>
@@ -1719,12 +1756,12 @@ Français - Wilfried</source>
         <translation type="vanished">시작</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Upload</source>
         <translation>업로드</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="650"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Open</source>
         <translation>열기</translation>
     </message>
@@ -1733,92 +1770,92 @@ Français - Wilfried</source>
         <translation type="vanished">기본값</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="758"/>
         <source>English</source>
         <translation>영어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="760"/>
         <source>Italian</source>
         <translation>이탈리아어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="756"/>
+        <location filename="../screens/SettingsScreen.qml" line="762"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="758"/>
+        <location filename="../screens/SettingsScreen.qml" line="764"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="760"/>
+        <location filename="../screens/SettingsScreen.qml" line="766"/>
         <source>German</source>
         <translation>독일어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="762"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Greek</source>
         <translation>그리스어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="764"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Japanese</source>
         <translation>일본어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="766"/>
+        <location filename="../screens/SettingsScreen.qml" line="772"/>
         <source>Korean</source>
         <translation>한국어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Dutch</source>
         <translation>네덜란드어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="776"/>
         <source>Romanian</source>
         <translation>루마니아어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="778"/>
         <source>Slovak</source>
         <translation>슬로바키아어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="774"/>
+        <location filename="../screens/SettingsScreen.qml" line="780"/>
         <source>Ukrainian</source>
         <translation>우크라이나어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="776"/>
+        <location filename="../screens/SettingsScreen.qml" line="782"/>
         <source>Chinese (Simplified)</source>
         <translation>중국어(간체)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="778"/>
+        <location filename="../screens/SettingsScreen.qml" line="784"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="780"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Hebrew</source>
         <translation>히브리어</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="782"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="784"/>
+        <location filename="../screens/SettingsScreen.qml" line="790"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>French</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1827,127 +1864,127 @@ Français - Wilfried</source>
         <translation type="vanished">자동</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="792"/>
+        <location filename="../screens/SettingsScreen.qml" line="798"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="794"/>
+        <location filename="../screens/SettingsScreen.qml" line="800"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="805"/>
+        <location filename="../screens/SettingsScreen.qml" line="811"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="807"/>
+        <location filename="../screens/SettingsScreen.qml" line="813"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="809"/>
+        <location filename="../screens/SettingsScreen.qml" line="815"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
-        <location filename="../screens/SettingsScreen.qml" line="787"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
-        <location filename="../screens/SettingsScreen.qml" line="810"/>
-        <location filename="../screens/SettingsScreen.qml" line="877"/>
-        <location filename="../screens/SettingsScreen.qml" line="925"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="793"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
+        <location filename="../screens/SettingsScreen.qml" line="816"/>
+        <location filename="../screens/SettingsScreen.qml" line="883"/>
+        <location filename="../screens/SettingsScreen.qml" line="931"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="158"/>
-        <location filename="../screens/SettingsScreen.qml" line="963"/>
+        <location filename="../screens/SettingsScreen.qml" line="969"/>
         <source>Interface resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="129"/>
-        <location filename="../screens/SettingsScreen.qml" line="1035"/>
+        <location filename="../screens/SettingsScreen.qml" line="1041"/>
         <source>Color scheme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>%1 × %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Automatic (Recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="717"/>
         <source>%1 (Animations off)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="815"/>
+        <location filename="../screens/SettingsScreen.qml" line="821"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="817"/>
+        <location filename="../screens/SettingsScreen.qml" line="823"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="818"/>
+        <location filename="../screens/SettingsScreen.qml" line="824"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="823"/>
+        <location filename="../screens/SettingsScreen.qml" line="829"/>
         <source>Detailed list view</source>
         <translation>자세한 목록 보기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="824"/>
+        <location filename="../screens/SettingsScreen.qml" line="830"/>
         <source>Grid view</source>
         <translation>그리드 보기</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="829"/>
+        <location filename="../screens/SettingsScreen.qml" line="835"/>
         <source>Full color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="830"/>
+        <location filename="../screens/SettingsScreen.qml" line="836"/>
         <source>Tinted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="855"/>
+        <location filename="../screens/SettingsScreen.qml" line="861"/>
         <source>Nord</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="852"/>
+        <location filename="../screens/SettingsScreen.qml" line="858"/>
         <source>Dracula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="90"/>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="120"/>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="211"/>
-        <location filename="../screens/SettingsScreen.qml" line="990"/>
+        <location filename="../screens/SettingsScreen.qml" line="996"/>
         <source>Region</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1957,72 +1994,72 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="859"/>
+        <location filename="../screens/SettingsScreen.qml" line="865"/>
         <source>Synthwave &apos;84</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="846"/>
+        <location filename="../screens/SettingsScreen.qml" line="852"/>
         <source>Amber Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="848"/>
+        <location filename="../screens/SettingsScreen.qml" line="854"/>
         <source>Green Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="849"/>
+        <location filename="../screens/SettingsScreen.qml" line="855"/>
         <source>Neo Geo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="850"/>
+        <location filename="../screens/SettingsScreen.qml" line="856"/>
         <source>NES</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="851"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>Virtual Boy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="854"/>
+        <location filename="../screens/SettingsScreen.qml" line="860"/>
         <source>Gruvbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="853"/>
+        <location filename="../screens/SettingsScreen.qml" line="859"/>
         <source>Everforest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="858"/>
+        <location filename="../screens/SettingsScreen.qml" line="864"/>
         <source>Solarized Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="863"/>
         <source>Rosé Pine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="856"/>
+        <location filename="../screens/SettingsScreen.qml" line="862"/>
         <source>Oxocarbon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="860"/>
+        <location filename="../screens/SettingsScreen.qml" line="866"/>
         <source>Flexoki Paper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="861"/>
+        <location filename="../screens/SettingsScreen.qml" line="867"/>
         <source>Solarized Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="847"/>
+        <location filename="../screens/SettingsScreen.qml" line="853"/>
         <source>Game Boy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2077,19 +2114,14 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Downloads box art, descriptions, and tags for your games. Choose a source and which systems.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
-        <location filename="../screens/SettingsScreen.qml" line="1008"/>
+        <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="285"/>
-        <location filename="../screens/SettingsScreen.qml" line="1017"/>
+        <location filename="../screens/SettingsScreen.qml" line="1023"/>
         <source>Games layout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2104,103 +2136,103 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <location filename="../screens/SettingsScreen.qml" line="324"/>
         <source>Writes extra detail to the log file to help track down a problem. Restarts the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Configure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="868"/>
+        <location filename="../screens/SettingsScreen.qml" line="874"/>
         <source>Style B</source>
         <translation>스타일 B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="870"/>
+        <location filename="../screens/SettingsScreen.qml" line="876"/>
         <source>Style C</source>
         <translation>스타일 C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="872"/>
+        <location filename="../screens/SettingsScreen.qml" line="878"/>
         <source>Style D</source>
         <translation>스타일 D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="874"/>
+        <location filename="../screens/SettingsScreen.qml" line="880"/>
         <source>Style E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="876"/>
+        <location filename="../screens/SettingsScreen.qml" line="882"/>
         <source>Style A</source>
         <translation>스타일 A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="892"/>
+        <location filename="../screens/SettingsScreen.qml" line="898"/>
         <source>Off</source>
         <translation>끔</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="894"/>
+        <location filename="../screens/SettingsScreen.qml" line="900"/>
         <source>1 second (testing)</source>
         <translation>1초 (테스트용)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="896"/>
+        <location filename="../screens/SettingsScreen.qml" line="902"/>
         <source>1 minute</source>
         <translation>1분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="898"/>
+        <location filename="../screens/SettingsScreen.qml" line="904"/>
         <source>2 minutes</source>
         <translation>2분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="900"/>
+        <location filename="../screens/SettingsScreen.qml" line="906"/>
         <source>5 minutes</source>
         <translation>5분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="902"/>
+        <location filename="../screens/SettingsScreen.qml" line="908"/>
         <source>10 minutes</source>
         <translation>10분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="904"/>
+        <location filename="../screens/SettingsScreen.qml" line="910"/>
         <source>15 minutes</source>
         <translation>15분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="906"/>
+        <location filename="../screens/SettingsScreen.qml" line="912"/>
         <source>30 minutes</source>
         <translation>30분</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="907"/>
+        <location filename="../screens/SettingsScreen.qml" line="913"/>
         <source>%1 seconds</source>
         <translation>%1초</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="917"/>
+        <location filename="../screens/SettingsScreen.qml" line="923"/>
         <source>PAL (50 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="919"/>
+        <location filename="../screens/SettingsScreen.qml" line="925"/>
         <source>480i (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="920"/>
+        <location filename="../screens/SettingsScreen.qml" line="926"/>
         <source>NTSC (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1905"/>
+        <location filename="../screens/SettingsScreen.qml" line="1911"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2210,13 +2242,13 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="108"/>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2266,6 +2298,16 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="269"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="280"/>
         <source>Show systems as a grid of covers, or as a list with details beside it.</source>
         <translation type="unfinished"></translation>
@@ -2286,92 +2328,107 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="324"/>
+        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <source>Shows a code you can scan to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="330"/>
         <source>Uploads the log file and gives you a link to share when reporting a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="843"/>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <source>%1 imported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="849"/>
         <source>Zaparoo Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="844"/>
+        <location filename="../screens/SettingsScreen.qml" line="850"/>
         <source>Zaparoo Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="845"/>
+        <location filename="../screens/SettingsScreen.qml" line="851"/>
         <source>Classic Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="927"/>
+        <location filename="../screens/SettingsScreen.qml" line="933"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="929"/>
+        <location filename="../screens/SettingsScreen.qml" line="935"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="931"/>
+        <location filename="../screens/SettingsScreen.qml" line="937"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="933"/>
+        <location filename="../screens/SettingsScreen.qml" line="939"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="935"/>
+        <location filename="../screens/SettingsScreen.qml" line="941"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="937"/>
+        <location filename="../screens/SettingsScreen.qml" line="943"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="939"/>
+        <location filename="../screens/SettingsScreen.qml" line="945"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="941"/>
+        <location filename="../screens/SettingsScreen.qml" line="947"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="943"/>
+        <location filename="../screens/SettingsScreen.qml" line="949"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="945"/>
+        <location filename="../screens/SettingsScreen.qml" line="951"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="947"/>
+        <location filename="../screens/SettingsScreen.qml" line="953"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="949"/>
+        <location filename="../screens/SettingsScreen.qml" line="955"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="355"/>
+        <location filename="../screens/SettingsScreen.qml" line="361"/>
         <source>Settings</source>
         <translation>설정</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1887"/>
+        <location filename="../screens/SettingsScreen.qml" line="1893"/>
         <source>No settings available on this platform</source>
         <translation>이 플랫폼에서는 설정을 사용할 수 없습니다</translation>
     </message>
@@ -2410,9 +2467,33 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/StatusLine.qml" line="105"/>
+        <source>Importing paused: game running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Import failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Imported %1 of %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scraping…</source>
-        <translation type="unfinished">메타데이터 수집 중…</translation>
+        <translation type="obsolete">메타데이터 수집 중…</translation>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
@@ -2441,16 +2522,6 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="105"/>
-        <source>Scraping paused: game running</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="106"/>
-        <source>Scraping: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>%1 files</source>
         <translation type="obsolete">파일 %1개</translation>
     </message>
@@ -2466,16 +2537,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scraped %1 of %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -35,8 +35,8 @@
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="212"/>
-        <source>Commercial licensing: legal@zaparoo.org</source>
-        <translation>Commerciële licenties: legal@zaparoo.org</translation>
+        <source>Commercial licensing: legal@zaparoo.com</source>
+        <translation>Commerciële licenties: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="223"/>
@@ -227,8 +227,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="116"/>
-        <source>Contact: legal@zaparoo.org</source>
-        <translation>Neem contact op: legal@zaparoo.org</translation>
+        <source>Contact: legal@zaparoo.com</source>
+        <translation>Neem contact op: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="127"/>
@@ -1530,27 +1530,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
-        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <source>Documentation: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="225"/>
         <source>Loading sources…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="262"/>
         <source>Replace existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="276"/>
         <source>Start import</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1559,7 +1559,7 @@ Français - Wilfried</source>
         <translation type="obsolete">Metadata ophalen</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="249"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -389,45 +389,6 @@ Français - Wilfried</source>
     </message>
 </context>
 <context>
-    <name>FirstRunIndexModal</name>
-    <message>
-        <source>First-time setup</source>
-        <translation type="vanished">Eerste installatie</translation>
-    </message>
-    <message>
-        <source>Indexing paused</source>
-        <translation type="vanished">Indexering gepauzeerd</translation>
-    </message>
-    <message>
-        <source>Optimizing database - almost done</source>
-        <translation type="vanished">Database optimaliseren – bijna klaar</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2 - %3</source>
-        <translation type="vanished">Stap %1 van %2 – %3</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2</source>
-        <translation type="vanished">Stap %1 van %2</translation>
-    </message>
-    <message>
-        <source>Preparing…</source>
-        <translation type="vanished">Voorbereiden…</translation>
-    </message>
-    <message>
-        <source>Done. %1 files indexed.</source>
-        <translation type="vanished">Klaar. %1 bestanden geïndexeerd.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Annuleren</translation>
-    </message>
-    <message>
-        <source>Start scan</source>
-        <translation type="vanished">Scan starten</translation>
-    </message>
-</context>
-<context>
     <name>GameInfoModal</name>
     <message>
         <location filename="../components/GameInfoModal.qml" line="153"/>
@@ -540,6 +501,26 @@ Français - Wilfried</source>
         <translation>Favorieten</translation>
     </message>
     <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>Updating the media database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>No games found yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Your games appear here as Core finds them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Update media database in Settings &gt; Library.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Recently Played</source>
         <translation type="vanished">Recent gespeeld</translation>
     </message>
@@ -569,35 +550,44 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
-        <translation>Geen systemen beschikbaar. Voer Database bijwerken uit via Instellingen.</translation>
+        <translation type="vanished">Geen systemen beschikbaar. Voer Database bijwerken uit via Instellingen.</translation>
     </message>
 </context>
 <context>
     <name>IndexSetupModal</name>
     <message>
         <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Start</source>
+        <translation type="unfinished">Starten</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Change</source>
+        <translation type="unfinished">Wijzigen</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="51"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="47"/>
+        <location filename="../components/IndexSetupModal.qml" line="53"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="115"/>
+        <location filename="../components/IndexSetupModal.qml" line="121"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediadatabase bijwerken</translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="124"/>
+        <location filename="../components/IndexSetupModal.qml" line="130"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="137"/>
+        <location filename="../components/IndexSetupModal.qml" line="143"/>
         <source>Start update</source>
         <translation type="unfinished"></translation>
     </message>
@@ -675,29 +665,29 @@ Français - Wilfried</source>
         <translation type="vanished">Core starten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
-        <location filename="../app/Main.qml" line="2330"/>
-        <location filename="../app/Main.qml" line="2393"/>
-        <location filename="../app/Main.qml" line="2699"/>
-        <location filename="../app/Main.qml" line="3741"/>
-        <location filename="../app/Main.qml" line="3784"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
+        <location filename="../app/Main.qml" line="2341"/>
+        <location filename="../app/Main.qml" line="2410"/>
+        <location filename="../app/Main.qml" line="2716"/>
+        <location filename="../app/Main.qml" line="3795"/>
+        <location filename="../app/Main.qml" line="3838"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Remove from favorites</source>
         <translation>Uit favorieten verwijderen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Add to favorites</source>
         <translation>Aan favorieten toevoegen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2264"/>
-        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2266"/>
+        <location filename="../app/Main.qml" line="2346"/>
         <source>Write to NFC token</source>
         <translation>Naar NFC-token schrijven</translation>
     </message>
@@ -706,53 +696,76 @@ Français - Wilfried</source>
         <translation type="vanished">QR-code</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
-        <location filename="../app/Main.qml" line="2308"/>
+        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2319"/>
         <source>Launch game</source>
         <translation>Game starten</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1070"/>
-        <location filename="../app/Main.qml" line="3417"/>
-        <location filename="../app/Main.qml" line="3464"/>
-        <location filename="../app/Main.qml" line="3474"/>
+        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3518"/>
+        <location filename="../app/Main.qml" line="3528"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3153"/>
+        <source>Get metadata failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3154"/>
+        <source>Could not start getting metadata. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3156"/>
+        <source>Source list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3157"/>
+        <source>Could not load the list of metadata sources. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3307"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4848"/>
+        <location filename="../app/Main.qml" line="4902"/>
         <source>Loading systems…</source>
         <translation>Systemen laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4855"/>
+        <location filename="../app/Main.qml" line="4909"/>
         <source>Loading favorites…</source>
         <translation>Favorieten laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4850"/>
+        <location filename="../app/Main.qml" line="4904"/>
         <source>Loading games…</source>
         <translation>Games laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2183"/>
-        <location filename="../app/Main.qml" line="2218"/>
+        <location filename="../app/Main.qml" line="2185"/>
+        <location filename="../app/Main.qml" line="2220"/>
         <source>Update media database</source>
         <translation type="unfinished">Mediadatabase bijwerken</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2186"/>
-        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
-        <translation type="unfinished">Metadata ophalen</translation>
+        <translation type="obsolete">Metadata ophalen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2179"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
@@ -762,90 +775,90 @@ Français - Wilfried</source>
         <translation type="unfinished">Instellingen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2096"/>
+        <location filename="../app/Main.qml" line="2098"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2153"/>
+        <location filename="../app/Main.qml" line="2155"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2179"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2258"/>
-        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2323"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
-        <location filename="../app/Main.qml" line="2346"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2280"/>
+        <location filename="../app/Main.qml" line="2357"/>
+        <location filename="../app/Main.qml" line="2451"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3507"/>
+        <location filename="../app/Main.qml" line="2395"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3561"/>
         <source>Default</source>
         <translation type="unfinished">Standaard</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2395"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2230"/>
-        <location filename="../app/Main.qml" line="2238"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="2164"/>
+        <location filename="../app/Main.qml" line="2215"/>
+        <location filename="../app/Main.qml" line="2232"/>
+        <location filename="../app/Main.qml" line="2240"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3454"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3445"/>
+        <location filename="../app/Main.qml" line="3499"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3460"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3511"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3565"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3482"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3515"/>
+        <location filename="../app/Main.qml" line="3569"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3436"/>
+        <location filename="../app/Main.qml" line="3490"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -870,45 +883,46 @@ Français - Wilfried</source>
         <translation type="unfinished">Afsluiten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2173"/>
-        <location filename="../app/Main.qml" line="2282"/>
-        <location filename="../app/Main.qml" line="2301"/>
-        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2284"/>
+        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2361"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2268"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2270"/>
+        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2807"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2461"/>
+        <location filename="../app/Main.qml" line="2478"/>
         <source>Move</source>
         <translation type="unfinished">Bewegen</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2667"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1032"/>
-        <location filename="../app/Main.qml" line="3043"/>
-        <location filename="../app/Main.qml" line="3065"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3131"/>
+        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3174"/>
         <source>OK</source>
         <translation type="unfinished">Akkoord</translation>
     </message>
@@ -923,226 +937,224 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="2188"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2293"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2807"/>
+        <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Scan this code to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3132"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3098"/>
+        <location filename="../app/Main.qml" line="3141"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3099"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3101"/>
+        <location filename="../app/Main.qml" line="3144"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3147"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3105"/>
+        <location filename="../app/Main.qml" line="3148"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3107"/>
+        <location filename="../app/Main.qml" line="3150"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3151"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3110"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3111"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3113"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3114"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3116"/>
+        <location filename="../app/Main.qml" line="3159"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3120"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3122"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3123"/>
+        <location filename="../app/Main.qml" line="3166"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3125"/>
+        <location filename="../app/Main.qml" line="3168"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3126"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3128"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3129"/>
+        <location filename="../app/Main.qml" line="3172"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3253"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3269"/>
+        <location filename="../app/Main.qml" line="3323"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3278"/>
+        <location filename="../app/Main.qml" line="3332"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3307"/>
+        <location filename="../app/Main.qml" line="3361"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3446"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3432"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3486"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorieten</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3415"/>
-        <location filename="../app/Main.qml" line="3461"/>
+        <location filename="../app/Main.qml" line="3469"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3449"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3503"/>
+        <location filename="../app/Main.qml" line="3525"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3489"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3485"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3492"/>
+        <location filename="../app/Main.qml" line="3546"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3708"/>
+        <location filename="../app/Main.qml" line="3762"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3119"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
-        <location filename="../app/Main.qml" line="3318"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="2910"/>
+        <location filename="../app/Main.qml" line="3372"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Retry</source>
         <translation type="unfinished">Opnieuw proberen</translation>
     </message>
@@ -1151,22 +1163,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4852"/>
+        <location filename="../app/Main.qml" line="4906"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4857"/>
+        <location filename="../app/Main.qml" line="4911"/>
         <source>Loading recently played…</source>
         <translation>Recent gespeeld laden…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4859"/>
+        <location filename="../app/Main.qml" line="4913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4861"/>
+        <location filename="../app/Main.qml" line="4915"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>
@@ -1174,7 +1186,7 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Writing failed</source>
         <translation>Schrijven mislukt</translation>
     </message>
@@ -1183,82 +1195,83 @@ Français - Wilfried</source>
         <translation type="vanished">Houd een beschrijfbare kaart bij de lezer</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="936"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="943"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="1365"/>
         <source>OK</source>
         <translation type="unfinished">Akkoord</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="535"/>
+        <location filename="../app/MainLayout.qml" line="541"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Hold a writable token near the reader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
         <source>Are you sure you want to exit?</source>
         <translation>Weet u zeker dat u wilt afsluiten?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1387"/>
+        <location filename="../app/MainLayout.qml" line="1409"/>
         <source>Select</source>
         <translation>Selecteren</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1283"/>
-        <location filename="../app/MainLayout.qml" line="1297"/>
-        <location filename="../app/MainLayout.qml" line="1312"/>
-        <location filename="../app/MainLayout.qml" line="1323"/>
-        <location filename="../app/MainLayout.qml" line="1349"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1321"/>
+        <location filename="../app/MainLayout.qml" line="1332"/>
+        <location filename="../app/MainLayout.qml" line="1358"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1425"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1339"/>
+        <location filename="../app/MainLayout.qml" line="1391"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1308"/>
+        <location filename="../app/MainLayout.qml" line="1317"/>
         <source>Done</source>
         <translation>Klaar</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1338"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
         <source>I understand</source>
         <translation>Ik begrijp het</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1376"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1389"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1267,28 +1280,29 @@ Français - Wilfried</source>
         <translation type="vanished">Starten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1656"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Scroll</source>
         <translation>Scrollen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1468"/>
-        <location filename="../app/MainLayout.qml" line="1555"/>
-        <location filename="../app/MainLayout.qml" line="1573"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
-        <location filename="../app/MainLayout.qml" line="1724"/>
+        <location filename="../app/MainLayout.qml" line="1500"/>
+        <location filename="../app/MainLayout.qml" line="1587"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1737"/>
+        <location filename="../app/MainLayout.qml" line="1756"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1374"/>
-        <location filename="../app/MainLayout.qml" line="1454"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1596"/>
-        <location filename="../app/MainLayout.qml" line="1615"/>
-        <location filename="../app/MainLayout.qml" line="1688"/>
+        <location filename="../app/MainLayout.qml" line="1284"/>
+        <location filename="../app/MainLayout.qml" line="1383"/>
+        <location filename="../app/MainLayout.qml" line="1405"/>
+        <location filename="../app/MainLayout.qml" line="1486"/>
+        <location filename="../app/MainLayout.qml" line="1523"/>
+        <location filename="../app/MainLayout.qml" line="1572"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1647"/>
+        <location filename="../app/MainLayout.qml" line="1720"/>
         <source>Move</source>
         <translation>Bewegen</translation>
     </message>
@@ -1298,8 +1312,8 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="531"/>
-        <location filename="../app/MainLayout.qml" line="533"/>
+        <location filename="../app/MainLayout.qml" line="537"/>
+        <location filename="../app/MainLayout.qml" line="539"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorieten</translation>
     </message>
@@ -1308,36 +1322,36 @@ Français - Wilfried</source>
         <translation type="obsolete">Recent gespeeld</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="916"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="917"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1096"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1417"/>
+        <location filename="../app/MainLayout.qml" line="1449"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1421"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1496"/>
-        <location filename="../app/MainLayout.qml" line="1545"/>
-        <location filename="../app/MainLayout.qml" line="1601"/>
-        <location filename="../app/MainLayout.qml" line="1693"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1528"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1633"/>
+        <location filename="../app/MainLayout.qml" line="1725"/>
         <source>Open</source>
         <translation>Openen</translation>
     </message>
@@ -1346,19 +1360,20 @@ Français - Wilfried</source>
         <translation type="vanished">Afsluiten</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1477"/>
-        <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1513"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1559"/>
-        <location filename="../app/MainLayout.qml" line="1577"/>
-        <location filename="../app/MainLayout.qml" line="1589"/>
-        <location filename="../app/MainLayout.qml" line="1605"/>
-        <location filename="../app/MainLayout.qml" line="1639"/>
-        <location filename="../app/MainLayout.qml" line="1660"/>
-        <location filename="../app/MainLayout.qml" line="1669"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
-        <location filename="../app/MainLayout.qml" line="1728"/>
+        <location filename="../app/MainLayout.qml" line="1413"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1561"/>
+        <location filename="../app/MainLayout.qml" line="1591"/>
+        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1621"/>
+        <location filename="../app/MainLayout.qml" line="1637"/>
+        <location filename="../app/MainLayout.qml" line="1671"/>
+        <location filename="../app/MainLayout.qml" line="1692"/>
+        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1741"/>
+        <location filename="../app/MainLayout.qml" line="1760"/>
         <source>Back</source>
         <translation>Terug</translation>
     </message>
@@ -1367,29 +1382,29 @@ Français - Wilfried</source>
         <translation type="vanished">Pagina</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1464"/>
-        <location filename="../app/MainLayout.qml" line="1499"/>
-        <location filename="../app/MainLayout.qml" line="1550"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1531"/>
+        <location filename="../app/MainLayout.qml" line="1582"/>
+        <location filename="../app/MainLayout.qml" line="1730"/>
         <source>Options</source>
         <translation>Opties</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1509"/>
-        <location filename="../app/MainLayout.qml" line="1567"/>
-        <location filename="../app/MainLayout.qml" line="1716"/>
+        <location filename="../app/MainLayout.qml" line="1328"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1541"/>
+        <location filename="../app/MainLayout.qml" line="1599"/>
+        <location filename="../app/MainLayout.qml" line="1748"/>
         <source>Retry</source>
         <translation>Opnieuw proberen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1624"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Change</source>
         <translation>Wijzigen</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1630"/>
+        <location filename="../app/MainLayout.qml" line="1662"/>
         <source>Toggle</source>
         <translation>Schakelen</translation>
     </message>
@@ -1450,12 +1465,12 @@ Français - Wilfried</source>
 <context>
     <name>QrCodeModal</name>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="23"/>
+        <location filename="../components/QrCodeModal.qml" line="19"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="43"/>
+        <location filename="../components/QrCodeModal.qml" line="20"/>
         <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1485,43 +1500,67 @@ Français - Wilfried</source>
 <context>
     <name>ScrapeSetupModal</name>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="67"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Start</source>
+        <translation type="unfinished">Starten</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Toggle</source>
+        <translation type="unfinished">Schakelen</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Change</source>
+        <translation type="unfinished">Wijzigen</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="89"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="69"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="91"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="171"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="193"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
+        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <source>Loading sources…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <source>Replace existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <source>Start import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scrape metadata</source>
-        <translation type="unfinished">Metadata ophalen</translation>
+        <translation type="obsolete">Metadata ophalen</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="185"/>
-        <source>Loading scrapers…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="196"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
         <source>Systems</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="222"/>
-        <source>Re-scrape existing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
-        <source>Start scrape</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1533,17 +1572,17 @@ Français - Wilfried</source>
         <translation>Niets hier</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="36"/>
         <source>Loading…</source>
         <translation>Laden…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="37"/>
         <source>Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="79"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="85"/>
         <source>Failed to load</source>
         <translation>Laden mislukt</translation>
     </message>
@@ -1553,8 +1592,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="114"/>
         <location filename="../screens/SettingsScreen.qml" line="205"/>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
-        <location filename="../screens/SettingsScreen.qml" line="972"/>
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="978"/>
         <source>Language</source>
         <translation>Taal</translation>
     </message>
@@ -1578,50 +1617,49 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="165"/>
-        <location filename="../screens/SettingsScreen.qml" line="999"/>
+        <location filename="../screens/SettingsScreen.qml" line="1005"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="225"/>
-        <location filename="../screens/SettingsScreen.qml" line="1051"/>
+        <location filename="../screens/SettingsScreen.qml" line="1057"/>
         <source>Button style</source>
         <translation>Knopstijl</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="1060"/>
+        <location filename="../screens/SettingsScreen.qml" line="1066"/>
         <source>Screensaver</source>
         <translation>Schermbeveiliging</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Library</source>
         <translation>Bibliotheek</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="291"/>
-        <location filename="../screens/SettingsScreen.qml" line="1069"/>
+        <location filename="../screens/SettingsScreen.qml" line="1075"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Scrape metadata</source>
-        <translation>Metadata ophalen</translation>
+        <translation type="vanished">Metadata ophalen</translation>
     </message>
     <message>
         <source>Advanced</source>
         <translation type="vanished">Geavanceerd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <location filename="../screens/SettingsScreen.qml" line="323"/>
         <source>Debug logging</source>
         <translation>Debug-logging</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="323"/>
+        <location filename="../screens/SettingsScreen.qml" line="329"/>
         <source>Upload log file</source>
         <translation>Logbestand uploaden</translation>
     </message>
@@ -1632,7 +1670,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="217"/>
-        <location filename="../screens/SettingsScreen.qml" line="981"/>
+        <location filename="../screens/SettingsScreen.qml" line="987"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1643,13 +1681,13 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="158"/>
-        <location filename="../screens/SettingsScreen.qml" line="963"/>
+        <location filename="../screens/SettingsScreen.qml" line="969"/>
         <source>Interface resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="129"/>
-        <location filename="../screens/SettingsScreen.qml" line="1035"/>
+        <location filename="../screens/SettingsScreen.qml" line="1041"/>
         <source>Color scheme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1665,7 +1703,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <location filename="../screens/SettingsScreen.qml" line="1078"/>
+        <location filename="../screens/SettingsScreen.qml" line="1084"/>
         <source>Video standard</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1676,7 +1714,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="135"/>
-        <location filename="../screens/SettingsScreen.qml" line="1026"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
         <source>System logos</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1697,19 +1735,19 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="90"/>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="120"/>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="211"/>
-        <location filename="../screens/SettingsScreen.qml" line="990"/>
+        <location filename="../screens/SettingsScreen.qml" line="996"/>
         <source>Region</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1719,35 +1757,34 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Optimizing</source>
         <translation>Optimaliseren</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>Paused</source>
         <translation>Gepauzeerd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>In progress</source>
         <translation>Bezig</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>%1 indexed</source>
         <translation>%1 geïndexeerd</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>%1 scraped</source>
-        <translation>%1 opgehaald</translation>
+        <translation type="vanished">%1 opgehaald</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
@@ -1756,117 +1793,117 @@ Français - Wilfried</source>
         <translation type="vanished">Starten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Upload</source>
         <translation>Uploaden</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="650"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Open</source>
         <translation>Openen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>%1 × %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Automatic (Recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="717"/>
         <source>%1 (Animations off)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="758"/>
         <source>English</source>
         <translation>Engels</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="760"/>
         <source>Italian</source>
         <translation>Italiaans</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="756"/>
+        <location filename="../screens/SettingsScreen.qml" line="762"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="758"/>
+        <location filename="../screens/SettingsScreen.qml" line="764"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="760"/>
+        <location filename="../screens/SettingsScreen.qml" line="766"/>
         <source>German</source>
         <translation>Duits</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="762"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Greek</source>
         <translation>Grieks</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="764"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Japanese</source>
         <translation>Japans</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="766"/>
+        <location filename="../screens/SettingsScreen.qml" line="772"/>
         <source>Korean</source>
         <translation>Koreaans</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Dutch</source>
         <translation>Nederlands</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="776"/>
         <source>Romanian</source>
         <translation>Roemeens</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="778"/>
         <source>Slovak</source>
         <translation>Slowaaks</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="774"/>
+        <location filename="../screens/SettingsScreen.qml" line="780"/>
         <source>Ukrainian</source>
         <translation>Oekraïens</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="776"/>
+        <location filename="../screens/SettingsScreen.qml" line="782"/>
         <source>Chinese (Simplified)</source>
         <translation>Chinees (vereenvoudigd)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="778"/>
+        <location filename="../screens/SettingsScreen.qml" line="784"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="780"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Hebrew</source>
         <translation>Hebreeuws</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="782"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="784"/>
+        <location filename="../screens/SettingsScreen.qml" line="790"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>French</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1875,37 +1912,37 @@ Français - Wilfried</source>
         <translation type="vanished">Automatisch</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="792"/>
+        <location filename="../screens/SettingsScreen.qml" line="798"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="794"/>
+        <location filename="../screens/SettingsScreen.qml" line="800"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="805"/>
+        <location filename="../screens/SettingsScreen.qml" line="811"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="807"/>
+        <location filename="../screens/SettingsScreen.qml" line="813"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="809"/>
+        <location filename="../screens/SettingsScreen.qml" line="815"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
-        <location filename="../screens/SettingsScreen.qml" line="787"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
-        <location filename="../screens/SettingsScreen.qml" line="810"/>
-        <location filename="../screens/SettingsScreen.qml" line="877"/>
-        <location filename="../screens/SettingsScreen.qml" line="925"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="793"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
+        <location filename="../screens/SettingsScreen.qml" line="816"/>
+        <location filename="../screens/SettingsScreen.qml" line="883"/>
+        <location filename="../screens/SettingsScreen.qml" line="931"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1960,19 +1997,14 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Downloads box art, descriptions, and tags for your games. Choose a source and which systems.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
-        <location filename="../screens/SettingsScreen.qml" line="1008"/>
+        <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="285"/>
-        <location filename="../screens/SettingsScreen.qml" line="1017"/>
+        <location filename="../screens/SettingsScreen.qml" line="1023"/>
         <source>Games layout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1987,93 +2019,93 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <location filename="../screens/SettingsScreen.qml" line="324"/>
         <source>Writes extra detail to the log file to help track down a problem. Restarts the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Configure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="815"/>
+        <location filename="../screens/SettingsScreen.qml" line="821"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="817"/>
+        <location filename="../screens/SettingsScreen.qml" line="823"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="818"/>
+        <location filename="../screens/SettingsScreen.qml" line="824"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="823"/>
+        <location filename="../screens/SettingsScreen.qml" line="829"/>
         <source>Detailed list view</source>
         <translation>Gedetailleerde lijstweergave</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="824"/>
+        <location filename="../screens/SettingsScreen.qml" line="830"/>
         <source>Grid view</source>
         <translation>Rasterweergave</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="829"/>
+        <location filename="../screens/SettingsScreen.qml" line="835"/>
         <source>Full color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="830"/>
+        <location filename="../screens/SettingsScreen.qml" line="836"/>
         <source>Tinted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="868"/>
+        <location filename="../screens/SettingsScreen.qml" line="874"/>
         <source>Style B</source>
         <translation>Stijl B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="870"/>
+        <location filename="../screens/SettingsScreen.qml" line="876"/>
         <source>Style C</source>
         <translation>Stijl C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="872"/>
+        <location filename="../screens/SettingsScreen.qml" line="878"/>
         <source>Style D</source>
         <translation>Stijl D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="874"/>
+        <location filename="../screens/SettingsScreen.qml" line="880"/>
         <source>Style E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="876"/>
+        <location filename="../screens/SettingsScreen.qml" line="882"/>
         <source>Style A</source>
         <translation>Stijl A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="917"/>
+        <location filename="../screens/SettingsScreen.qml" line="923"/>
         <source>PAL (50 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="919"/>
+        <location filename="../screens/SettingsScreen.qml" line="925"/>
         <source>480i (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="920"/>
+        <location filename="../screens/SettingsScreen.qml" line="926"/>
         <source>NTSC (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1905"/>
+        <location filename="../screens/SettingsScreen.qml" line="1911"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2082,47 +2114,47 @@ Français - Wilfried</source>
         <translation type="vanished">Standaard</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="892"/>
+        <location filename="../screens/SettingsScreen.qml" line="898"/>
         <source>Off</source>
         <translation>Uit</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="894"/>
+        <location filename="../screens/SettingsScreen.qml" line="900"/>
         <source>1 second (testing)</source>
         <translation>1 seconde (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="896"/>
+        <location filename="../screens/SettingsScreen.qml" line="902"/>
         <source>1 minute</source>
         <translation>1 minuut</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="898"/>
+        <location filename="../screens/SettingsScreen.qml" line="904"/>
         <source>2 minutes</source>
         <translation>2 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="900"/>
+        <location filename="../screens/SettingsScreen.qml" line="906"/>
         <source>5 minutes</source>
         <translation>5 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="902"/>
+        <location filename="../screens/SettingsScreen.qml" line="908"/>
         <source>10 minutes</source>
         <translation>10 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="904"/>
+        <location filename="../screens/SettingsScreen.qml" line="910"/>
         <source>15 minutes</source>
         <translation>15 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="906"/>
+        <location filename="../screens/SettingsScreen.qml" line="912"/>
         <source>30 minutes</source>
         <translation>30 minuten</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="907"/>
+        <location filename="../screens/SettingsScreen.qml" line="913"/>
         <source>%1 seconds</source>
         <translation>%1 seconden</translation>
     </message>
@@ -2132,93 +2164,93 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="108"/>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="855"/>
+        <location filename="../screens/SettingsScreen.qml" line="861"/>
         <source>Nord</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="852"/>
+        <location filename="../screens/SettingsScreen.qml" line="858"/>
         <source>Dracula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="859"/>
+        <location filename="../screens/SettingsScreen.qml" line="865"/>
         <source>Synthwave &apos;84</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="846"/>
+        <location filename="../screens/SettingsScreen.qml" line="852"/>
         <source>Amber Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="848"/>
+        <location filename="../screens/SettingsScreen.qml" line="854"/>
         <source>Green Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="849"/>
+        <location filename="../screens/SettingsScreen.qml" line="855"/>
         <source>Neo Geo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="850"/>
+        <location filename="../screens/SettingsScreen.qml" line="856"/>
         <source>NES</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="851"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>Virtual Boy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="854"/>
+        <location filename="../screens/SettingsScreen.qml" line="860"/>
         <source>Gruvbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="853"/>
+        <location filename="../screens/SettingsScreen.qml" line="859"/>
         <source>Everforest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="858"/>
+        <location filename="../screens/SettingsScreen.qml" line="864"/>
         <source>Solarized Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="863"/>
         <source>Rosé Pine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="856"/>
+        <location filename="../screens/SettingsScreen.qml" line="862"/>
         <source>Oxocarbon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="860"/>
+        <location filename="../screens/SettingsScreen.qml" line="866"/>
         <source>Flexoki Paper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="861"/>
+        <location filename="../screens/SettingsScreen.qml" line="867"/>
         <source>Solarized Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="847"/>
+        <location filename="../screens/SettingsScreen.qml" line="853"/>
         <source>Game Boy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2268,6 +2300,16 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="269"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="280"/>
         <source>Show systems as a grid of covers, or as a list with details beside it.</source>
         <translation type="unfinished"></translation>
@@ -2288,92 +2330,107 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="324"/>
+        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <source>Shows a code you can scan to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="330"/>
         <source>Uploads the log file and gives you a link to share when reporting a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="927"/>
-        <source>Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="929"/>
-        <source>Thumbnail</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="931"/>
-        <source>Box art</source>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <source>%1 imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="933"/>
-        <source>3D box art</source>
+        <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="935"/>
-        <source>Screenshot</source>
+        <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="937"/>
-        <source>Wheel</source>
+        <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="939"/>
-        <source>Title screen</source>
+        <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="941"/>
-        <source>Map</source>
+        <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="943"/>
-        <source>Marquee</source>
+        <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="945"/>
-        <source>Fan art</source>
+        <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="947"/>
-        <source>Box side</source>
+        <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="949"/>
+        <source>Marquee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="951"/>
+        <source>Fan art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="953"/>
+        <source>Box side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="955"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="355"/>
+        <location filename="../screens/SettingsScreen.qml" line="361"/>
         <source>Settings</source>
         <translation>Instellingen</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="843"/>
+        <location filename="../screens/SettingsScreen.qml" line="849"/>
         <source>Zaparoo Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="844"/>
+        <location filename="../screens/SettingsScreen.qml" line="850"/>
         <source>Zaparoo Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="845"/>
+        <location filename="../screens/SettingsScreen.qml" line="851"/>
         <source>Classic Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1887"/>
+        <location filename="../screens/SettingsScreen.qml" line="1893"/>
         <source>No settings available on this platform</source>
         <translation>Geen instellingen beschikbaar op dit platform</translation>
     </message>
@@ -2412,9 +2469,33 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/StatusLine.qml" line="105"/>
+        <source>Importing paused: game running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Import failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Imported %1 of %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scraping…</source>
-        <translation type="unfinished">Bezig met scrapen…</translation>
+        <translation type="obsolete">Bezig met scrapen…</translation>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
@@ -2443,16 +2524,6 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="105"/>
-        <source>Scraping paused: game running</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="106"/>
-        <source>Scraping: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>%1 files</source>
         <translation type="obsolete">%1 bestanden</translation>
     </message>
@@ -2468,16 +2539,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scraped %1 of %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -1997,6 +1997,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
         <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
@@ -2302,11 +2307,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Get metadata</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_nl.ts
+++ b/src/ui/translations/frontend_nl.ts
@@ -2110,7 +2110,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1911"/>
+        <location filename="../screens/SettingsScreen.qml" line="1913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2430,7 +2430,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1893"/>
+        <location filename="../screens/SettingsScreen.qml" line="1895"/>
         <source>No settings available on this platform</source>
         <translation>Geen instellingen beschikbaar op dit platform</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -35,8 +35,8 @@
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="212"/>
-        <source>Commercial licensing: legal@zaparoo.org</source>
-        <translation>Licențiere comercială: legal@zaparoo.org</translation>
+        <source>Commercial licensing: legal@zaparoo.com</source>
+        <translation>Licențiere comercială: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="223"/>
@@ -227,8 +227,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="116"/>
-        <source>Contact: legal@zaparoo.org</source>
-        <translation>Contactați: legal@zaparoo.org</translation>
+        <source>Contact: legal@zaparoo.com</source>
+        <translation>Contactați: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="127"/>
@@ -1532,27 +1532,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
-        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <source>Documentation: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="225"/>
         <source>Loading sources…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="262"/>
         <source>Replace existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="276"/>
         <source>Start import</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1561,7 +1561,7 @@ Français - Wilfried</source>
         <translation type="obsolete">Extragere metadate</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="249"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -2112,7 +2112,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1911"/>
+        <location filename="../screens/SettingsScreen.qml" line="1913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2432,7 +2432,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1893"/>
+        <location filename="../screens/SettingsScreen.qml" line="1895"/>
         <source>No settings available on this platform</source>
         <translation>Nicio setare disponibilă pe această platformă</translation>
     </message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -391,45 +391,6 @@ Français - Wilfried</source>
     </message>
 </context>
 <context>
-    <name>FirstRunIndexModal</name>
-    <message>
-        <source>First-time setup</source>
-        <translation type="vanished">Configurare inițială</translation>
-    </message>
-    <message>
-        <source>Indexing paused</source>
-        <translation type="vanished">Indexare în pauză</translation>
-    </message>
-    <message>
-        <source>Optimizing database - almost done</source>
-        <translation type="vanished">Optimizare bază de date – aproape gata</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2 - %3</source>
-        <translation type="vanished">Pasul %1 din %2 – %3</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2</source>
-        <translation type="vanished">Pasul %1 din %2</translation>
-    </message>
-    <message>
-        <source>Preparing…</source>
-        <translation type="vanished">Pregătire…</translation>
-    </message>
-    <message>
-        <source>Done. %1 files indexed.</source>
-        <translation type="vanished">Gata. %1 fișiere indexate.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Anulare</translation>
-    </message>
-    <message>
-        <source>Start scan</source>
-        <translation type="vanished">Pornire scanare</translation>
-    </message>
-</context>
-<context>
     <name>GameInfoModal</name>
     <message>
         <location filename="../components/GameInfoModal.qml" line="153"/>
@@ -542,6 +503,26 @@ Français - Wilfried</source>
         <translation>Favorite</translation>
     </message>
     <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>Updating the media database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>No games found yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Your games appear here as Core finds them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Update media database in Settings &gt; Library.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Recently Played</source>
         <translation type="vanished">Recent Jucate</translation>
     </message>
@@ -571,35 +552,44 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
-        <translation>Niciun sistem disponibil. Rulați Actualizare bază de date din Setări.</translation>
+        <translation type="vanished">Niciun sistem disponibil. Rulați Actualizare bază de date din Setări.</translation>
     </message>
 </context>
 <context>
     <name>IndexSetupModal</name>
     <message>
         <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Start</source>
+        <translation type="unfinished">Pornire</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Change</source>
+        <translation type="unfinished">Schimbare</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="51"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="47"/>
+        <location filename="../components/IndexSetupModal.qml" line="53"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="115"/>
+        <location filename="../components/IndexSetupModal.qml" line="121"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizare bază de date media</translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="124"/>
+        <location filename="../components/IndexSetupModal.qml" line="130"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="137"/>
+        <location filename="../components/IndexSetupModal.qml" line="143"/>
         <source>Start update</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,29 +667,29 @@ Français - Wilfried</source>
         <translation type="vanished">Lansare core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
-        <location filename="../app/Main.qml" line="2330"/>
-        <location filename="../app/Main.qml" line="2393"/>
-        <location filename="../app/Main.qml" line="2699"/>
-        <location filename="../app/Main.qml" line="3741"/>
-        <location filename="../app/Main.qml" line="3784"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
+        <location filename="../app/Main.qml" line="2341"/>
+        <location filename="../app/Main.qml" line="2410"/>
+        <location filename="../app/Main.qml" line="2716"/>
+        <location filename="../app/Main.qml" line="3795"/>
+        <location filename="../app/Main.qml" line="3838"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Remove from favorites</source>
         <translation>Elimină din favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Add to favorites</source>
         <translation>Adaugă la favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2264"/>
-        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2266"/>
+        <location filename="../app/Main.qml" line="2346"/>
         <source>Write to NFC token</source>
         <translation>Scriere pe token NFC</translation>
     </message>
@@ -708,53 +698,76 @@ Français - Wilfried</source>
         <translation type="vanished">Cod QR</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
-        <location filename="../app/Main.qml" line="2308"/>
+        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2319"/>
         <source>Launch game</source>
         <translation>Lansare joc</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1070"/>
-        <location filename="../app/Main.qml" line="3417"/>
-        <location filename="../app/Main.qml" line="3464"/>
-        <location filename="../app/Main.qml" line="3474"/>
+        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3518"/>
+        <location filename="../app/Main.qml" line="3528"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3153"/>
+        <source>Get metadata failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3154"/>
+        <source>Could not start getting metadata. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3156"/>
+        <source>Source list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3157"/>
+        <source>Could not load the list of metadata sources. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3307"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4848"/>
+        <location filename="../app/Main.qml" line="4902"/>
         <source>Loading systems…</source>
         <translation>Se încarcă sistemele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4855"/>
+        <location filename="../app/Main.qml" line="4909"/>
         <source>Loading favorites…</source>
         <translation>Se încarcă favoritele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4850"/>
+        <location filename="../app/Main.qml" line="4904"/>
         <source>Loading games…</source>
         <translation>Se încarcă jocurile…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2183"/>
-        <location filename="../app/Main.qml" line="2218"/>
+        <location filename="../app/Main.qml" line="2185"/>
+        <location filename="../app/Main.qml" line="2220"/>
         <source>Update media database</source>
         <translation type="unfinished">Actualizare bază de date media</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2186"/>
-        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
-        <translation type="unfinished">Extragere metadate</translation>
+        <translation type="obsolete">Extragere metadate</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2179"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
@@ -764,90 +777,90 @@ Français - Wilfried</source>
         <translation type="unfinished">Setări</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2096"/>
+        <location filename="../app/Main.qml" line="2098"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2153"/>
+        <location filename="../app/Main.qml" line="2155"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2179"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2258"/>
-        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2323"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
-        <location filename="../app/Main.qml" line="2346"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2280"/>
+        <location filename="../app/Main.qml" line="2357"/>
+        <location filename="../app/Main.qml" line="2451"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3507"/>
+        <location filename="../app/Main.qml" line="2395"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3561"/>
         <source>Default</source>
         <translation type="unfinished">Implicit</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2395"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2230"/>
-        <location filename="../app/Main.qml" line="2238"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="2164"/>
+        <location filename="../app/Main.qml" line="2215"/>
+        <location filename="../app/Main.qml" line="2232"/>
+        <location filename="../app/Main.qml" line="2240"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3454"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3445"/>
+        <location filename="../app/Main.qml" line="3499"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3460"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3511"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3565"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3482"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3515"/>
+        <location filename="../app/Main.qml" line="3569"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3436"/>
+        <location filename="../app/Main.qml" line="3490"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -872,45 +885,46 @@ Français - Wilfried</source>
         <translation type="unfinished">Ieșire</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2173"/>
-        <location filename="../app/Main.qml" line="2282"/>
-        <location filename="../app/Main.qml" line="2301"/>
-        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2284"/>
+        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2361"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2268"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2270"/>
+        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2807"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2461"/>
+        <location filename="../app/Main.qml" line="2478"/>
         <source>Move</source>
         <translation type="unfinished">Mutare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2667"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1032"/>
-        <location filename="../app/Main.qml" line="3043"/>
-        <location filename="../app/Main.qml" line="3065"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3131"/>
+        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3174"/>
         <source>OK</source>
         <translation type="unfinished">În regulă</translation>
     </message>
@@ -925,226 +939,224 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="2188"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2293"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2807"/>
+        <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Scan this code to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3132"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3098"/>
+        <location filename="../app/Main.qml" line="3141"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3099"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3101"/>
+        <location filename="../app/Main.qml" line="3144"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3147"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3105"/>
+        <location filename="../app/Main.qml" line="3148"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3107"/>
+        <location filename="../app/Main.qml" line="3150"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3151"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3110"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3111"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3113"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3114"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3116"/>
+        <location filename="../app/Main.qml" line="3159"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3120"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3122"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3123"/>
+        <location filename="../app/Main.qml" line="3166"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3125"/>
+        <location filename="../app/Main.qml" line="3168"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3126"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3128"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3129"/>
+        <location filename="../app/Main.qml" line="3172"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3253"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3269"/>
+        <location filename="../app/Main.qml" line="3323"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3278"/>
+        <location filename="../app/Main.qml" line="3332"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3307"/>
+        <location filename="../app/Main.qml" line="3361"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3446"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3432"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3486"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorite</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3415"/>
-        <location filename="../app/Main.qml" line="3461"/>
+        <location filename="../app/Main.qml" line="3469"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3449"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3503"/>
+        <location filename="../app/Main.qml" line="3525"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3489"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3485"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3492"/>
+        <location filename="../app/Main.qml" line="3546"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3708"/>
+        <location filename="../app/Main.qml" line="3762"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3119"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
-        <location filename="../app/Main.qml" line="3318"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="2910"/>
+        <location filename="../app/Main.qml" line="3372"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Retry</source>
         <translation type="unfinished">Reîncercare</translation>
     </message>
@@ -1153,22 +1165,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Anulare</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4852"/>
+        <location filename="../app/Main.qml" line="4906"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4857"/>
+        <location filename="../app/Main.qml" line="4911"/>
         <source>Loading recently played…</source>
         <translation>Se încarcă recent jucatele…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4859"/>
+        <location filename="../app/Main.qml" line="4913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4861"/>
+        <location filename="../app/Main.qml" line="4915"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>
@@ -1176,7 +1188,7 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Writing failed</source>
         <translation>Scriere eșuată</translation>
     </message>
@@ -1185,82 +1197,83 @@ Français - Wilfried</source>
         <translation type="vanished">Apropiați un card inscriptibil de cititor</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="936"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="943"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="1365"/>
         <source>OK</source>
         <translation type="unfinished">În regulă</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="535"/>
+        <location filename="../app/MainLayout.qml" line="541"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Hold a writable token near the reader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
         <source>Are you sure you want to exit?</source>
         <translation>Sigur doriți să ieșiți?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1387"/>
+        <location filename="../app/MainLayout.qml" line="1409"/>
         <source>Select</source>
         <translation>Selectare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1283"/>
-        <location filename="../app/MainLayout.qml" line="1297"/>
-        <location filename="../app/MainLayout.qml" line="1312"/>
-        <location filename="../app/MainLayout.qml" line="1323"/>
-        <location filename="../app/MainLayout.qml" line="1349"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1321"/>
+        <location filename="../app/MainLayout.qml" line="1332"/>
+        <location filename="../app/MainLayout.qml" line="1358"/>
         <source>Close</source>
         <translation>Închidere</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1425"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1339"/>
+        <location filename="../app/MainLayout.qml" line="1391"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1308"/>
+        <location filename="../app/MainLayout.qml" line="1317"/>
         <source>Done</source>
         <translation>Gata</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1338"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
         <source>I understand</source>
         <translation>Am înțeles</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1376"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1389"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1269,28 +1282,29 @@ Français - Wilfried</source>
         <translation type="vanished">Pornire</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1656"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Scroll</source>
         <translation>Derulare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1468"/>
-        <location filename="../app/MainLayout.qml" line="1555"/>
-        <location filename="../app/MainLayout.qml" line="1573"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
-        <location filename="../app/MainLayout.qml" line="1724"/>
+        <location filename="../app/MainLayout.qml" line="1500"/>
+        <location filename="../app/MainLayout.qml" line="1587"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1737"/>
+        <location filename="../app/MainLayout.qml" line="1756"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1374"/>
-        <location filename="../app/MainLayout.qml" line="1454"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1596"/>
-        <location filename="../app/MainLayout.qml" line="1615"/>
-        <location filename="../app/MainLayout.qml" line="1688"/>
+        <location filename="../app/MainLayout.qml" line="1284"/>
+        <location filename="../app/MainLayout.qml" line="1383"/>
+        <location filename="../app/MainLayout.qml" line="1405"/>
+        <location filename="../app/MainLayout.qml" line="1486"/>
+        <location filename="../app/MainLayout.qml" line="1523"/>
+        <location filename="../app/MainLayout.qml" line="1572"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1647"/>
+        <location filename="../app/MainLayout.qml" line="1720"/>
         <source>Move</source>
         <translation>Mutare</translation>
     </message>
@@ -1300,8 +1314,8 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="531"/>
-        <location filename="../app/MainLayout.qml" line="533"/>
+        <location filename="../app/MainLayout.qml" line="537"/>
+        <location filename="../app/MainLayout.qml" line="539"/>
         <source>Favorites</source>
         <translation type="unfinished">Favorite</translation>
     </message>
@@ -1310,36 +1324,36 @@ Français - Wilfried</source>
         <translation type="obsolete">Recent Jucate</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="916"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="917"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1096"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1417"/>
+        <location filename="../app/MainLayout.qml" line="1449"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1421"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1496"/>
-        <location filename="../app/MainLayout.qml" line="1545"/>
-        <location filename="../app/MainLayout.qml" line="1601"/>
-        <location filename="../app/MainLayout.qml" line="1693"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1528"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1633"/>
+        <location filename="../app/MainLayout.qml" line="1725"/>
         <source>Open</source>
         <translation>Deschidere</translation>
     </message>
@@ -1348,19 +1362,20 @@ Français - Wilfried</source>
         <translation type="vanished">Ieșire</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1477"/>
-        <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1513"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1559"/>
-        <location filename="../app/MainLayout.qml" line="1577"/>
-        <location filename="../app/MainLayout.qml" line="1589"/>
-        <location filename="../app/MainLayout.qml" line="1605"/>
-        <location filename="../app/MainLayout.qml" line="1639"/>
-        <location filename="../app/MainLayout.qml" line="1660"/>
-        <location filename="../app/MainLayout.qml" line="1669"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
-        <location filename="../app/MainLayout.qml" line="1728"/>
+        <location filename="../app/MainLayout.qml" line="1413"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1561"/>
+        <location filename="../app/MainLayout.qml" line="1591"/>
+        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1621"/>
+        <location filename="../app/MainLayout.qml" line="1637"/>
+        <location filename="../app/MainLayout.qml" line="1671"/>
+        <location filename="../app/MainLayout.qml" line="1692"/>
+        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1741"/>
+        <location filename="../app/MainLayout.qml" line="1760"/>
         <source>Back</source>
         <translation>Înapoi</translation>
     </message>
@@ -1369,29 +1384,29 @@ Français - Wilfried</source>
         <translation type="vanished">Pagină</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1464"/>
-        <location filename="../app/MainLayout.qml" line="1499"/>
-        <location filename="../app/MainLayout.qml" line="1550"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1531"/>
+        <location filename="../app/MainLayout.qml" line="1582"/>
+        <location filename="../app/MainLayout.qml" line="1730"/>
         <source>Options</source>
         <translation>Opțiuni</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1509"/>
-        <location filename="../app/MainLayout.qml" line="1567"/>
-        <location filename="../app/MainLayout.qml" line="1716"/>
+        <location filename="../app/MainLayout.qml" line="1328"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1541"/>
+        <location filename="../app/MainLayout.qml" line="1599"/>
+        <location filename="../app/MainLayout.qml" line="1748"/>
         <source>Retry</source>
         <translation>Reîncercare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1624"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Change</source>
         <translation>Schimbare</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1630"/>
+        <location filename="../app/MainLayout.qml" line="1662"/>
         <source>Toggle</source>
         <translation>Comutare</translation>
     </message>
@@ -1452,12 +1467,12 @@ Français - Wilfried</source>
 <context>
     <name>QrCodeModal</name>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="23"/>
+        <location filename="../components/QrCodeModal.qml" line="19"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="43"/>
+        <location filename="../components/QrCodeModal.qml" line="20"/>
         <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1487,43 +1502,67 @@ Français - Wilfried</source>
 <context>
     <name>ScrapeSetupModal</name>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="67"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Start</source>
+        <translation type="unfinished">Pornire</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Toggle</source>
+        <translation type="unfinished">Comutare</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Change</source>
+        <translation type="unfinished">Schimbare</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="89"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="69"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="91"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="171"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="193"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
+        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <source>Loading sources…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <source>Replace existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <source>Start import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scrape metadata</source>
-        <translation type="unfinished">Extragere metadate</translation>
+        <translation type="obsolete">Extragere metadate</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="185"/>
-        <source>Loading scrapers…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="196"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
         <source>Systems</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="222"/>
-        <source>Re-scrape existing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
-        <source>Start scrape</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1535,17 +1574,17 @@ Français - Wilfried</source>
         <translation>Nimic aici</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="36"/>
         <source>Loading…</source>
         <translation>Se încarcă…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="37"/>
         <source>Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="79"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="85"/>
         <source>Failed to load</source>
         <translation>Încărcare eșuată</translation>
     </message>
@@ -1555,8 +1594,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="114"/>
         <location filename="../screens/SettingsScreen.qml" line="205"/>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
-        <location filename="../screens/SettingsScreen.qml" line="972"/>
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="978"/>
         <source>Language</source>
         <translation>Limbă</translation>
     </message>
@@ -1580,50 +1619,49 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="165"/>
-        <location filename="../screens/SettingsScreen.qml" line="999"/>
+        <location filename="../screens/SettingsScreen.qml" line="1005"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="225"/>
-        <location filename="../screens/SettingsScreen.qml" line="1051"/>
+        <location filename="../screens/SettingsScreen.qml" line="1057"/>
         <source>Button style</source>
         <translation>Stil butoane</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="1060"/>
+        <location filename="../screens/SettingsScreen.qml" line="1066"/>
         <source>Screensaver</source>
         <translation>Economizor de ecran</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Library</source>
         <translation>Bibliotecă</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="291"/>
-        <location filename="../screens/SettingsScreen.qml" line="1069"/>
+        <location filename="../screens/SettingsScreen.qml" line="1075"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Scrape metadata</source>
-        <translation>Extragere metadate</translation>
+        <translation type="vanished">Extragere metadate</translation>
     </message>
     <message>
         <source>Advanced</source>
         <translation type="vanished">Avansat</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <location filename="../screens/SettingsScreen.qml" line="323"/>
         <source>Debug logging</source>
         <translation>Jurnal depanare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="323"/>
+        <location filename="../screens/SettingsScreen.qml" line="329"/>
         <source>Upload log file</source>
         <translation>Încărcare fișier jurnal</translation>
     </message>
@@ -1634,7 +1672,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="217"/>
-        <location filename="../screens/SettingsScreen.qml" line="981"/>
+        <location filename="../screens/SettingsScreen.qml" line="987"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1645,13 +1683,13 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="158"/>
-        <location filename="../screens/SettingsScreen.qml" line="963"/>
+        <location filename="../screens/SettingsScreen.qml" line="969"/>
         <source>Interface resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="129"/>
-        <location filename="../screens/SettingsScreen.qml" line="1035"/>
+        <location filename="../screens/SettingsScreen.qml" line="1041"/>
         <source>Color scheme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1667,7 +1705,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <location filename="../screens/SettingsScreen.qml" line="1078"/>
+        <location filename="../screens/SettingsScreen.qml" line="1084"/>
         <source>Video standard</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1678,7 +1716,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="135"/>
-        <location filename="../screens/SettingsScreen.qml" line="1026"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
         <source>System logos</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1699,19 +1737,19 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="90"/>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="120"/>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="211"/>
-        <location filename="../screens/SettingsScreen.qml" line="990"/>
+        <location filename="../screens/SettingsScreen.qml" line="996"/>
         <source>Region</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1721,35 +1759,34 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Optimizing</source>
         <translation>Optimizare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>Paused</source>
         <translation>În pauză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>In progress</source>
         <translation>În curs</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>%1 indexed</source>
         <translation>%1 indexate</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>%1 scraped</source>
-        <translation>%1 extrase</translation>
+        <translation type="vanished">%1 extrase</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Cancel</source>
         <translation>Anulare</translation>
     </message>
@@ -1758,117 +1795,117 @@ Français - Wilfried</source>
         <translation type="vanished">Pornire</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Upload</source>
         <translation>Încărcare</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="650"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Open</source>
         <translation>Deschidere</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>%1 × %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Automatic (Recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="717"/>
         <source>%1 (Animations off)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="758"/>
         <source>English</source>
         <translation>Engleză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="760"/>
         <source>Italian</source>
         <translation>Italiană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="756"/>
+        <location filename="../screens/SettingsScreen.qml" line="762"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="758"/>
+        <location filename="../screens/SettingsScreen.qml" line="764"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="760"/>
+        <location filename="../screens/SettingsScreen.qml" line="766"/>
         <source>German</source>
         <translation>Germană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="762"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Greek</source>
         <translation>Greacă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="764"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Japanese</source>
         <translation>Japoneză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="766"/>
+        <location filename="../screens/SettingsScreen.qml" line="772"/>
         <source>Korean</source>
         <translation>Coreeană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Dutch</source>
         <translation>Olandeză</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="776"/>
         <source>Romanian</source>
         <translation>Română</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="778"/>
         <source>Slovak</source>
         <translation>Slovacă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="774"/>
+        <location filename="../screens/SettingsScreen.qml" line="780"/>
         <source>Ukrainian</source>
         <translation>Ucraineană</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="776"/>
+        <location filename="../screens/SettingsScreen.qml" line="782"/>
         <source>Chinese (Simplified)</source>
         <translation>Chineză (simplificată)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="778"/>
+        <location filename="../screens/SettingsScreen.qml" line="784"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="780"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Hebrew</source>
         <translation>Ebraică</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="782"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="784"/>
+        <location filename="../screens/SettingsScreen.qml" line="790"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>French</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1877,37 +1914,37 @@ Français - Wilfried</source>
         <translation type="vanished">Automat</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="792"/>
+        <location filename="../screens/SettingsScreen.qml" line="798"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="794"/>
+        <location filename="../screens/SettingsScreen.qml" line="800"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="805"/>
+        <location filename="../screens/SettingsScreen.qml" line="811"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="807"/>
+        <location filename="../screens/SettingsScreen.qml" line="813"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="809"/>
+        <location filename="../screens/SettingsScreen.qml" line="815"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
-        <location filename="../screens/SettingsScreen.qml" line="787"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
-        <location filename="../screens/SettingsScreen.qml" line="810"/>
-        <location filename="../screens/SettingsScreen.qml" line="877"/>
-        <location filename="../screens/SettingsScreen.qml" line="925"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="793"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
+        <location filename="../screens/SettingsScreen.qml" line="816"/>
+        <location filename="../screens/SettingsScreen.qml" line="883"/>
+        <location filename="../screens/SettingsScreen.qml" line="931"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1962,19 +1999,14 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Downloads box art, descriptions, and tags for your games. Choose a source and which systems.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
-        <location filename="../screens/SettingsScreen.qml" line="1008"/>
+        <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="285"/>
-        <location filename="../screens/SettingsScreen.qml" line="1017"/>
+        <location filename="../screens/SettingsScreen.qml" line="1023"/>
         <source>Games layout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1989,93 +2021,93 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <location filename="../screens/SettingsScreen.qml" line="324"/>
         <source>Writes extra detail to the log file to help track down a problem. Restarts the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Configure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="815"/>
+        <location filename="../screens/SettingsScreen.qml" line="821"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="817"/>
+        <location filename="../screens/SettingsScreen.qml" line="823"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="818"/>
+        <location filename="../screens/SettingsScreen.qml" line="824"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="823"/>
+        <location filename="../screens/SettingsScreen.qml" line="829"/>
         <source>Detailed list view</source>
         <translation>Vizualizare listă detaliată</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="824"/>
+        <location filename="../screens/SettingsScreen.qml" line="830"/>
         <source>Grid view</source>
         <translation>Vizualizare grilă</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="829"/>
+        <location filename="../screens/SettingsScreen.qml" line="835"/>
         <source>Full color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="830"/>
+        <location filename="../screens/SettingsScreen.qml" line="836"/>
         <source>Tinted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="868"/>
+        <location filename="../screens/SettingsScreen.qml" line="874"/>
         <source>Style B</source>
         <translation>Stil B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="870"/>
+        <location filename="../screens/SettingsScreen.qml" line="876"/>
         <source>Style C</source>
         <translation>Stil C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="872"/>
+        <location filename="../screens/SettingsScreen.qml" line="878"/>
         <source>Style D</source>
         <translation>Stil D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="874"/>
+        <location filename="../screens/SettingsScreen.qml" line="880"/>
         <source>Style E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="876"/>
+        <location filename="../screens/SettingsScreen.qml" line="882"/>
         <source>Style A</source>
         <translation>Stil A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="917"/>
+        <location filename="../screens/SettingsScreen.qml" line="923"/>
         <source>PAL (50 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="919"/>
+        <location filename="../screens/SettingsScreen.qml" line="925"/>
         <source>480i (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="920"/>
+        <location filename="../screens/SettingsScreen.qml" line="926"/>
         <source>NTSC (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1905"/>
+        <location filename="../screens/SettingsScreen.qml" line="1911"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2084,47 +2116,47 @@ Français - Wilfried</source>
         <translation type="vanished">Implicit</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="892"/>
+        <location filename="../screens/SettingsScreen.qml" line="898"/>
         <source>Off</source>
         <translation>Dezactivat</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="894"/>
+        <location filename="../screens/SettingsScreen.qml" line="900"/>
         <source>1 second (testing)</source>
         <translation>1 secundă (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="896"/>
+        <location filename="../screens/SettingsScreen.qml" line="902"/>
         <source>1 minute</source>
         <translation>1 minut</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="898"/>
+        <location filename="../screens/SettingsScreen.qml" line="904"/>
         <source>2 minutes</source>
         <translation>2 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="900"/>
+        <location filename="../screens/SettingsScreen.qml" line="906"/>
         <source>5 minutes</source>
         <translation>5 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="902"/>
+        <location filename="../screens/SettingsScreen.qml" line="908"/>
         <source>10 minutes</source>
         <translation>10 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="904"/>
+        <location filename="../screens/SettingsScreen.qml" line="910"/>
         <source>15 minutes</source>
         <translation>15 minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="906"/>
+        <location filename="../screens/SettingsScreen.qml" line="912"/>
         <source>30 minutes</source>
         <translation>30 de minute</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="907"/>
+        <location filename="../screens/SettingsScreen.qml" line="913"/>
         <source>%1 seconds</source>
         <translation>%1 secunde</translation>
     </message>
@@ -2134,93 +2166,93 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="108"/>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="855"/>
+        <location filename="../screens/SettingsScreen.qml" line="861"/>
         <source>Nord</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="852"/>
+        <location filename="../screens/SettingsScreen.qml" line="858"/>
         <source>Dracula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="859"/>
+        <location filename="../screens/SettingsScreen.qml" line="865"/>
         <source>Synthwave &apos;84</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="846"/>
+        <location filename="../screens/SettingsScreen.qml" line="852"/>
         <source>Amber Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="848"/>
+        <location filename="../screens/SettingsScreen.qml" line="854"/>
         <source>Green Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="849"/>
+        <location filename="../screens/SettingsScreen.qml" line="855"/>
         <source>Neo Geo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="850"/>
+        <location filename="../screens/SettingsScreen.qml" line="856"/>
         <source>NES</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="851"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>Virtual Boy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="854"/>
+        <location filename="../screens/SettingsScreen.qml" line="860"/>
         <source>Gruvbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="853"/>
+        <location filename="../screens/SettingsScreen.qml" line="859"/>
         <source>Everforest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="858"/>
+        <location filename="../screens/SettingsScreen.qml" line="864"/>
         <source>Solarized Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="863"/>
         <source>Rosé Pine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="856"/>
+        <location filename="../screens/SettingsScreen.qml" line="862"/>
         <source>Oxocarbon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="860"/>
+        <location filename="../screens/SettingsScreen.qml" line="866"/>
         <source>Flexoki Paper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="861"/>
+        <location filename="../screens/SettingsScreen.qml" line="867"/>
         <source>Solarized Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="847"/>
+        <location filename="../screens/SettingsScreen.qml" line="853"/>
         <source>Game Boy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2270,6 +2302,16 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="269"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="280"/>
         <source>Show systems as a grid of covers, or as a list with details beside it.</source>
         <translation type="unfinished"></translation>
@@ -2290,92 +2332,107 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="324"/>
+        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <source>Shows a code you can scan to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="330"/>
         <source>Uploads the log file and gives you a link to share when reporting a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="927"/>
-        <source>Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="929"/>
-        <source>Thumbnail</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="931"/>
-        <source>Box art</source>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <source>%1 imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="933"/>
-        <source>3D box art</source>
+        <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="935"/>
-        <source>Screenshot</source>
+        <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="937"/>
-        <source>Wheel</source>
+        <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="939"/>
-        <source>Title screen</source>
+        <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="941"/>
-        <source>Map</source>
+        <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="943"/>
-        <source>Marquee</source>
+        <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="945"/>
-        <source>Fan art</source>
+        <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="947"/>
-        <source>Box side</source>
+        <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="949"/>
+        <source>Marquee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="951"/>
+        <source>Fan art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="953"/>
+        <source>Box side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="955"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="355"/>
+        <location filename="../screens/SettingsScreen.qml" line="361"/>
         <source>Settings</source>
         <translation>Setări</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="843"/>
+        <location filename="../screens/SettingsScreen.qml" line="849"/>
         <source>Zaparoo Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="844"/>
+        <location filename="../screens/SettingsScreen.qml" line="850"/>
         <source>Zaparoo Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="845"/>
+        <location filename="../screens/SettingsScreen.qml" line="851"/>
         <source>Classic Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1887"/>
+        <location filename="../screens/SettingsScreen.qml" line="1893"/>
         <source>No settings available on this platform</source>
         <translation>Nicio setare disponibilă pe această platformă</translation>
     </message>
@@ -2414,9 +2471,33 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/StatusLine.qml" line="105"/>
+        <source>Importing paused: game running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Import failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Imported %1 of %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scraping…</source>
-        <translation type="unfinished">Se preiau datele…</translation>
+        <translation type="obsolete">Se preiau datele…</translation>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
@@ -2445,16 +2526,6 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="105"/>
-        <source>Scraping paused: game running</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="106"/>
-        <source>Scraping: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>%1 files</source>
         <translation type="obsolete">%1 fișiere</translation>
     </message>
@@ -2470,16 +2541,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scraped %1 of %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_ro.ts
+++ b/src/ui/translations/frontend_ro.ts
@@ -1999,6 +1999,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
         <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
@@ -2304,11 +2309,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Get metadata</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -391,45 +391,6 @@ Français - Wilfried</source>
     </message>
 </context>
 <context>
-    <name>FirstRunIndexModal</name>
-    <message>
-        <source>First-time setup</source>
-        <translation type="vanished">Prvé nastavenie</translation>
-    </message>
-    <message>
-        <source>Indexing paused</source>
-        <translation type="vanished">Indexovanie pozastavené</translation>
-    </message>
-    <message>
-        <source>Optimizing database - almost done</source>
-        <translation type="vanished">Optimalizácia databázy – takmer hotovo</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2 - %3</source>
-        <translation type="vanished">Krok %1 z %2 – %3</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2</source>
-        <translation type="vanished">Krok %1 z %2</translation>
-    </message>
-    <message>
-        <source>Preparing…</source>
-        <translation type="vanished">Príprava…</translation>
-    </message>
-    <message>
-        <source>Done. %1 files indexed.</source>
-        <translation type="vanished">Hotovo. Indexovaných %1 súborov.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Zrušiť</translation>
-    </message>
-    <message>
-        <source>Start scan</source>
-        <translation type="vanished">Spustiť skenovanie</translation>
-    </message>
-</context>
-<context>
     <name>GameInfoModal</name>
     <message>
         <location filename="../components/GameInfoModal.qml" line="153"/>
@@ -542,6 +503,26 @@ Français - Wilfried</source>
         <translation>Obľúbené</translation>
     </message>
     <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>Updating the media database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>No games found yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Your games appear here as Core finds them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Update media database in Settings &gt; Library.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Recently Played</source>
         <translation type="vanished">Nedávno hrané</translation>
     </message>
@@ -571,35 +552,44 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
-        <translation>Žiadne systémy nie sú dostupné. Spustite Aktualizovať databázu médií v Nastaveniach.</translation>
+        <translation type="vanished">Žiadne systémy nie sú dostupné. Spustite Aktualizovať databázu médií v Nastaveniach.</translation>
     </message>
 </context>
 <context>
     <name>IndexSetupModal</name>
     <message>
         <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Start</source>
+        <translation type="unfinished">Spustiť</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Change</source>
+        <translation type="unfinished">Zmeniť</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="51"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="47"/>
+        <location filename="../components/IndexSetupModal.qml" line="53"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="115"/>
+        <location filename="../components/IndexSetupModal.qml" line="121"/>
         <source>Update media database</source>
         <translation type="unfinished">Aktualizovať databázu médií</translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="124"/>
+        <location filename="../components/IndexSetupModal.qml" line="130"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="137"/>
+        <location filename="../components/IndexSetupModal.qml" line="143"/>
         <source>Start update</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,29 +667,29 @@ Français - Wilfried</source>
         <translation type="vanished">Spustiť core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
-        <location filename="../app/Main.qml" line="2330"/>
-        <location filename="../app/Main.qml" line="2393"/>
-        <location filename="../app/Main.qml" line="2699"/>
-        <location filename="../app/Main.qml" line="3741"/>
-        <location filename="../app/Main.qml" line="3784"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
+        <location filename="../app/Main.qml" line="2341"/>
+        <location filename="../app/Main.qml" line="2410"/>
+        <location filename="../app/Main.qml" line="2716"/>
+        <location filename="../app/Main.qml" line="3795"/>
+        <location filename="../app/Main.qml" line="3838"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Remove from favorites</source>
         <translation>Odstrániť z obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Add to favorites</source>
         <translation>Pridať do obľúbených</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2264"/>
-        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2266"/>
+        <location filename="../app/Main.qml" line="2346"/>
         <source>Write to NFC token</source>
         <translation>Zapísať na NFC token</translation>
     </message>
@@ -708,53 +698,76 @@ Français - Wilfried</source>
         <translation type="vanished">QR kód</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
-        <location filename="../app/Main.qml" line="2308"/>
+        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2319"/>
         <source>Launch game</source>
         <translation>Spustiť hru</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1070"/>
-        <location filename="../app/Main.qml" line="3417"/>
-        <location filename="../app/Main.qml" line="3464"/>
-        <location filename="../app/Main.qml" line="3474"/>
+        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3518"/>
+        <location filename="../app/Main.qml" line="3528"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3153"/>
+        <source>Get metadata failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3154"/>
+        <source>Could not start getting metadata. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3156"/>
+        <source>Source list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3157"/>
+        <source>Could not load the list of metadata sources. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3307"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4848"/>
+        <location filename="../app/Main.qml" line="4902"/>
         <source>Loading systems…</source>
         <translation>Načítanie systémov…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4855"/>
+        <location filename="../app/Main.qml" line="4909"/>
         <source>Loading favorites…</source>
         <translation>Načítanie obľúbených…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4850"/>
+        <location filename="../app/Main.qml" line="4904"/>
         <source>Loading games…</source>
         <translation>Načítanie hier…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2183"/>
-        <location filename="../app/Main.qml" line="2218"/>
+        <location filename="../app/Main.qml" line="2185"/>
+        <location filename="../app/Main.qml" line="2220"/>
         <source>Update media database</source>
         <translation type="unfinished">Aktualizovať databázu médií</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2186"/>
-        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
-        <translation type="unfinished">Získať metadáta</translation>
+        <translation type="obsolete">Získať metadáta</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2179"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
@@ -764,90 +777,90 @@ Français - Wilfried</source>
         <translation type="unfinished">Nastavenia</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2096"/>
+        <location filename="../app/Main.qml" line="2098"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2153"/>
+        <location filename="../app/Main.qml" line="2155"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2179"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2258"/>
-        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2323"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
-        <location filename="../app/Main.qml" line="2346"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2280"/>
+        <location filename="../app/Main.qml" line="2357"/>
+        <location filename="../app/Main.qml" line="2451"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3507"/>
+        <location filename="../app/Main.qml" line="2395"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3561"/>
         <source>Default</source>
         <translation type="unfinished">Predvolené</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2395"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2230"/>
-        <location filename="../app/Main.qml" line="2238"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="2164"/>
+        <location filename="../app/Main.qml" line="2215"/>
+        <location filename="../app/Main.qml" line="2232"/>
+        <location filename="../app/Main.qml" line="2240"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3454"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3445"/>
+        <location filename="../app/Main.qml" line="3499"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3460"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3511"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3565"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3482"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3515"/>
+        <location filename="../app/Main.qml" line="3569"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3436"/>
+        <location filename="../app/Main.qml" line="3490"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -872,45 +885,46 @@ Français - Wilfried</source>
         <translation type="unfinished">Ukončiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2173"/>
-        <location filename="../app/Main.qml" line="2282"/>
-        <location filename="../app/Main.qml" line="2301"/>
-        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2284"/>
+        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2361"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2268"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2270"/>
+        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2807"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2461"/>
+        <location filename="../app/Main.qml" line="2478"/>
         <source>Move</source>
         <translation type="unfinished">Presunúť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2667"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1032"/>
-        <location filename="../app/Main.qml" line="3043"/>
-        <location filename="../app/Main.qml" line="3065"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3131"/>
+        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3174"/>
         <source>OK</source>
         <translation type="unfinished">V poriadku</translation>
     </message>
@@ -925,226 +939,224 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="2188"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2293"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2807"/>
+        <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Scan this code to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3132"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3098"/>
+        <location filename="../app/Main.qml" line="3141"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3099"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3101"/>
+        <location filename="../app/Main.qml" line="3144"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3147"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3105"/>
+        <location filename="../app/Main.qml" line="3148"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3107"/>
+        <location filename="../app/Main.qml" line="3150"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3151"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3110"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3111"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3113"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3114"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3116"/>
+        <location filename="../app/Main.qml" line="3159"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3120"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3122"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3123"/>
+        <location filename="../app/Main.qml" line="3166"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3125"/>
+        <location filename="../app/Main.qml" line="3168"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3126"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3128"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3129"/>
+        <location filename="../app/Main.qml" line="3172"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3253"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3269"/>
+        <location filename="../app/Main.qml" line="3323"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3278"/>
+        <location filename="../app/Main.qml" line="3332"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3307"/>
+        <location filename="../app/Main.qml" line="3361"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3446"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3432"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3486"/>
         <source>Favorites</source>
         <translation type="unfinished">Obľúbené</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3415"/>
-        <location filename="../app/Main.qml" line="3461"/>
+        <location filename="../app/Main.qml" line="3469"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3449"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3503"/>
+        <location filename="../app/Main.qml" line="3525"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3489"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3485"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3492"/>
+        <location filename="../app/Main.qml" line="3546"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3708"/>
+        <location filename="../app/Main.qml" line="3762"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3119"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
-        <location filename="../app/Main.qml" line="3318"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="2910"/>
+        <location filename="../app/Main.qml" line="3372"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Retry</source>
         <translation type="unfinished">Skúsiť znova</translation>
     </message>
@@ -1153,22 +1165,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4852"/>
+        <location filename="../app/Main.qml" line="4906"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4857"/>
+        <location filename="../app/Main.qml" line="4911"/>
         <source>Loading recently played…</source>
         <translation>Načítanie nedávno hraných…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4859"/>
+        <location filename="../app/Main.qml" line="4913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4861"/>
+        <location filename="../app/Main.qml" line="4915"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>
@@ -1176,7 +1188,7 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Writing failed</source>
         <translation>Zápis zlyhal</translation>
     </message>
@@ -1185,82 +1197,83 @@ Français - Wilfried</source>
         <translation type="vanished">Priložte zapisovateľnú kartu k čítačke</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="936"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="943"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="1365"/>
         <source>OK</source>
         <translation type="unfinished">V poriadku</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="535"/>
+        <location filename="../app/MainLayout.qml" line="541"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Hold a writable token near the reader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
         <source>Are you sure you want to exit?</source>
         <translation>Naozaj chcete ukončiť?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1387"/>
+        <location filename="../app/MainLayout.qml" line="1409"/>
         <source>Select</source>
         <translation>Vybrať</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1283"/>
-        <location filename="../app/MainLayout.qml" line="1297"/>
-        <location filename="../app/MainLayout.qml" line="1312"/>
-        <location filename="../app/MainLayout.qml" line="1323"/>
-        <location filename="../app/MainLayout.qml" line="1349"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1321"/>
+        <location filename="../app/MainLayout.qml" line="1332"/>
+        <location filename="../app/MainLayout.qml" line="1358"/>
         <source>Close</source>
         <translation>Zavrieť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1425"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1339"/>
+        <location filename="../app/MainLayout.qml" line="1391"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1308"/>
+        <location filename="../app/MainLayout.qml" line="1317"/>
         <source>Done</source>
         <translation>Hotovo</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1338"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
         <source>I understand</source>
         <translation>Rozumiem</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1376"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1389"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1269,28 +1282,29 @@ Français - Wilfried</source>
         <translation type="vanished">Spustiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1656"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Scroll</source>
         <translation>Posúvať</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1468"/>
-        <location filename="../app/MainLayout.qml" line="1555"/>
-        <location filename="../app/MainLayout.qml" line="1573"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
-        <location filename="../app/MainLayout.qml" line="1724"/>
+        <location filename="../app/MainLayout.qml" line="1500"/>
+        <location filename="../app/MainLayout.qml" line="1587"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1737"/>
+        <location filename="../app/MainLayout.qml" line="1756"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1374"/>
-        <location filename="../app/MainLayout.qml" line="1454"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1596"/>
-        <location filename="../app/MainLayout.qml" line="1615"/>
-        <location filename="../app/MainLayout.qml" line="1688"/>
+        <location filename="../app/MainLayout.qml" line="1284"/>
+        <location filename="../app/MainLayout.qml" line="1383"/>
+        <location filename="../app/MainLayout.qml" line="1405"/>
+        <location filename="../app/MainLayout.qml" line="1486"/>
+        <location filename="../app/MainLayout.qml" line="1523"/>
+        <location filename="../app/MainLayout.qml" line="1572"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1647"/>
+        <location filename="../app/MainLayout.qml" line="1720"/>
         <source>Move</source>
         <translation>Presunúť</translation>
     </message>
@@ -1300,8 +1314,8 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="531"/>
-        <location filename="../app/MainLayout.qml" line="533"/>
+        <location filename="../app/MainLayout.qml" line="537"/>
+        <location filename="../app/MainLayout.qml" line="539"/>
         <source>Favorites</source>
         <translation type="unfinished">Obľúbené</translation>
     </message>
@@ -1310,36 +1324,36 @@ Français - Wilfried</source>
         <translation type="obsolete">Nedávno hrané</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="916"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="917"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1096"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1417"/>
+        <location filename="../app/MainLayout.qml" line="1449"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1421"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1496"/>
-        <location filename="../app/MainLayout.qml" line="1545"/>
-        <location filename="../app/MainLayout.qml" line="1601"/>
-        <location filename="../app/MainLayout.qml" line="1693"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1528"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1633"/>
+        <location filename="../app/MainLayout.qml" line="1725"/>
         <source>Open</source>
         <translation>Otvoriť</translation>
     </message>
@@ -1348,19 +1362,20 @@ Français - Wilfried</source>
         <translation type="vanished">Ukončiť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1477"/>
-        <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1513"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1559"/>
-        <location filename="../app/MainLayout.qml" line="1577"/>
-        <location filename="../app/MainLayout.qml" line="1589"/>
-        <location filename="../app/MainLayout.qml" line="1605"/>
-        <location filename="../app/MainLayout.qml" line="1639"/>
-        <location filename="../app/MainLayout.qml" line="1660"/>
-        <location filename="../app/MainLayout.qml" line="1669"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
-        <location filename="../app/MainLayout.qml" line="1728"/>
+        <location filename="../app/MainLayout.qml" line="1413"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1561"/>
+        <location filename="../app/MainLayout.qml" line="1591"/>
+        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1621"/>
+        <location filename="../app/MainLayout.qml" line="1637"/>
+        <location filename="../app/MainLayout.qml" line="1671"/>
+        <location filename="../app/MainLayout.qml" line="1692"/>
+        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1741"/>
+        <location filename="../app/MainLayout.qml" line="1760"/>
         <source>Back</source>
         <translation>Späť</translation>
     </message>
@@ -1369,29 +1384,29 @@ Français - Wilfried</source>
         <translation type="vanished">Stránka</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1464"/>
-        <location filename="../app/MainLayout.qml" line="1499"/>
-        <location filename="../app/MainLayout.qml" line="1550"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1531"/>
+        <location filename="../app/MainLayout.qml" line="1582"/>
+        <location filename="../app/MainLayout.qml" line="1730"/>
         <source>Options</source>
         <translation>Možnosti</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1509"/>
-        <location filename="../app/MainLayout.qml" line="1567"/>
-        <location filename="../app/MainLayout.qml" line="1716"/>
+        <location filename="../app/MainLayout.qml" line="1328"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1541"/>
+        <location filename="../app/MainLayout.qml" line="1599"/>
+        <location filename="../app/MainLayout.qml" line="1748"/>
         <source>Retry</source>
         <translation>Skúsiť znova</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1624"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Change</source>
         <translation>Zmeniť</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1630"/>
+        <location filename="../app/MainLayout.qml" line="1662"/>
         <source>Toggle</source>
         <translation>Prepínať</translation>
     </message>
@@ -1452,12 +1467,12 @@ Français - Wilfried</source>
 <context>
     <name>QrCodeModal</name>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="23"/>
+        <location filename="../components/QrCodeModal.qml" line="19"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="43"/>
+        <location filename="../components/QrCodeModal.qml" line="20"/>
         <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1487,43 +1502,67 @@ Français - Wilfried</source>
 <context>
     <name>ScrapeSetupModal</name>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="67"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Start</source>
+        <translation type="unfinished">Spustiť</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Toggle</source>
+        <translation type="unfinished">Prepínať</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Change</source>
+        <translation type="unfinished">Zmeniť</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="89"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="69"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="91"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="171"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="193"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
+        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <source>Loading sources…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <source>Replace existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <source>Start import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scrape metadata</source>
-        <translation type="unfinished">Získať metadáta</translation>
+        <translation type="obsolete">Získať metadáta</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="185"/>
-        <source>Loading scrapers…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="196"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
         <source>Systems</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="222"/>
-        <source>Re-scrape existing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
-        <source>Start scrape</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1535,17 +1574,17 @@ Français - Wilfried</source>
         <translation>Nič tu nie je</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="36"/>
         <source>Loading…</source>
         <translation>Načítanie…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="37"/>
         <source>Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="79"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="85"/>
         <source>Failed to load</source>
         <translation>Načítanie zlyhalo</translation>
     </message>
@@ -1555,8 +1594,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="114"/>
         <location filename="../screens/SettingsScreen.qml" line="205"/>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
-        <location filename="../screens/SettingsScreen.qml" line="972"/>
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="978"/>
         <source>Language</source>
         <translation>Jazyk</translation>
     </message>
@@ -1580,50 +1619,49 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="165"/>
-        <location filename="../screens/SettingsScreen.qml" line="999"/>
+        <location filename="../screens/SettingsScreen.qml" line="1005"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="225"/>
-        <location filename="../screens/SettingsScreen.qml" line="1051"/>
+        <location filename="../screens/SettingsScreen.qml" line="1057"/>
         <source>Button style</source>
         <translation>Štýl tlačidiel</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="1060"/>
+        <location filename="../screens/SettingsScreen.qml" line="1066"/>
         <source>Screensaver</source>
         <translation>Šetrič obrazovky</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Library</source>
         <translation>Knižnica</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="291"/>
-        <location filename="../screens/SettingsScreen.qml" line="1069"/>
+        <location filename="../screens/SettingsScreen.qml" line="1075"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Scrape metadata</source>
-        <translation>Získať metadáta</translation>
+        <translation type="vanished">Získať metadáta</translation>
     </message>
     <message>
         <source>Advanced</source>
         <translation type="vanished">Rozšírené</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <location filename="../screens/SettingsScreen.qml" line="323"/>
         <source>Debug logging</source>
         <translation>Ladiace záznamy</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="323"/>
+        <location filename="../screens/SettingsScreen.qml" line="329"/>
         <source>Upload log file</source>
         <translation>Nahrať súbor protokolu</translation>
     </message>
@@ -1634,7 +1672,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="217"/>
-        <location filename="../screens/SettingsScreen.qml" line="981"/>
+        <location filename="../screens/SettingsScreen.qml" line="987"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1645,13 +1683,13 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="158"/>
-        <location filename="../screens/SettingsScreen.qml" line="963"/>
+        <location filename="../screens/SettingsScreen.qml" line="969"/>
         <source>Interface resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="129"/>
-        <location filename="../screens/SettingsScreen.qml" line="1035"/>
+        <location filename="../screens/SettingsScreen.qml" line="1041"/>
         <source>Color scheme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1667,7 +1705,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <location filename="../screens/SettingsScreen.qml" line="1078"/>
+        <location filename="../screens/SettingsScreen.qml" line="1084"/>
         <source>Video standard</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1678,7 +1716,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="135"/>
-        <location filename="../screens/SettingsScreen.qml" line="1026"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
         <source>System logos</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1699,19 +1737,19 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="90"/>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="120"/>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="211"/>
-        <location filename="../screens/SettingsScreen.qml" line="990"/>
+        <location filename="../screens/SettingsScreen.qml" line="996"/>
         <source>Region</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1721,35 +1759,34 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Optimizing</source>
         <translation>Optimalizácia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>Paused</source>
         <translation>Pozastavené</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>In progress</source>
         <translation>Prebieha</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>%1 indexed</source>
         <translation>%1 indexovaných</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>%1 scraped</source>
-        <translation>%1 zozbieraných</translation>
+        <translation type="vanished">%1 zozbieraných</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Cancel</source>
         <translation>Zrušiť</translation>
     </message>
@@ -1758,117 +1795,117 @@ Français - Wilfried</source>
         <translation type="vanished">Spustiť</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Upload</source>
         <translation>Nahrať</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="650"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Open</source>
         <translation>Otvoriť</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>%1 × %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Automatic (Recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="717"/>
         <source>%1 (Animations off)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="758"/>
         <source>English</source>
         <translation>Angličtina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="760"/>
         <source>Italian</source>
         <translation>Taliančina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="756"/>
+        <location filename="../screens/SettingsScreen.qml" line="762"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="758"/>
+        <location filename="../screens/SettingsScreen.qml" line="764"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="760"/>
+        <location filename="../screens/SettingsScreen.qml" line="766"/>
         <source>German</source>
         <translation>Nemčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="762"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Greek</source>
         <translation>Gréčtina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="764"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Japanese</source>
         <translation>Japončina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="766"/>
+        <location filename="../screens/SettingsScreen.qml" line="772"/>
         <source>Korean</source>
         <translation>Kórejčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Dutch</source>
         <translation>Holandčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="776"/>
         <source>Romanian</source>
         <translation>Rumunčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="778"/>
         <source>Slovak</source>
         <translation>Slovenčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="774"/>
+        <location filename="../screens/SettingsScreen.qml" line="780"/>
         <source>Ukrainian</source>
         <translation>Ukrajinčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="776"/>
+        <location filename="../screens/SettingsScreen.qml" line="782"/>
         <source>Chinese (Simplified)</source>
         <translation>Čínština (zjednodušená)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="778"/>
+        <location filename="../screens/SettingsScreen.qml" line="784"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="780"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Hebrew</source>
         <translation>Hebrejčina</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="782"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="784"/>
+        <location filename="../screens/SettingsScreen.qml" line="790"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>French</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1877,37 +1914,37 @@ Français - Wilfried</source>
         <translation type="vanished">Automaticky</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="792"/>
+        <location filename="../screens/SettingsScreen.qml" line="798"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="794"/>
+        <location filename="../screens/SettingsScreen.qml" line="800"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="805"/>
+        <location filename="../screens/SettingsScreen.qml" line="811"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="807"/>
+        <location filename="../screens/SettingsScreen.qml" line="813"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="809"/>
+        <location filename="../screens/SettingsScreen.qml" line="815"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
-        <location filename="../screens/SettingsScreen.qml" line="787"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
-        <location filename="../screens/SettingsScreen.qml" line="810"/>
-        <location filename="../screens/SettingsScreen.qml" line="877"/>
-        <location filename="../screens/SettingsScreen.qml" line="925"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="793"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
+        <location filename="../screens/SettingsScreen.qml" line="816"/>
+        <location filename="../screens/SettingsScreen.qml" line="883"/>
+        <location filename="../screens/SettingsScreen.qml" line="931"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1962,19 +1999,14 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Downloads box art, descriptions, and tags for your games. Choose a source and which systems.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
-        <location filename="../screens/SettingsScreen.qml" line="1008"/>
+        <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="285"/>
-        <location filename="../screens/SettingsScreen.qml" line="1017"/>
+        <location filename="../screens/SettingsScreen.qml" line="1023"/>
         <source>Games layout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1989,93 +2021,93 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <location filename="../screens/SettingsScreen.qml" line="324"/>
         <source>Writes extra detail to the log file to help track down a problem. Restarts the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Configure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="815"/>
+        <location filename="../screens/SettingsScreen.qml" line="821"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="817"/>
+        <location filename="../screens/SettingsScreen.qml" line="823"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="818"/>
+        <location filename="../screens/SettingsScreen.qml" line="824"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="823"/>
+        <location filename="../screens/SettingsScreen.qml" line="829"/>
         <source>Detailed list view</source>
         <translation>Podrobné zobrazenie zoznamu</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="824"/>
+        <location filename="../screens/SettingsScreen.qml" line="830"/>
         <source>Grid view</source>
         <translation>Zobrazenie mriežky</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="829"/>
+        <location filename="../screens/SettingsScreen.qml" line="835"/>
         <source>Full color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="830"/>
+        <location filename="../screens/SettingsScreen.qml" line="836"/>
         <source>Tinted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="868"/>
+        <location filename="../screens/SettingsScreen.qml" line="874"/>
         <source>Style B</source>
         <translation>Štýl B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="870"/>
+        <location filename="../screens/SettingsScreen.qml" line="876"/>
         <source>Style C</source>
         <translation>Štýl C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="872"/>
+        <location filename="../screens/SettingsScreen.qml" line="878"/>
         <source>Style D</source>
         <translation>Štýl D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="874"/>
+        <location filename="../screens/SettingsScreen.qml" line="880"/>
         <source>Style E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="876"/>
+        <location filename="../screens/SettingsScreen.qml" line="882"/>
         <source>Style A</source>
         <translation>Štýl A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="917"/>
+        <location filename="../screens/SettingsScreen.qml" line="923"/>
         <source>PAL (50 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="919"/>
+        <location filename="../screens/SettingsScreen.qml" line="925"/>
         <source>480i (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="920"/>
+        <location filename="../screens/SettingsScreen.qml" line="926"/>
         <source>NTSC (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1905"/>
+        <location filename="../screens/SettingsScreen.qml" line="1911"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2084,47 +2116,47 @@ Français - Wilfried</source>
         <translation type="vanished">Predvolené</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="892"/>
+        <location filename="../screens/SettingsScreen.qml" line="898"/>
         <source>Off</source>
         <translation>Vypnuté</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="894"/>
+        <location filename="../screens/SettingsScreen.qml" line="900"/>
         <source>1 second (testing)</source>
         <translation>1 sekunda (test)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="896"/>
+        <location filename="../screens/SettingsScreen.qml" line="902"/>
         <source>1 minute</source>
         <translation>1 minúta</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="898"/>
+        <location filename="../screens/SettingsScreen.qml" line="904"/>
         <source>2 minutes</source>
         <translation>2 minúty</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="900"/>
+        <location filename="../screens/SettingsScreen.qml" line="906"/>
         <source>5 minutes</source>
         <translation>5 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="902"/>
+        <location filename="../screens/SettingsScreen.qml" line="908"/>
         <source>10 minutes</source>
         <translation>10 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="904"/>
+        <location filename="../screens/SettingsScreen.qml" line="910"/>
         <source>15 minutes</source>
         <translation>15 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="906"/>
+        <location filename="../screens/SettingsScreen.qml" line="912"/>
         <source>30 minutes</source>
         <translation>30 minút</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="907"/>
+        <location filename="../screens/SettingsScreen.qml" line="913"/>
         <source>%1 seconds</source>
         <translation>%1 sekúnd</translation>
     </message>
@@ -2134,93 +2166,93 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="108"/>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="855"/>
+        <location filename="../screens/SettingsScreen.qml" line="861"/>
         <source>Nord</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="852"/>
+        <location filename="../screens/SettingsScreen.qml" line="858"/>
         <source>Dracula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="859"/>
+        <location filename="../screens/SettingsScreen.qml" line="865"/>
         <source>Synthwave &apos;84</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="846"/>
+        <location filename="../screens/SettingsScreen.qml" line="852"/>
         <source>Amber Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="848"/>
+        <location filename="../screens/SettingsScreen.qml" line="854"/>
         <source>Green Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="849"/>
+        <location filename="../screens/SettingsScreen.qml" line="855"/>
         <source>Neo Geo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="850"/>
+        <location filename="../screens/SettingsScreen.qml" line="856"/>
         <source>NES</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="851"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>Virtual Boy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="854"/>
+        <location filename="../screens/SettingsScreen.qml" line="860"/>
         <source>Gruvbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="853"/>
+        <location filename="../screens/SettingsScreen.qml" line="859"/>
         <source>Everforest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="858"/>
+        <location filename="../screens/SettingsScreen.qml" line="864"/>
         <source>Solarized Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="863"/>
         <source>Rosé Pine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="856"/>
+        <location filename="../screens/SettingsScreen.qml" line="862"/>
         <source>Oxocarbon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="860"/>
+        <location filename="../screens/SettingsScreen.qml" line="866"/>
         <source>Flexoki Paper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="861"/>
+        <location filename="../screens/SettingsScreen.qml" line="867"/>
         <source>Solarized Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="847"/>
+        <location filename="../screens/SettingsScreen.qml" line="853"/>
         <source>Game Boy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2270,6 +2302,16 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="269"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="280"/>
         <source>Show systems as a grid of covers, or as a list with details beside it.</source>
         <translation type="unfinished"></translation>
@@ -2290,92 +2332,107 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="324"/>
+        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <source>Shows a code you can scan to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="330"/>
         <source>Uploads the log file and gives you a link to share when reporting a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="927"/>
-        <source>Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="929"/>
-        <source>Thumbnail</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="931"/>
-        <source>Box art</source>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <source>%1 imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="933"/>
-        <source>3D box art</source>
+        <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="935"/>
-        <source>Screenshot</source>
+        <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="937"/>
-        <source>Wheel</source>
+        <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="939"/>
-        <source>Title screen</source>
+        <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="941"/>
-        <source>Map</source>
+        <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="943"/>
-        <source>Marquee</source>
+        <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="945"/>
-        <source>Fan art</source>
+        <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="947"/>
-        <source>Box side</source>
+        <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="949"/>
+        <source>Marquee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="951"/>
+        <source>Fan art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="953"/>
+        <source>Box side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="955"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="355"/>
+        <location filename="../screens/SettingsScreen.qml" line="361"/>
         <source>Settings</source>
         <translation>Nastavenia</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="843"/>
+        <location filename="../screens/SettingsScreen.qml" line="849"/>
         <source>Zaparoo Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="844"/>
+        <location filename="../screens/SettingsScreen.qml" line="850"/>
         <source>Zaparoo Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="845"/>
+        <location filename="../screens/SettingsScreen.qml" line="851"/>
         <source>Classic Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1887"/>
+        <location filename="../screens/SettingsScreen.qml" line="1893"/>
         <source>No settings available on this platform</source>
         <translation>Na tejto platforme nie sú dostupné žiadne nastavenia</translation>
     </message>
@@ -2414,9 +2471,33 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/StatusLine.qml" line="105"/>
+        <source>Importing paused: game running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Import failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Imported %1 of %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scraping…</source>
-        <translation type="unfinished">Prebieha sťahovanie…</translation>
+        <translation type="obsolete">Prebieha sťahovanie…</translation>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
@@ -2445,16 +2526,6 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="105"/>
-        <source>Scraping paused: game running</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="106"/>
-        <source>Scraping: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>%1 files</source>
         <translation type="obsolete">%1 súborov</translation>
     </message>
@@ -2470,16 +2541,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scraped %1 of %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -2112,7 +2112,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1911"/>
+        <location filename="../screens/SettingsScreen.qml" line="1913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2432,7 +2432,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1893"/>
+        <location filename="../screens/SettingsScreen.qml" line="1895"/>
         <source>No settings available on this platform</source>
         <translation>Na tejto platforme nie sú dostupné žiadne nastavenia</translation>
     </message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -1999,6 +1999,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
         <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
@@ -2304,11 +2309,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Get metadata</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_sk.ts
+++ b/src/ui/translations/frontend_sk.ts
@@ -35,8 +35,8 @@
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="212"/>
-        <source>Commercial licensing: legal@zaparoo.org</source>
-        <translation>Komerčné licencovanie: legal@zaparoo.org</translation>
+        <source>Commercial licensing: legal@zaparoo.com</source>
+        <translation>Komerčné licencovanie: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="223"/>
@@ -227,8 +227,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="116"/>
-        <source>Contact: legal@zaparoo.org</source>
-        <translation>Kontakt: legal@zaparoo.org</translation>
+        <source>Contact: legal@zaparoo.com</source>
+        <translation>Kontakt: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="127"/>
@@ -1532,27 +1532,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
-        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <source>Documentation: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="225"/>
         <source>Loading sources…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="262"/>
         <source>Replace existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="276"/>
         <source>Start import</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1561,7 +1561,7 @@ Français - Wilfried</source>
         <translation type="obsolete">Získať metadáta</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="249"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -391,45 +391,6 @@ Français - Wilfried</source>
     </message>
 </context>
 <context>
-    <name>FirstRunIndexModal</name>
-    <message>
-        <source>First-time setup</source>
-        <translation type="vanished">Початкове налаштування</translation>
-    </message>
-    <message>
-        <source>Indexing paused</source>
-        <translation type="vanished">Індексування призупинено</translation>
-    </message>
-    <message>
-        <source>Optimizing database - almost done</source>
-        <translation type="vanished">Оптимізація бази даних – майже готово</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2 - %3</source>
-        <translation type="vanished">Крок %1 з %2 – %3</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2</source>
-        <translation type="vanished">Крок %1 з %2</translation>
-    </message>
-    <message>
-        <source>Preparing…</source>
-        <translation type="vanished">Підготовка…</translation>
-    </message>
-    <message>
-        <source>Done. %1 files indexed.</source>
-        <translation type="vanished">Готово. Проіндексовано %1 файлів.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Скасувати</translation>
-    </message>
-    <message>
-        <source>Start scan</source>
-        <translation type="vanished">Почати сканування</translation>
-    </message>
-</context>
-<context>
     <name>GameInfoModal</name>
     <message>
         <location filename="../components/GameInfoModal.qml" line="153"/>
@@ -542,6 +503,26 @@ Français - Wilfried</source>
         <translation>Вибране</translation>
     </message>
     <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>Updating the media database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>No games found yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Your games appear here as Core finds them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Update media database in Settings &gt; Library.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Recently Played</source>
         <translation type="vanished">Нещодавно зіграні</translation>
     </message>
@@ -571,35 +552,44 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
-        <translation>Немає доступних систем. Запустіть Оновлення бази даних з Налаштувань.</translation>
+        <translation type="vanished">Немає доступних систем. Запустіть Оновлення бази даних з Налаштувань.</translation>
     </message>
 </context>
 <context>
     <name>IndexSetupModal</name>
     <message>
         <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Start</source>
+        <translation type="unfinished">Почати</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Change</source>
+        <translation type="unfinished">Змінити</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="51"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="47"/>
+        <location filename="../components/IndexSetupModal.qml" line="53"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="115"/>
+        <location filename="../components/IndexSetupModal.qml" line="121"/>
         <source>Update media database</source>
         <translation type="unfinished">Оновити базу медіа</translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="124"/>
+        <location filename="../components/IndexSetupModal.qml" line="130"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="137"/>
+        <location filename="../components/IndexSetupModal.qml" line="143"/>
         <source>Start update</source>
         <translation type="unfinished"></translation>
     </message>
@@ -677,29 +667,29 @@ Français - Wilfried</source>
         <translation type="vanished">Запустити core</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
-        <location filename="../app/Main.qml" line="2330"/>
-        <location filename="../app/Main.qml" line="2393"/>
-        <location filename="../app/Main.qml" line="2699"/>
-        <location filename="../app/Main.qml" line="3741"/>
-        <location filename="../app/Main.qml" line="3784"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
+        <location filename="../app/Main.qml" line="2341"/>
+        <location filename="../app/Main.qml" line="2410"/>
+        <location filename="../app/Main.qml" line="2716"/>
+        <location filename="../app/Main.qml" line="3795"/>
+        <location filename="../app/Main.qml" line="3838"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Remove from favorites</source>
         <translation>Видалити з вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Add to favorites</source>
         <translation>Додати до вибраного</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2264"/>
-        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2266"/>
+        <location filename="../app/Main.qml" line="2346"/>
         <source>Write to NFC token</source>
         <translation>Записати на NFC-токен</translation>
     </message>
@@ -708,53 +698,76 @@ Français - Wilfried</source>
         <translation type="vanished">QR-код</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
-        <location filename="../app/Main.qml" line="2308"/>
+        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2319"/>
         <source>Launch game</source>
         <translation>Запустити гру</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1070"/>
-        <location filename="../app/Main.qml" line="3417"/>
-        <location filename="../app/Main.qml" line="3464"/>
-        <location filename="../app/Main.qml" line="3474"/>
+        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3518"/>
+        <location filename="../app/Main.qml" line="3528"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3153"/>
+        <source>Get metadata failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3154"/>
+        <source>Could not start getting metadata. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3156"/>
+        <source>Source list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3157"/>
+        <source>Could not load the list of metadata sources. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3307"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4848"/>
+        <location filename="../app/Main.qml" line="4902"/>
         <source>Loading systems…</source>
         <translation>Завантаження систем…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4855"/>
+        <location filename="../app/Main.qml" line="4909"/>
         <source>Loading favorites…</source>
         <translation>Завантаження вибраного…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4850"/>
+        <location filename="../app/Main.qml" line="4904"/>
         <source>Loading games…</source>
         <translation>Завантаження ігор…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2183"/>
-        <location filename="../app/Main.qml" line="2218"/>
+        <location filename="../app/Main.qml" line="2185"/>
+        <location filename="../app/Main.qml" line="2220"/>
         <source>Update media database</source>
         <translation type="unfinished">Оновити базу медіа</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2186"/>
-        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
-        <translation type="unfinished">Отримати метадані</translation>
+        <translation type="obsolete">Отримати метадані</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2179"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
@@ -764,90 +777,90 @@ Français - Wilfried</source>
         <translation type="unfinished">Налаштування</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2096"/>
+        <location filename="../app/Main.qml" line="2098"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2153"/>
+        <location filename="../app/Main.qml" line="2155"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2179"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2258"/>
-        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2323"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
-        <location filename="../app/Main.qml" line="2346"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2280"/>
+        <location filename="../app/Main.qml" line="2357"/>
+        <location filename="../app/Main.qml" line="2451"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3507"/>
+        <location filename="../app/Main.qml" line="2395"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3561"/>
         <source>Default</source>
         <translation type="unfinished">Типовий</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2395"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2230"/>
-        <location filename="../app/Main.qml" line="2238"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="2164"/>
+        <location filename="../app/Main.qml" line="2215"/>
+        <location filename="../app/Main.qml" line="2232"/>
+        <location filename="../app/Main.qml" line="2240"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3454"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3445"/>
+        <location filename="../app/Main.qml" line="3499"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3460"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3511"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3565"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3482"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3515"/>
+        <location filename="../app/Main.qml" line="3569"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3436"/>
+        <location filename="../app/Main.qml" line="3490"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -872,45 +885,46 @@ Français - Wilfried</source>
         <translation type="unfinished">Вийти</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2173"/>
-        <location filename="../app/Main.qml" line="2282"/>
-        <location filename="../app/Main.qml" line="2301"/>
-        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2284"/>
+        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2361"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2268"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2270"/>
+        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2807"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2461"/>
+        <location filename="../app/Main.qml" line="2478"/>
         <source>Move</source>
         <translation type="unfinished">Переміщення</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2667"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1032"/>
-        <location filename="../app/Main.qml" line="3043"/>
-        <location filename="../app/Main.qml" line="3065"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3131"/>
+        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3174"/>
         <source>OK</source>
         <translation type="unfinished">Гаразд</translation>
     </message>
@@ -925,226 +939,224 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="2188"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2293"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2807"/>
+        <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Scan this code to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3132"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3098"/>
+        <location filename="../app/Main.qml" line="3141"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3099"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3101"/>
+        <location filename="../app/Main.qml" line="3144"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3147"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3105"/>
+        <location filename="../app/Main.qml" line="3148"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3107"/>
+        <location filename="../app/Main.qml" line="3150"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3151"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3110"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3111"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3113"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3114"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3116"/>
+        <location filename="../app/Main.qml" line="3159"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3120"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3122"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3123"/>
+        <location filename="../app/Main.qml" line="3166"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3125"/>
+        <location filename="../app/Main.qml" line="3168"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3126"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3128"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3129"/>
+        <location filename="../app/Main.qml" line="3172"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3253"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3269"/>
+        <location filename="../app/Main.qml" line="3323"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3278"/>
+        <location filename="../app/Main.qml" line="3332"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3307"/>
+        <location filename="../app/Main.qml" line="3361"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3446"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3432"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3486"/>
         <source>Favorites</source>
         <translation type="unfinished">Вибране</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3415"/>
-        <location filename="../app/Main.qml" line="3461"/>
+        <location filename="../app/Main.qml" line="3469"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3449"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3503"/>
+        <location filename="../app/Main.qml" line="3525"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3489"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3485"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3492"/>
+        <location filename="../app/Main.qml" line="3546"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3708"/>
+        <location filename="../app/Main.qml" line="3762"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3119"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
-        <location filename="../app/Main.qml" line="3318"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="2910"/>
+        <location filename="../app/Main.qml" line="3372"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Retry</source>
         <translation type="unfinished">Повторити</translation>
     </message>
@@ -1153,22 +1165,22 @@ Français - Wilfried</source>
         <translation type="obsolete">Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4852"/>
+        <location filename="../app/Main.qml" line="4906"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4857"/>
+        <location filename="../app/Main.qml" line="4911"/>
         <source>Loading recently played…</source>
         <translation>Завантаження нещодавніх…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4859"/>
+        <location filename="../app/Main.qml" line="4913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4861"/>
+        <location filename="../app/Main.qml" line="4915"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>
@@ -1176,7 +1188,7 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Writing failed</source>
         <translation>Помилка запису</translation>
     </message>
@@ -1185,82 +1197,83 @@ Français - Wilfried</source>
         <translation type="vanished">Прикладіть картку для запису до зчитувача</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="936"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="943"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="1365"/>
         <source>OK</source>
         <translation type="unfinished">Гаразд</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="535"/>
+        <location filename="../app/MainLayout.qml" line="541"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Hold a writable token near the reader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
         <source>Are you sure you want to exit?</source>
         <translation>Ви впевнені, що хочете вийти?</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1387"/>
+        <location filename="../app/MainLayout.qml" line="1409"/>
         <source>Select</source>
         <translation>Вибрати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1283"/>
-        <location filename="../app/MainLayout.qml" line="1297"/>
-        <location filename="../app/MainLayout.qml" line="1312"/>
-        <location filename="../app/MainLayout.qml" line="1323"/>
-        <location filename="../app/MainLayout.qml" line="1349"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1321"/>
+        <location filename="../app/MainLayout.qml" line="1332"/>
+        <location filename="../app/MainLayout.qml" line="1358"/>
         <source>Close</source>
         <translation>Закрити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1425"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1339"/>
+        <location filename="../app/MainLayout.qml" line="1391"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1308"/>
+        <location filename="../app/MainLayout.qml" line="1317"/>
         <source>Done</source>
         <translation>Готово</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1338"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
         <source>I understand</source>
         <translation>Я розумію</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1376"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1389"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1269,28 +1282,29 @@ Français - Wilfried</source>
         <translation type="vanished">Почати</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1656"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Scroll</source>
         <translation>Прокрутка</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1468"/>
-        <location filename="../app/MainLayout.qml" line="1555"/>
-        <location filename="../app/MainLayout.qml" line="1573"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
-        <location filename="../app/MainLayout.qml" line="1724"/>
+        <location filename="../app/MainLayout.qml" line="1500"/>
+        <location filename="../app/MainLayout.qml" line="1587"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1737"/>
+        <location filename="../app/MainLayout.qml" line="1756"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1374"/>
-        <location filename="../app/MainLayout.qml" line="1454"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1596"/>
-        <location filename="../app/MainLayout.qml" line="1615"/>
-        <location filename="../app/MainLayout.qml" line="1688"/>
+        <location filename="../app/MainLayout.qml" line="1284"/>
+        <location filename="../app/MainLayout.qml" line="1383"/>
+        <location filename="../app/MainLayout.qml" line="1405"/>
+        <location filename="../app/MainLayout.qml" line="1486"/>
+        <location filename="../app/MainLayout.qml" line="1523"/>
+        <location filename="../app/MainLayout.qml" line="1572"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1647"/>
+        <location filename="../app/MainLayout.qml" line="1720"/>
         <source>Move</source>
         <translation>Переміщення</translation>
     </message>
@@ -1300,8 +1314,8 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="531"/>
-        <location filename="../app/MainLayout.qml" line="533"/>
+        <location filename="../app/MainLayout.qml" line="537"/>
+        <location filename="../app/MainLayout.qml" line="539"/>
         <source>Favorites</source>
         <translation type="unfinished">Вибране</translation>
     </message>
@@ -1310,36 +1324,36 @@ Français - Wilfried</source>
         <translation type="obsolete">Нещодавно зіграні</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="916"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="917"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1096"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1417"/>
+        <location filename="../app/MainLayout.qml" line="1449"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1421"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1496"/>
-        <location filename="../app/MainLayout.qml" line="1545"/>
-        <location filename="../app/MainLayout.qml" line="1601"/>
-        <location filename="../app/MainLayout.qml" line="1693"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1528"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1633"/>
+        <location filename="../app/MainLayout.qml" line="1725"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
@@ -1348,19 +1362,20 @@ Français - Wilfried</source>
         <translation type="vanished">Вийти</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1477"/>
-        <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1513"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1559"/>
-        <location filename="../app/MainLayout.qml" line="1577"/>
-        <location filename="../app/MainLayout.qml" line="1589"/>
-        <location filename="../app/MainLayout.qml" line="1605"/>
-        <location filename="../app/MainLayout.qml" line="1639"/>
-        <location filename="../app/MainLayout.qml" line="1660"/>
-        <location filename="../app/MainLayout.qml" line="1669"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
-        <location filename="../app/MainLayout.qml" line="1728"/>
+        <location filename="../app/MainLayout.qml" line="1413"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1561"/>
+        <location filename="../app/MainLayout.qml" line="1591"/>
+        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1621"/>
+        <location filename="../app/MainLayout.qml" line="1637"/>
+        <location filename="../app/MainLayout.qml" line="1671"/>
+        <location filename="../app/MainLayout.qml" line="1692"/>
+        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1741"/>
+        <location filename="../app/MainLayout.qml" line="1760"/>
         <source>Back</source>
         <translation>Назад</translation>
     </message>
@@ -1369,29 +1384,29 @@ Français - Wilfried</source>
         <translation type="vanished">Сторінка</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1464"/>
-        <location filename="../app/MainLayout.qml" line="1499"/>
-        <location filename="../app/MainLayout.qml" line="1550"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1531"/>
+        <location filename="../app/MainLayout.qml" line="1582"/>
+        <location filename="../app/MainLayout.qml" line="1730"/>
         <source>Options</source>
         <translation>Параметри</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1509"/>
-        <location filename="../app/MainLayout.qml" line="1567"/>
-        <location filename="../app/MainLayout.qml" line="1716"/>
+        <location filename="../app/MainLayout.qml" line="1328"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1541"/>
+        <location filename="../app/MainLayout.qml" line="1599"/>
+        <location filename="../app/MainLayout.qml" line="1748"/>
         <source>Retry</source>
         <translation>Повторити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1624"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Change</source>
         <translation>Змінити</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1630"/>
+        <location filename="../app/MainLayout.qml" line="1662"/>
         <source>Toggle</source>
         <translation>Перемкнути</translation>
     </message>
@@ -1452,12 +1467,12 @@ Français - Wilfried</source>
 <context>
     <name>QrCodeModal</name>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="23"/>
+        <location filename="../components/QrCodeModal.qml" line="19"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="43"/>
+        <location filename="../components/QrCodeModal.qml" line="20"/>
         <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1487,43 +1502,67 @@ Français - Wilfried</source>
 <context>
     <name>ScrapeSetupModal</name>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="67"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Start</source>
+        <translation type="unfinished">Почати</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Toggle</source>
+        <translation type="unfinished">Перемкнути</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Change</source>
+        <translation type="unfinished">Змінити</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="89"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="69"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="91"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="171"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="193"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
+        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <source>Loading sources…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <source>Replace existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <source>Start import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scrape metadata</source>
-        <translation type="unfinished">Отримати метадані</translation>
+        <translation type="obsolete">Отримати метадані</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="185"/>
-        <source>Loading scrapers…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="196"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
         <source>Systems</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="222"/>
-        <source>Re-scrape existing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
-        <source>Start scrape</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1535,17 +1574,17 @@ Français - Wilfried</source>
         <translation>Тут нічого немає</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="36"/>
         <source>Loading…</source>
         <translation>Завантаження…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="37"/>
         <source>Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="79"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="85"/>
         <source>Failed to load</source>
         <translation>Не вдалося завантажити</translation>
     </message>
@@ -1555,8 +1594,8 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="114"/>
         <location filename="../screens/SettingsScreen.qml" line="205"/>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
-        <location filename="../screens/SettingsScreen.qml" line="972"/>
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="978"/>
         <source>Language</source>
         <translation>Мова</translation>
     </message>
@@ -1580,50 +1619,49 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="165"/>
-        <location filename="../screens/SettingsScreen.qml" line="999"/>
+        <location filename="../screens/SettingsScreen.qml" line="1005"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="225"/>
-        <location filename="../screens/SettingsScreen.qml" line="1051"/>
+        <location filename="../screens/SettingsScreen.qml" line="1057"/>
         <source>Button style</source>
         <translation>Стиль кнопок</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="1060"/>
+        <location filename="../screens/SettingsScreen.qml" line="1066"/>
         <source>Screensaver</source>
         <translation>Заставка</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Library</source>
         <translation>Бібліотека</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="291"/>
-        <location filename="../screens/SettingsScreen.qml" line="1069"/>
+        <location filename="../screens/SettingsScreen.qml" line="1075"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Scrape metadata</source>
-        <translation>Отримати метадані</translation>
+        <translation type="vanished">Отримати метадані</translation>
     </message>
     <message>
         <source>Advanced</source>
         <translation type="vanished">Розширені</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <location filename="../screens/SettingsScreen.qml" line="323"/>
         <source>Debug logging</source>
         <translation>Журнал відлагодження</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="323"/>
+        <location filename="../screens/SettingsScreen.qml" line="329"/>
         <source>Upload log file</source>
         <translation>Завантажити файл журналу</translation>
     </message>
@@ -1634,7 +1672,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="217"/>
-        <location filename="../screens/SettingsScreen.qml" line="981"/>
+        <location filename="../screens/SettingsScreen.qml" line="987"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1645,13 +1683,13 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="158"/>
-        <location filename="../screens/SettingsScreen.qml" line="963"/>
+        <location filename="../screens/SettingsScreen.qml" line="969"/>
         <source>Interface resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="129"/>
-        <location filename="../screens/SettingsScreen.qml" line="1035"/>
+        <location filename="../screens/SettingsScreen.qml" line="1041"/>
         <source>Color scheme</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1667,7 +1705,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <location filename="../screens/SettingsScreen.qml" line="1078"/>
+        <location filename="../screens/SettingsScreen.qml" line="1084"/>
         <source>Video standard</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1678,7 +1716,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="135"/>
-        <location filename="../screens/SettingsScreen.qml" line="1026"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
         <source>System logos</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1699,19 +1737,19 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="90"/>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="120"/>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="211"/>
-        <location filename="../screens/SettingsScreen.qml" line="990"/>
+        <location filename="../screens/SettingsScreen.qml" line="996"/>
         <source>Region</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1721,35 +1759,34 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Optimizing</source>
         <translation>Оптимізація</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>Paused</source>
         <translation>Призупинено</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>In progress</source>
         <translation>Виконується</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>%1 indexed</source>
         <translation>%1 проіндексовано</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>%1 scraped</source>
-        <translation>%1 зібрано</translation>
+        <translation type="vanished">%1 зібрано</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Cancel</source>
         <translation>Скасувати</translation>
     </message>
@@ -1758,117 +1795,117 @@ Français - Wilfried</source>
         <translation type="vanished">Почати</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Upload</source>
         <translation>Вивантажити</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="650"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Open</source>
         <translation>Відкрити</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>%1 × %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Automatic (Recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="717"/>
         <source>%1 (Animations off)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="758"/>
         <source>English</source>
         <translation>Англійська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="760"/>
         <source>Italian</source>
         <translation>Італійська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="756"/>
+        <location filename="../screens/SettingsScreen.qml" line="762"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="758"/>
+        <location filename="../screens/SettingsScreen.qml" line="764"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="760"/>
+        <location filename="../screens/SettingsScreen.qml" line="766"/>
         <source>German</source>
         <translation>Німецька</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="762"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Greek</source>
         <translation>Грецька</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="764"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Japanese</source>
         <translation>Японська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="766"/>
+        <location filename="../screens/SettingsScreen.qml" line="772"/>
         <source>Korean</source>
         <translation>Корейська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Dutch</source>
         <translation>Нідерландська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="776"/>
         <source>Romanian</source>
         <translation>Румунська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="778"/>
         <source>Slovak</source>
         <translation>Словацька</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="774"/>
+        <location filename="../screens/SettingsScreen.qml" line="780"/>
         <source>Ukrainian</source>
         <translation>Українська</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="776"/>
+        <location filename="../screens/SettingsScreen.qml" line="782"/>
         <source>Chinese (Simplified)</source>
         <translation>Китайська (спрощена)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="778"/>
+        <location filename="../screens/SettingsScreen.qml" line="784"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="780"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Hebrew</source>
         <translation>Іврит</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="782"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="784"/>
+        <location filename="../screens/SettingsScreen.qml" line="790"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>French</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1877,37 +1914,37 @@ Français - Wilfried</source>
         <translation type="vanished">Автоматично</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="792"/>
+        <location filename="../screens/SettingsScreen.qml" line="798"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="794"/>
+        <location filename="../screens/SettingsScreen.qml" line="800"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="805"/>
+        <location filename="../screens/SettingsScreen.qml" line="811"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="807"/>
+        <location filename="../screens/SettingsScreen.qml" line="813"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="809"/>
+        <location filename="../screens/SettingsScreen.qml" line="815"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
-        <location filename="../screens/SettingsScreen.qml" line="787"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
-        <location filename="../screens/SettingsScreen.qml" line="810"/>
-        <location filename="../screens/SettingsScreen.qml" line="877"/>
-        <location filename="../screens/SettingsScreen.qml" line="925"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="793"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
+        <location filename="../screens/SettingsScreen.qml" line="816"/>
+        <location filename="../screens/SettingsScreen.qml" line="883"/>
+        <location filename="../screens/SettingsScreen.qml" line="931"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1962,19 +1999,14 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Downloads box art, descriptions, and tags for your games. Choose a source and which systems.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
-        <location filename="../screens/SettingsScreen.qml" line="1008"/>
+        <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="285"/>
-        <location filename="../screens/SettingsScreen.qml" line="1017"/>
+        <location filename="../screens/SettingsScreen.qml" line="1023"/>
         <source>Games layout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1989,93 +2021,93 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <location filename="../screens/SettingsScreen.qml" line="324"/>
         <source>Writes extra detail to the log file to help track down a problem. Restarts the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Configure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="815"/>
+        <location filename="../screens/SettingsScreen.qml" line="821"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="817"/>
+        <location filename="../screens/SettingsScreen.qml" line="823"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="818"/>
+        <location filename="../screens/SettingsScreen.qml" line="824"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="823"/>
+        <location filename="../screens/SettingsScreen.qml" line="829"/>
         <source>Detailed list view</source>
         <translation>Детальний перегляд списку</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="824"/>
+        <location filename="../screens/SettingsScreen.qml" line="830"/>
         <source>Grid view</source>
         <translation>Перегляд сіткою</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="829"/>
+        <location filename="../screens/SettingsScreen.qml" line="835"/>
         <source>Full color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="830"/>
+        <location filename="../screens/SettingsScreen.qml" line="836"/>
         <source>Tinted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="868"/>
+        <location filename="../screens/SettingsScreen.qml" line="874"/>
         <source>Style B</source>
         <translation>Стиль B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="870"/>
+        <location filename="../screens/SettingsScreen.qml" line="876"/>
         <source>Style C</source>
         <translation>Стиль C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="872"/>
+        <location filename="../screens/SettingsScreen.qml" line="878"/>
         <source>Style D</source>
         <translation>Стиль D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="874"/>
+        <location filename="../screens/SettingsScreen.qml" line="880"/>
         <source>Style E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="876"/>
+        <location filename="../screens/SettingsScreen.qml" line="882"/>
         <source>Style A</source>
         <translation>Стиль A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="917"/>
+        <location filename="../screens/SettingsScreen.qml" line="923"/>
         <source>PAL (50 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="919"/>
+        <location filename="../screens/SettingsScreen.qml" line="925"/>
         <source>480i (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="920"/>
+        <location filename="../screens/SettingsScreen.qml" line="926"/>
         <source>NTSC (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1905"/>
+        <location filename="../screens/SettingsScreen.qml" line="1911"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2084,47 +2116,47 @@ Français - Wilfried</source>
         <translation type="vanished">Типовий</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="892"/>
+        <location filename="../screens/SettingsScreen.qml" line="898"/>
         <source>Off</source>
         <translation>Вимкнено</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="894"/>
+        <location filename="../screens/SettingsScreen.qml" line="900"/>
         <source>1 second (testing)</source>
         <translation>1 секунда (тест)</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="896"/>
+        <location filename="../screens/SettingsScreen.qml" line="902"/>
         <source>1 minute</source>
         <translation>1 хвилина</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="898"/>
+        <location filename="../screens/SettingsScreen.qml" line="904"/>
         <source>2 minutes</source>
         <translation>2 хвилини</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="900"/>
+        <location filename="../screens/SettingsScreen.qml" line="906"/>
         <source>5 minutes</source>
         <translation>5 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="902"/>
+        <location filename="../screens/SettingsScreen.qml" line="908"/>
         <source>10 minutes</source>
         <translation>10 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="904"/>
+        <location filename="../screens/SettingsScreen.qml" line="910"/>
         <source>15 minutes</source>
         <translation>15 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="906"/>
+        <location filename="../screens/SettingsScreen.qml" line="912"/>
         <source>30 minutes</source>
         <translation>30 хвилин</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="907"/>
+        <location filename="../screens/SettingsScreen.qml" line="913"/>
         <source>%1 seconds</source>
         <translation>%1 секунд</translation>
     </message>
@@ -2134,93 +2166,93 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="108"/>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="855"/>
+        <location filename="../screens/SettingsScreen.qml" line="861"/>
         <source>Nord</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="852"/>
+        <location filename="../screens/SettingsScreen.qml" line="858"/>
         <source>Dracula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="859"/>
+        <location filename="../screens/SettingsScreen.qml" line="865"/>
         <source>Synthwave &apos;84</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="846"/>
+        <location filename="../screens/SettingsScreen.qml" line="852"/>
         <source>Amber Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="848"/>
+        <location filename="../screens/SettingsScreen.qml" line="854"/>
         <source>Green Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="849"/>
+        <location filename="../screens/SettingsScreen.qml" line="855"/>
         <source>Neo Geo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="850"/>
+        <location filename="../screens/SettingsScreen.qml" line="856"/>
         <source>NES</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="851"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>Virtual Boy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="854"/>
+        <location filename="../screens/SettingsScreen.qml" line="860"/>
         <source>Gruvbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="853"/>
+        <location filename="../screens/SettingsScreen.qml" line="859"/>
         <source>Everforest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="858"/>
+        <location filename="../screens/SettingsScreen.qml" line="864"/>
         <source>Solarized Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="863"/>
         <source>Rosé Pine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="856"/>
+        <location filename="../screens/SettingsScreen.qml" line="862"/>
         <source>Oxocarbon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="860"/>
+        <location filename="../screens/SettingsScreen.qml" line="866"/>
         <source>Flexoki Paper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="861"/>
+        <location filename="../screens/SettingsScreen.qml" line="867"/>
         <source>Solarized Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="847"/>
+        <location filename="../screens/SettingsScreen.qml" line="853"/>
         <source>Game Boy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2270,6 +2302,16 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="269"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="280"/>
         <source>Show systems as a grid of covers, or as a list with details beside it.</source>
         <translation type="unfinished"></translation>
@@ -2290,92 +2332,107 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="324"/>
+        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <source>Shows a code you can scan to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="330"/>
         <source>Uploads the log file and gives you a link to share when reporting a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="927"/>
-        <source>Image</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="929"/>
-        <source>Thumbnail</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="931"/>
-        <source>Box art</source>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <source>%1 imported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="933"/>
-        <source>3D box art</source>
+        <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="935"/>
-        <source>Screenshot</source>
+        <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="937"/>
-        <source>Wheel</source>
+        <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="939"/>
-        <source>Title screen</source>
+        <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="941"/>
-        <source>Map</source>
+        <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="943"/>
-        <source>Marquee</source>
+        <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="945"/>
-        <source>Fan art</source>
+        <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="947"/>
-        <source>Box side</source>
+        <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="949"/>
+        <source>Marquee</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="951"/>
+        <source>Fan art</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="953"/>
+        <source>Box side</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="955"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="355"/>
+        <location filename="../screens/SettingsScreen.qml" line="361"/>
         <source>Settings</source>
         <translation>Налаштування</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="843"/>
+        <location filename="../screens/SettingsScreen.qml" line="849"/>
         <source>Zaparoo Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="844"/>
+        <location filename="../screens/SettingsScreen.qml" line="850"/>
         <source>Zaparoo Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="845"/>
+        <location filename="../screens/SettingsScreen.qml" line="851"/>
         <source>Classic Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1887"/>
+        <location filename="../screens/SettingsScreen.qml" line="1893"/>
         <source>No settings available on this platform</source>
         <translation>На цій платформі налаштування недоступні</translation>
     </message>
@@ -2414,9 +2471,33 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/StatusLine.qml" line="105"/>
+        <source>Importing paused: game running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Import failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Imported %1 of %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scraping…</source>
-        <translation type="unfinished">Скрейпінг…</translation>
+        <translation type="obsolete">Скрейпінг…</translation>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
@@ -2445,16 +2526,6 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="105"/>
-        <source>Scraping paused: game running</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="106"/>
-        <source>Scraping: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>%1 files</source>
         <translation type="obsolete">%1 файлів</translation>
     </message>
@@ -2470,16 +2541,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scraped %1 of %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -2112,7 +2112,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1911"/>
+        <location filename="../screens/SettingsScreen.qml" line="1913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2432,7 +2432,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1893"/>
+        <location filename="../screens/SettingsScreen.qml" line="1895"/>
         <source>No settings available on this platform</source>
         <translation>На цій платформі налаштування недоступні</translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -35,8 +35,8 @@
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="212"/>
-        <source>Commercial licensing: legal@zaparoo.org</source>
-        <translation>Комерційне ліцензування: legal@zaparoo.org</translation>
+        <source>Commercial licensing: legal@zaparoo.com</source>
+        <translation>Комерційне ліцензування: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="223"/>
@@ -227,8 +227,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="116"/>
-        <source>Contact: legal@zaparoo.org</source>
-        <translation>Контакт: legal@zaparoo.org</translation>
+        <source>Contact: legal@zaparoo.com</source>
+        <translation>Контакт: legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="127"/>
@@ -1532,27 +1532,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
-        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <source>Documentation: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="225"/>
         <source>Loading sources…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="262"/>
         <source>Replace existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="276"/>
         <source>Start import</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1561,7 +1561,7 @@ Français - Wilfried</source>
         <translation type="obsolete">Отримати метадані</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="249"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_uk.ts
+++ b/src/ui/translations/frontend_uk.ts
@@ -1999,6 +1999,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
         <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
@@ -2304,11 +2309,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Get metadata</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -35,8 +35,8 @@
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="212"/>
-        <source>Commercial licensing: legal@zaparoo.org</source>
-        <translation>商业许可：legal@zaparoo.org</translation>
+        <source>Commercial licensing: legal@zaparoo.com</source>
+        <translation>商业许可：legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../screens/AboutScreen.qml" line="223"/>
@@ -227,8 +227,8 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="116"/>
-        <source>Contact: legal@zaparoo.org</source>
-        <translation>联系：legal@zaparoo.org</translation>
+        <source>Contact: legal@zaparoo.com</source>
+        <translation>联系：legal@zaparoo.com</translation>
     </message>
     <message>
         <location filename="../components/CommercialNoticeModal.qml" line="127"/>
@@ -1528,27 +1528,27 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
-        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <source>Documentation: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="225"/>
         <source>Loading sources…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="262"/>
         <source>Replace existing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="276"/>
         <source>Start import</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1557,7 +1557,7 @@ Français - Wilfried</source>
         <translation type="obsolete">抓取元数据</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="249"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -387,45 +387,6 @@ Français - Wilfried</source>
     </message>
 </context>
 <context>
-    <name>FirstRunIndexModal</name>
-    <message>
-        <source>First-time setup</source>
-        <translation type="vanished">首次设置</translation>
-    </message>
-    <message>
-        <source>Optimizing database - almost done</source>
-        <translation type="vanished">正在优化数据库 - 即将完成</translation>
-    </message>
-    <message>
-        <source>Indexing paused</source>
-        <translation type="vanished">索引已暂停</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2 - %3</source>
-        <translation type="vanished">第 %1 / %2 步 - %3</translation>
-    </message>
-    <message>
-        <source>Step %1 of %2</source>
-        <translation type="vanished">第 %1 / %2 步</translation>
-    </message>
-    <message>
-        <source>Preparing…</source>
-        <translation type="vanished">正在准备…</translation>
-    </message>
-    <message>
-        <source>Done. %1 files indexed.</source>
-        <translation type="vanished">完成。已索引 %1 个文件。</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">取消</translation>
-    </message>
-    <message>
-        <source>Start scan</source>
-        <translation type="vanished">开始扫描</translation>
-    </message>
-</context>
-<context>
     <name>GameInfoModal</name>
     <message>
         <location filename="../components/GameInfoModal.qml" line="153"/>
@@ -538,6 +499,26 @@ Français - Wilfried</source>
         <translation>收藏</translation>
     </message>
     <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>Updating the media database</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1615"/>
+        <source>No games found yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Your games appear here as Core finds them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/HubScreen.qml" line="1616"/>
+        <source>Update media database in Settings &gt; Library.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Recently Played</source>
         <translation type="vanished">最近游玩</translation>
     </message>
@@ -567,35 +548,44 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/HubScreen.qml" line="1609"/>
         <source>No systems available. Run Update media database from Settings.</source>
-        <translation>没有可用系统。请在“设置”中运行“更新媒体数据库”。</translation>
+        <translation type="vanished">没有可用系统。请在“设置”中运行“更新媒体数据库”。</translation>
     </message>
 </context>
 <context>
     <name>IndexSetupModal</name>
     <message>
         <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Start</source>
+        <translation type="unfinished">开始</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="45"/>
+        <source>Change</source>
+        <translation type="unfinished">更改</translation>
+    </message>
+    <message>
+        <location filename="../components/IndexSetupModal.qml" line="51"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="47"/>
+        <location filename="../components/IndexSetupModal.qml" line="53"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="115"/>
+        <location filename="../components/IndexSetupModal.qml" line="121"/>
         <source>Update media database</source>
         <translation type="unfinished">更新媒体数据库</translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="124"/>
+        <location filename="../components/IndexSetupModal.qml" line="130"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/IndexSetupModal.qml" line="137"/>
+        <location filename="../components/IndexSetupModal.qml" line="143"/>
         <source>Start update</source>
         <translation type="unfinished"></translation>
     </message>
@@ -673,30 +663,28 @@ Français - Wilfried</source>
         <translation type="vanished">启动核心</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
-        <location filename="../app/Main.qml" line="2330"/>
-        <location filename="../app/Main.qml" line="2393"/>
-        <location filename="../app/Main.qml" line="2699"/>
-        <location filename="../app/Main.qml" line="3741"/>
-        <location filename="../app/Main.qml" line="3784"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
+        <location filename="../app/Main.qml" line="2341"/>
+        <location filename="../app/Main.qml" line="2410"/>
+        <location filename="../app/Main.qml" line="2716"/>
+        <location filename="../app/Main.qml" line="3795"/>
+        <location filename="../app/Main.qml" line="3838"/>
         <source>Change launcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2183"/>
-        <location filename="../app/Main.qml" line="2218"/>
+        <location filename="../app/Main.qml" line="2185"/>
+        <location filename="../app/Main.qml" line="2220"/>
         <source>Update media database</source>
         <translation type="unfinished">更新媒体数据库</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2186"/>
-        <location filename="../app/Main.qml" line="2221"/>
         <source>Scrape metadata</source>
-        <translation type="unfinished">抓取元数据</translation>
+        <translation type="obsolete">抓取元数据</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
+        <location filename="../app/Main.qml" line="2179"/>
         <source>Unhide</source>
         <translation type="unfinished"></translation>
     </message>
@@ -706,53 +694,53 @@ Français - Wilfried</source>
         <translation type="unfinished">设置</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2096"/>
+        <location filename="../app/Main.qml" line="2098"/>
         <source>No alternates found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2153"/>
+        <location filename="../app/Main.qml" line="2155"/>
         <source>Launch system</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2177"/>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2179"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2254"/>
-        <location filename="../app/Main.qml" line="2308"/>
+        <location filename="../app/Main.qml" line="2256"/>
+        <location filename="../app/Main.qml" line="2319"/>
         <source>Launch game</source>
         <translation>启动游戏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2258"/>
-        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2260"/>
+        <location filename="../app/Main.qml" line="2323"/>
         <source>Details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2278"/>
-        <location filename="../app/Main.qml" line="2346"/>
-        <location filename="../app/Main.qml" line="2434"/>
+        <location filename="../app/Main.qml" line="2280"/>
+        <location filename="../app/Main.qml" line="2357"/>
+        <location filename="../app/Main.qml" line="2451"/>
         <source>Discover alt. versions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Remove from favorites</source>
         <translation>从收藏中移除</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2316"/>
+        <location filename="../app/Main.qml" line="2327"/>
         <source>Add to favorites</source>
         <translation>添加到收藏</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2264"/>
-        <location filename="../app/Main.qml" line="2335"/>
+        <location filename="../app/Main.qml" line="2266"/>
+        <location filename="../app/Main.qml" line="2346"/>
         <source>Write to NFC token</source>
         <translation>写入 NFC 令牌</translation>
     </message>
@@ -761,70 +749,95 @@ Français - Wilfried</source>
         <translation type="vanished">二维码</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3507"/>
+        <location filename="../app/Main.qml" line="2395"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3561"/>
         <source>Default</source>
         <translation type="unfinished">默认</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2378"/>
+        <location filename="../app/Main.qml" line="2395"/>
         <source>Current: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2162"/>
-        <location filename="../app/Main.qml" line="2213"/>
-        <location filename="../app/Main.qml" line="2230"/>
-        <location filename="../app/Main.qml" line="2238"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3400"/>
+        <location filename="../app/Main.qml" line="2164"/>
+        <location filename="../app/Main.qml" line="2215"/>
+        <location filename="../app/Main.qml" line="2232"/>
+        <location filename="../app/Main.qml" line="2240"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3454"/>
         <source>Random game</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3432"/>
+        <location filename="../app/Main.qml" line="3153"/>
+        <source>Get metadata failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3154"/>
+        <source>Could not start getting metadata. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3156"/>
+        <source>Source list unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3157"/>
+        <source>Could not load the list of metadata sources. Check Zaparoo Core and try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3307"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3486"/>
         <source>Favorites</source>
         <translation type="unfinished">收藏</translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1070"/>
-        <location filename="../app/Main.qml" line="3417"/>
-        <location filename="../app/Main.qml" line="3464"/>
-        <location filename="../app/Main.qml" line="3474"/>
+        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3518"/>
+        <location filename="../app/Main.qml" line="3528"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3445"/>
+        <location filename="../app/Main.qml" line="3499"/>
         <source>Sort: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
+        <location filename="../app/Main.qml" line="3460"/>
         <source>Show: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3496"/>
-        <location filename="../app/Main.qml" line="3511"/>
+        <location filename="../app/Main.qml" line="3550"/>
+        <location filename="../app/Main.qml" line="3565"/>
         <source>A-Z</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3406"/>
-        <location filename="../app/Main.qml" line="3428"/>
+        <location filename="../app/Main.qml" line="3460"/>
+        <location filename="../app/Main.qml" line="3482"/>
         <source>All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3515"/>
+        <location filename="../app/Main.qml" line="3569"/>
         <source>Sort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3436"/>
+        <location filename="../app/Main.qml" line="3490"/>
         <source>Show</source>
         <translation type="unfinished"></translation>
     </message>
@@ -849,50 +862,51 @@ Français - Wilfried</source>
         <translation type="unfinished">退出</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2173"/>
-        <location filename="../app/Main.qml" line="2282"/>
-        <location filename="../app/Main.qml" line="2301"/>
-        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2175"/>
+        <location filename="../app/Main.qml" line="2284"/>
+        <location filename="../app/Main.qml" line="2312"/>
+        <location filename="../app/Main.qml" line="2361"/>
         <source>Add to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2268"/>
-        <location filename="../app/Main.qml" line="2339"/>
+        <location filename="../app/Main.qml" line="2270"/>
+        <location filename="../app/Main.qml" line="2350"/>
+        <location filename="../app/Main.qml" line="2807"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2457"/>
+        <location filename="../app/Main.qml" line="2474"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2461"/>
+        <location filename="../app/Main.qml" line="2478"/>
         <source>Move</source>
         <translation type="unfinished">移动</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2667"/>
+        <location filename="../app/Main.qml" line="2684"/>
         <source>Searching…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Details unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
+        <location filename="../app/Main.qml" line="2910"/>
         <source>Could not load details for this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/Main.qml" line="1032"/>
-        <location filename="../app/Main.qml" line="3043"/>
-        <location filename="../app/Main.qml" line="3065"/>
-        <location filename="../app/Main.qml" line="3089"/>
-        <location filename="../app/Main.qml" line="3131"/>
+        <location filename="../app/Main.qml" line="3086"/>
+        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3132"/>
+        <location filename="../app/Main.qml" line="3174"/>
         <source>OK</source>
         <translation type="unfinished">确定</translation>
     </message>
@@ -907,225 +921,223 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2132"/>
-        <location filename="../app/Main.qml" line="2168"/>
+        <location filename="../app/Main.qml" line="2134"/>
+        <location filename="../app/Main.qml" line="2170"/>
         <source>Change launcher: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3089"/>
+        <location filename="../app/Main.qml" line="2188"/>
+        <location filename="../app/Main.qml" line="2223"/>
+        <location filename="../app/Main.qml" line="2293"/>
+        <location filename="../app/Main.qml" line="2367"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2807"/>
+        <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="2946"/>
+        <source>Scan this code to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../app/Main.qml" line="3132"/>
         <source>No matching games found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3098"/>
+        <location filename="../app/Main.qml" line="3141"/>
         <source>Action failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3099"/>
+        <location filename="../app/Main.qml" line="3142"/>
         <source>The action could not be completed. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3101"/>
+        <location filename="../app/Main.qml" line="3144"/>
         <source>Launch failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start %1. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3102"/>
+        <location filename="../app/Main.qml" line="3145"/>
         <source>Could not start this item. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3104"/>
+        <location filename="../app/Main.qml" line="3147"/>
         <source>Favorite update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3105"/>
+        <location filename="../app/Main.qml" line="3148"/>
         <source>Could not update this favorite. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3107"/>
+        <location filename="../app/Main.qml" line="3150"/>
         <source>Media update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3108"/>
+        <location filename="../app/Main.qml" line="3151"/>
         <source>Could not start the media database update. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3110"/>
-        <source>Metadata scrape failed</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3111"/>
-        <source>Could not start metadata scraping. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3113"/>
-        <source>Scraper list unavailable</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3114"/>
-        <source>Could not load the list of scrapers. Check Zaparoo Core and try again.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3116"/>
+        <location filename="../app/Main.qml" line="3159"/>
         <source>Cancel failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3117"/>
+        <location filename="../app/Main.qml" line="3160"/>
         <source>Could not cancel the media operation. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3120"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3163"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Could not change the launcher. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3122"/>
+        <location filename="../app/Main.qml" line="3165"/>
         <source>Alternate versions unavailable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3123"/>
+        <location filename="../app/Main.qml" line="3166"/>
         <source>Could not find alternate versions. Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3125"/>
+        <location filename="../app/Main.qml" line="3168"/>
         <source>QR code failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3126"/>
+        <location filename="../app/Main.qml" line="3169"/>
         <source>Could not create the QR code for this item.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3128"/>
+        <location filename="../app/Main.qml" line="3171"/>
         <source>Setting not saved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3129"/>
+        <location filename="../app/Main.qml" line="3172"/>
         <source>Could not save this setting. Try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3253"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../app/Main.qml" line="3269"/>
+        <location filename="../app/Main.qml" line="3323"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3278"/>
+        <location filename="../app/Main.qml" line="3332"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3307"/>
+        <location filename="../app/Main.qml" line="3361"/>
         <source>Systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Log upload failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3318"/>
+        <location filename="../app/Main.qml" line="3372"/>
         <source>Could not upload the logs. Check the network connection and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3392"/>
+        <location filename="../app/Main.qml" line="3446"/>
         <source>Go to…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3415"/>
-        <location filename="../app/Main.qml" line="3461"/>
+        <location filename="../app/Main.qml" line="3469"/>
+        <location filename="../app/Main.qml" line="3515"/>
         <source>Back to Hub</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3449"/>
-        <location filename="../app/Main.qml" line="3471"/>
+        <location filename="../app/Main.qml" line="3503"/>
+        <location filename="../app/Main.qml" line="3525"/>
         <source>Group by: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3453"/>
+        <location filename="../app/Main.qml" line="3507"/>
         <source>Random favorite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3489"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3543"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3478"/>
-        <location filename="../app/Main.qml" line="3485"/>
+        <location filename="../app/Main.qml" line="3532"/>
+        <location filename="../app/Main.qml" line="3539"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3492"/>
+        <location filename="../app/Main.qml" line="3546"/>
         <source>Group by</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3708"/>
+        <location filename="../app/Main.qml" line="3762"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Token write failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Could not write to this token. Check that it is writable and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="3119"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
+        <location filename="../app/Main.qml" line="3162"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
         <source>Launcher update failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="2887"/>
-        <location filename="../app/Main.qml" line="3318"/>
-        <location filename="../app/Main.qml" line="3754"/>
-        <location filename="../app/Main.qml" line="3799"/>
-        <location filename="../app/Main.qml" line="4155"/>
+        <location filename="../app/Main.qml" line="2910"/>
+        <location filename="../app/Main.qml" line="3372"/>
+        <location filename="../app/Main.qml" line="3808"/>
+        <location filename="../app/Main.qml" line="3853"/>
+        <location filename="../app/Main.qml" line="4209"/>
         <source>Retry</source>
         <translation type="unfinished">重试</translation>
     </message>
@@ -1134,37 +1146,37 @@ Français - Wilfried</source>
         <translation type="obsolete">取消</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4848"/>
+        <location filename="../app/Main.qml" line="4902"/>
         <source>Loading systems…</source>
         <translation>正在加载系统…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4850"/>
+        <location filename="../app/Main.qml" line="4904"/>
         <source>Loading games…</source>
         <translation>正在加载游戏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4852"/>
+        <location filename="../app/Main.qml" line="4906"/>
         <source>Loading game…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4855"/>
+        <location filename="../app/Main.qml" line="4909"/>
         <source>Loading favorites…</source>
         <translation>正在加载收藏…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4857"/>
+        <location filename="../app/Main.qml" line="4911"/>
         <source>Loading recently played…</source>
         <translation>正在加载最近游玩…</translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4859"/>
+        <location filename="../app/Main.qml" line="4913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/Main.qml" line="4861"/>
+        <location filename="../app/Main.qml" line="4915"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>
@@ -1172,7 +1184,7 @@ Français - Wilfried</source>
 <context>
     <name>MainLayout</name>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Writing failed</source>
         <translation>写入失败</translation>
     </message>
@@ -1186,8 +1198,8 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="531"/>
-        <location filename="../app/MainLayout.qml" line="533"/>
+        <location filename="../app/MainLayout.qml" line="537"/>
+        <location filename="../app/MainLayout.qml" line="539"/>
         <source>Favorites</source>
         <translation type="unfinished">收藏</translation>
     </message>
@@ -1196,128 +1208,130 @@ Français - Wilfried</source>
         <translation type="obsolete">最近游玩</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="916"/>
+        <location filename="../app/MainLayout.qml" line="922"/>
         <source>Quit and restart Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="917"/>
+        <location filename="../app/MainLayout.qml" line="923"/>
         <source>In order to apply this setting we need to restart the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="936"/>
+        <location filename="../app/MainLayout.qml" line="942"/>
         <source>Update Zaparoo Core</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="937"/>
+        <location filename="../app/MainLayout.qml" line="943"/>
         <source>This frontend needs Zaparoo Core %1 or newer. You&apos;re running %2. Some features may not work until you update.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../app/MainLayout.qml" line="391"/>
-        <location filename="../app/MainLayout.qml" line="938"/>
-        <location filename="../app/MainLayout.qml" line="1356"/>
+        <location filename="../app/MainLayout.qml" line="944"/>
+        <location filename="../app/MainLayout.qml" line="1365"/>
         <source>OK</source>
         <translation type="unfinished">确定</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="535"/>
+        <location filename="../app/MainLayout.qml" line="541"/>
         <source>Recently played</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="899"/>
+        <location filename="../app/MainLayout.qml" line="905"/>
         <source>Hold a writable token near the reader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1096"/>
+        <location filename="../app/MainLayout.qml" line="1105"/>
         <source>Quit Zaparoo Frontend?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1097"/>
+        <location filename="../app/MainLayout.qml" line="1106"/>
         <source>Are you sure you want to exit?</source>
         <translation>确定要退出吗？</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1275"/>
-        <location filename="../app/MainLayout.qml" line="1374"/>
-        <location filename="../app/MainLayout.qml" line="1454"/>
-        <location filename="../app/MainLayout.qml" line="1491"/>
-        <location filename="../app/MainLayout.qml" line="1540"/>
-        <location filename="../app/MainLayout.qml" line="1596"/>
-        <location filename="../app/MainLayout.qml" line="1615"/>
-        <location filename="../app/MainLayout.qml" line="1688"/>
+        <location filename="../app/MainLayout.qml" line="1284"/>
+        <location filename="../app/MainLayout.qml" line="1383"/>
+        <location filename="../app/MainLayout.qml" line="1405"/>
+        <location filename="../app/MainLayout.qml" line="1486"/>
+        <location filename="../app/MainLayout.qml" line="1523"/>
+        <location filename="../app/MainLayout.qml" line="1572"/>
+        <location filename="../app/MainLayout.qml" line="1628"/>
+        <location filename="../app/MainLayout.qml" line="1647"/>
+        <location filename="../app/MainLayout.qml" line="1720"/>
         <source>Move</source>
         <translation>移动</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1279"/>
-        <location filename="../app/MainLayout.qml" line="1378"/>
+        <location filename="../app/MainLayout.qml" line="1288"/>
+        <location filename="../app/MainLayout.qml" line="1387"/>
+        <location filename="../app/MainLayout.qml" line="1409"/>
         <source>Select</source>
         <translation>选择</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1283"/>
-        <location filename="../app/MainLayout.qml" line="1297"/>
-        <location filename="../app/MainLayout.qml" line="1312"/>
-        <location filename="../app/MainLayout.qml" line="1323"/>
-        <location filename="../app/MainLayout.qml" line="1349"/>
+        <location filename="../app/MainLayout.qml" line="1292"/>
+        <location filename="../app/MainLayout.qml" line="1306"/>
+        <location filename="../app/MainLayout.qml" line="1321"/>
+        <location filename="../app/MainLayout.qml" line="1332"/>
+        <location filename="../app/MainLayout.qml" line="1358"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1290"/>
-        <location filename="../app/MainLayout.qml" line="1330"/>
-        <location filename="../app/MainLayout.qml" line="1382"/>
-        <location filename="../app/MainLayout.qml" line="1425"/>
+        <location filename="../app/MainLayout.qml" line="1299"/>
+        <location filename="../app/MainLayout.qml" line="1339"/>
+        <location filename="../app/MainLayout.qml" line="1391"/>
+        <location filename="../app/MainLayout.qml" line="1457"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1308"/>
+        <location filename="../app/MainLayout.qml" line="1317"/>
         <source>Done</source>
         <translation>完成</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1319"/>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1509"/>
-        <location filename="../app/MainLayout.qml" line="1567"/>
-        <location filename="../app/MainLayout.qml" line="1716"/>
+        <location filename="../app/MainLayout.qml" line="1328"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1541"/>
+        <location filename="../app/MainLayout.qml" line="1599"/>
+        <location filename="../app/MainLayout.qml" line="1748"/>
         <source>Retry</source>
         <translation>重试</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1338"/>
+        <location filename="../app/MainLayout.qml" line="1347"/>
         <source>I understand</source>
         <translation>我明白了</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1367"/>
+        <location filename="../app/MainLayout.qml" line="1376"/>
         <source>Saving…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1389"/>
+        <location filename="../app/MainLayout.qml" line="1421"/>
         <source>Adjust</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1393"/>
+        <location filename="../app/MainLayout.qml" line="1425"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1417"/>
+        <location filename="../app/MainLayout.qml" line="1449"/>
         <source>Reposition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1421"/>
+        <location filename="../app/MainLayout.qml" line="1453"/>
         <source>Place</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1326,11 +1340,11 @@ Français - Wilfried</source>
         <translation type="vanished">开始</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1458"/>
-        <location filename="../app/MainLayout.qml" line="1496"/>
-        <location filename="../app/MainLayout.qml" line="1545"/>
-        <location filename="../app/MainLayout.qml" line="1601"/>
-        <location filename="../app/MainLayout.qml" line="1693"/>
+        <location filename="../app/MainLayout.qml" line="1490"/>
+        <location filename="../app/MainLayout.qml" line="1528"/>
+        <location filename="../app/MainLayout.qml" line="1577"/>
+        <location filename="../app/MainLayout.qml" line="1633"/>
+        <location filename="../app/MainLayout.qml" line="1725"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
@@ -1339,28 +1353,29 @@ Français - Wilfried</source>
         <translation type="vanished">退出</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1477"/>
-        <location filename="../app/MainLayout.qml" line="1502"/>
-        <location filename="../app/MainLayout.qml" line="1513"/>
-        <location filename="../app/MainLayout.qml" line="1529"/>
-        <location filename="../app/MainLayout.qml" line="1559"/>
-        <location filename="../app/MainLayout.qml" line="1577"/>
-        <location filename="../app/MainLayout.qml" line="1589"/>
-        <location filename="../app/MainLayout.qml" line="1605"/>
-        <location filename="../app/MainLayout.qml" line="1639"/>
-        <location filename="../app/MainLayout.qml" line="1660"/>
-        <location filename="../app/MainLayout.qml" line="1669"/>
-        <location filename="../app/MainLayout.qml" line="1709"/>
-        <location filename="../app/MainLayout.qml" line="1728"/>
+        <location filename="../app/MainLayout.qml" line="1413"/>
+        <location filename="../app/MainLayout.qml" line="1509"/>
+        <location filename="../app/MainLayout.qml" line="1534"/>
+        <location filename="../app/MainLayout.qml" line="1545"/>
+        <location filename="../app/MainLayout.qml" line="1561"/>
+        <location filename="../app/MainLayout.qml" line="1591"/>
+        <location filename="../app/MainLayout.qml" line="1609"/>
+        <location filename="../app/MainLayout.qml" line="1621"/>
+        <location filename="../app/MainLayout.qml" line="1637"/>
+        <location filename="../app/MainLayout.qml" line="1671"/>
+        <location filename="../app/MainLayout.qml" line="1692"/>
+        <location filename="../app/MainLayout.qml" line="1701"/>
+        <location filename="../app/MainLayout.qml" line="1741"/>
+        <location filename="../app/MainLayout.qml" line="1760"/>
         <source>Back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1468"/>
-        <location filename="../app/MainLayout.qml" line="1555"/>
-        <location filename="../app/MainLayout.qml" line="1573"/>
-        <location filename="../app/MainLayout.qml" line="1705"/>
-        <location filename="../app/MainLayout.qml" line="1724"/>
+        <location filename="../app/MainLayout.qml" line="1500"/>
+        <location filename="../app/MainLayout.qml" line="1587"/>
+        <location filename="../app/MainLayout.qml" line="1605"/>
+        <location filename="../app/MainLayout.qml" line="1737"/>
+        <location filename="../app/MainLayout.qml" line="1756"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1369,25 +1384,25 @@ Français - Wilfried</source>
         <translation type="vanished">页面</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1464"/>
-        <location filename="../app/MainLayout.qml" line="1499"/>
-        <location filename="../app/MainLayout.qml" line="1550"/>
-        <location filename="../app/MainLayout.qml" line="1698"/>
+        <location filename="../app/MainLayout.qml" line="1496"/>
+        <location filename="../app/MainLayout.qml" line="1531"/>
+        <location filename="../app/MainLayout.qml" line="1582"/>
+        <location filename="../app/MainLayout.qml" line="1730"/>
         <source>Options</source>
         <translation>选项</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1624"/>
+        <location filename="../app/MainLayout.qml" line="1656"/>
         <source>Change</source>
         <translation>更改</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1630"/>
+        <location filename="../app/MainLayout.qml" line="1662"/>
         <source>Toggle</source>
         <translation>切换</translation>
     </message>
     <message>
-        <location filename="../app/MainLayout.qml" line="1656"/>
+        <location filename="../app/MainLayout.qml" line="1688"/>
         <source>Scroll</source>
         <translation>滚动</translation>
     </message>
@@ -1448,12 +1463,12 @@ Français - Wilfried</source>
 <context>
     <name>QrCodeModal</name>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="23"/>
+        <location filename="../components/QrCodeModal.qml" line="19"/>
         <source>Write with App</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/QrCodeModal.qml" line="43"/>
+        <location filename="../components/QrCodeModal.qml" line="20"/>
         <source>Scan this code with the Zaparoo App to write this game to a Zaparoo token.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1483,43 +1498,67 @@ Français - Wilfried</source>
 <context>
     <name>ScrapeSetupModal</name>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="67"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Start</source>
+        <translation type="unfinished">开始</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Toggle</source>
+        <translation type="unfinished">切换</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="73"/>
+        <source>Change</source>
+        <translation type="unfinished">更改</translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="89"/>
         <source>All systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="69"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="91"/>
         <source>All %1 systems</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="171"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="193"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="210"/>
+        <source>Zaparoo imports artwork and details from files you already have. It does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="237"/>
+        <source>Loading sources…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="248"/>
+        <source>Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="274"/>
+        <source>Replace existing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/ScrapeSetupModal.qml" line="288"/>
+        <source>Start import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scrape metadata</source>
-        <translation type="unfinished">抓取元数据</translation>
+        <translation type="obsolete">抓取元数据</translation>
     </message>
     <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="185"/>
-        <source>Loading scrapers…</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="196"/>
-        <source>Scraper</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="209"/>
+        <location filename="../components/ScrapeSetupModal.qml" line="261"/>
         <source>Systems</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="222"/>
-        <source>Re-scrape existing</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/ScrapeSetupModal.qml" line="236"/>
-        <source>Start scrape</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -1531,17 +1570,17 @@ Français - Wilfried</source>
         <translation>这里什么都没有</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="30"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="36"/>
         <source>Loading…</source>
         <translation>正在加载…</translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="31"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="37"/>
         <source>Check Zaparoo Core and try again.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/ScreenStateOverlay.qml" line="79"/>
+        <location filename="../components/ScreenStateOverlay.qml" line="85"/>
         <source>Failed to load</source>
         <translation>加载失败</translation>
     </message>
@@ -1555,14 +1594,14 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="114"/>
         <location filename="../screens/SettingsScreen.qml" line="205"/>
-        <location filename="../screens/SettingsScreen.qml" line="348"/>
-        <location filename="../screens/SettingsScreen.qml" line="972"/>
+        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="978"/>
         <source>Language</source>
         <translation>语言</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="165"/>
-        <location filename="../screens/SettingsScreen.qml" line="999"/>
+        <location filename="../screens/SettingsScreen.qml" line="1005"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1572,25 +1611,25 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="225"/>
-        <location filename="../screens/SettingsScreen.qml" line="1051"/>
+        <location filename="../screens/SettingsScreen.qml" line="1057"/>
         <source>Button style</source>
         <translation>按钮样式</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="147"/>
-        <location filename="../screens/SettingsScreen.qml" line="1060"/>
+        <location filename="../screens/SettingsScreen.qml" line="1066"/>
         <source>Screensaver</source>
         <translation>屏幕保护程序</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="96"/>
-        <location filename="../screens/SettingsScreen.qml" line="352"/>
+        <location filename="../screens/SettingsScreen.qml" line="358"/>
         <source>Library</source>
         <translation>资料库</translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="291"/>
-        <location filename="../screens/SettingsScreen.qml" line="1069"/>
+        <location filename="../screens/SettingsScreen.qml" line="1075"/>
         <source>Preferred artwork</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1600,9 +1639,8 @@ Français - Wilfried</source>
         <translation>更新媒体数据库</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Scrape metadata</source>
-        <translation>抓取元数据</translation>
+        <translation type="vanished">抓取元数据</translation>
     </message>
     <message>
         <source>Advanced</source>
@@ -1614,12 +1652,12 @@ Français - Wilfried</source>
         <translation>鼠标支持</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <location filename="../screens/SettingsScreen.qml" line="323"/>
         <source>Debug logging</source>
         <translation>调试日志</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="323"/>
+        <location filename="../screens/SettingsScreen.qml" line="329"/>
         <source>Upload log file</source>
         <translation>上传日志文件</translation>
     </message>
@@ -1630,7 +1668,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="217"/>
-        <location filename="../screens/SettingsScreen.qml" line="981"/>
+        <location filename="../screens/SettingsScreen.qml" line="987"/>
         <source>Clock format</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1651,7 +1689,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="187"/>
-        <location filename="../screens/SettingsScreen.qml" line="1078"/>
+        <location filename="../screens/SettingsScreen.qml" line="1084"/>
         <source>Video standard</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1662,7 +1700,7 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="135"/>
-        <location filename="../screens/SettingsScreen.qml" line="1026"/>
+        <location filename="../screens/SettingsScreen.qml" line="1032"/>
         <source>System logos</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1682,35 +1720,34 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="369"/>
+        <location filename="../screens/SettingsScreen.qml" line="375"/>
         <source>Optimizing</source>
         <translation>正在优化</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>Paused</source>
         <translation>已暂停</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="371"/>
-        <location filename="../screens/SettingsScreen.qml" line="380"/>
+        <location filename="../screens/SettingsScreen.qml" line="377"/>
+        <location filename="../screens/SettingsScreen.qml" line="386"/>
         <source>In progress</source>
         <translation>进行中</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="374"/>
+        <location filename="../screens/SettingsScreen.qml" line="380"/>
         <source>%1 indexed</source>
         <translation>已索引 %1 个</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="383"/>
         <source>%1 scraped</source>
-        <translation>已抓取 %1 个</translation>
+        <translation type="vanished">已抓取 %1 个</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
@@ -1719,12 +1756,12 @@ Français - Wilfried</source>
         <translation type="vanished">开始</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="649"/>
+        <location filename="../screens/SettingsScreen.qml" line="655"/>
         <source>Upload</source>
         <translation>上传</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="650"/>
+        <location filename="../screens/SettingsScreen.qml" line="656"/>
         <source>Open</source>
         <translation>打开</translation>
     </message>
@@ -1733,92 +1770,92 @@ Français - Wilfried</source>
         <translation type="vanished">默认</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="752"/>
+        <location filename="../screens/SettingsScreen.qml" line="758"/>
         <source>English</source>
         <translation>英语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="754"/>
+        <location filename="../screens/SettingsScreen.qml" line="760"/>
         <source>Italian</source>
         <translation>意大利语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="756"/>
+        <location filename="../screens/SettingsScreen.qml" line="762"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="758"/>
+        <location filename="../screens/SettingsScreen.qml" line="764"/>
         <source>Basque</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="760"/>
+        <location filename="../screens/SettingsScreen.qml" line="766"/>
         <source>German</source>
         <translation>德语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="762"/>
+        <location filename="../screens/SettingsScreen.qml" line="768"/>
         <source>Greek</source>
         <translation>希腊语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="764"/>
+        <location filename="../screens/SettingsScreen.qml" line="770"/>
         <source>Japanese</source>
         <translation>日语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="766"/>
+        <location filename="../screens/SettingsScreen.qml" line="772"/>
         <source>Korean</source>
         <translation>韩语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="768"/>
+        <location filename="../screens/SettingsScreen.qml" line="774"/>
         <source>Dutch</source>
         <translation>荷兰语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="770"/>
+        <location filename="../screens/SettingsScreen.qml" line="776"/>
         <source>Romanian</source>
         <translation>罗马尼亚语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="772"/>
+        <location filename="../screens/SettingsScreen.qml" line="778"/>
         <source>Slovak</source>
         <translation>斯洛伐克语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="774"/>
+        <location filename="../screens/SettingsScreen.qml" line="780"/>
         <source>Ukrainian</source>
         <translation>乌克兰语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="776"/>
+        <location filename="../screens/SettingsScreen.qml" line="782"/>
         <source>Chinese (Simplified)</source>
         <translation>简体中文</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="778"/>
+        <location filename="../screens/SettingsScreen.qml" line="784"/>
         <source>Chinese (Traditional)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="780"/>
+        <location filename="../screens/SettingsScreen.qml" line="786"/>
         <source>Hebrew</source>
         <translation>希伯来语</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="782"/>
+        <location filename="../screens/SettingsScreen.qml" line="788"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="784"/>
+        <location filename="../screens/SettingsScreen.qml" line="790"/>
         <source>Hindi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="786"/>
+        <location filename="../screens/SettingsScreen.qml" line="792"/>
         <source>French</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1827,127 +1864,127 @@ Français - Wilfried</source>
         <translation type="vanished">自动</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="792"/>
+        <location filename="../screens/SettingsScreen.qml" line="798"/>
         <source>12-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="794"/>
+        <location filename="../screens/SettingsScreen.qml" line="800"/>
         <source>24-hour</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="805"/>
+        <location filename="../screens/SettingsScreen.qml" line="811"/>
         <source>Americas</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="807"/>
+        <location filename="../screens/SettingsScreen.qml" line="813"/>
         <source>Europe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="809"/>
+        <location filename="../screens/SettingsScreen.qml" line="815"/>
         <source>Japan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="698"/>
-        <location filename="../screens/SettingsScreen.qml" line="787"/>
-        <location filename="../screens/SettingsScreen.qml" line="795"/>
-        <location filename="../screens/SettingsScreen.qml" line="810"/>
-        <location filename="../screens/SettingsScreen.qml" line="877"/>
-        <location filename="../screens/SettingsScreen.qml" line="925"/>
+        <location filename="../screens/SettingsScreen.qml" line="704"/>
+        <location filename="../screens/SettingsScreen.qml" line="793"/>
+        <location filename="../screens/SettingsScreen.qml" line="801"/>
+        <location filename="../screens/SettingsScreen.qml" line="816"/>
+        <location filename="../screens/SettingsScreen.qml" line="883"/>
+        <location filename="../screens/SettingsScreen.qml" line="931"/>
         <source>Automatic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="158"/>
-        <location filename="../screens/SettingsScreen.qml" line="963"/>
+        <location filename="../screens/SettingsScreen.qml" line="969"/>
         <source>Interface resolution</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="129"/>
-        <location filename="../screens/SettingsScreen.qml" line="1035"/>
+        <location filename="../screens/SettingsScreen.qml" line="1041"/>
         <source>Color scheme</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="702"/>
+        <location filename="../screens/SettingsScreen.qml" line="708"/>
         <source>%1 × %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="707"/>
+        <location filename="../screens/SettingsScreen.qml" line="713"/>
         <source>Automatic (Recommended)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="711"/>
+        <location filename="../screens/SettingsScreen.qml" line="717"/>
         <source>%1 (Animations off)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="815"/>
+        <location filename="../screens/SettingsScreen.qml" line="821"/>
         <source>Rotated CW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="817"/>
+        <location filename="../screens/SettingsScreen.qml" line="823"/>
         <source>Rotated CCW</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="818"/>
+        <location filename="../screens/SettingsScreen.qml" line="824"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="823"/>
+        <location filename="../screens/SettingsScreen.qml" line="829"/>
         <source>Detailed list view</source>
         <translation>详细列表视图</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="824"/>
+        <location filename="../screens/SettingsScreen.qml" line="830"/>
         <source>Grid view</source>
         <translation>网格视图</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="829"/>
+        <location filename="../screens/SettingsScreen.qml" line="835"/>
         <source>Full color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="830"/>
+        <location filename="../screens/SettingsScreen.qml" line="836"/>
         <source>Tinted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="855"/>
+        <location filename="../screens/SettingsScreen.qml" line="861"/>
         <source>Nord</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="852"/>
+        <location filename="../screens/SettingsScreen.qml" line="858"/>
         <source>Dracula</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="90"/>
-        <location filename="../screens/SettingsScreen.qml" line="344"/>
+        <location filename="../screens/SettingsScreen.qml" line="350"/>
         <source>Appearance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="120"/>
-        <location filename="../screens/SettingsScreen.qml" line="354"/>
+        <location filename="../screens/SettingsScreen.qml" line="360"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="211"/>
-        <location filename="../screens/SettingsScreen.qml" line="990"/>
+        <location filename="../screens/SettingsScreen.qml" line="996"/>
         <source>Region</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1957,72 +1994,72 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="859"/>
+        <location filename="../screens/SettingsScreen.qml" line="865"/>
         <source>Synthwave &apos;84</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="846"/>
+        <location filename="../screens/SettingsScreen.qml" line="852"/>
         <source>Amber Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="848"/>
+        <location filename="../screens/SettingsScreen.qml" line="854"/>
         <source>Green Phosphor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="849"/>
+        <location filename="../screens/SettingsScreen.qml" line="855"/>
         <source>Neo Geo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="850"/>
+        <location filename="../screens/SettingsScreen.qml" line="856"/>
         <source>NES</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="851"/>
+        <location filename="../screens/SettingsScreen.qml" line="857"/>
         <source>Virtual Boy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="854"/>
+        <location filename="../screens/SettingsScreen.qml" line="860"/>
         <source>Gruvbox</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="853"/>
+        <location filename="../screens/SettingsScreen.qml" line="859"/>
         <source>Everforest</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="858"/>
+        <location filename="../screens/SettingsScreen.qml" line="864"/>
         <source>Solarized Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="857"/>
+        <location filename="../screens/SettingsScreen.qml" line="863"/>
         <source>Rosé Pine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="856"/>
+        <location filename="../screens/SettingsScreen.qml" line="862"/>
         <source>Oxocarbon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="860"/>
+        <location filename="../screens/SettingsScreen.qml" line="866"/>
         <source>Flexoki Paper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="861"/>
+        <location filename="../screens/SettingsScreen.qml" line="867"/>
         <source>Solarized Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="847"/>
+        <location filename="../screens/SettingsScreen.qml" line="853"/>
         <source>Game Boy</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2077,19 +2114,14 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Downloads box art, descriptions, and tags for your games. Choose a source and which systems.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
-        <location filename="../screens/SettingsScreen.qml" line="1008"/>
+        <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="285"/>
-        <location filename="../screens/SettingsScreen.qml" line="1017"/>
+        <location filename="../screens/SettingsScreen.qml" line="1023"/>
         <source>Games layout</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2104,103 +2136,103 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <location filename="../screens/SettingsScreen.qml" line="324"/>
         <source>Writes extra detail to the log file to help track down a problem. Restarts the frontend.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="645"/>
-        <location filename="../screens/SettingsScreen.qml" line="647"/>
+        <location filename="../screens/SettingsScreen.qml" line="651"/>
+        <location filename="../screens/SettingsScreen.qml" line="653"/>
         <source>Configure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="868"/>
+        <location filename="../screens/SettingsScreen.qml" line="874"/>
         <source>Style B</source>
         <translation>样式 B</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="870"/>
+        <location filename="../screens/SettingsScreen.qml" line="876"/>
         <source>Style C</source>
         <translation>样式 C</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="872"/>
+        <location filename="../screens/SettingsScreen.qml" line="878"/>
         <source>Style D</source>
         <translation>样式 D</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="874"/>
+        <location filename="../screens/SettingsScreen.qml" line="880"/>
         <source>Style E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="876"/>
+        <location filename="../screens/SettingsScreen.qml" line="882"/>
         <source>Style A</source>
         <translation>样式 A</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="892"/>
+        <location filename="../screens/SettingsScreen.qml" line="898"/>
         <source>Off</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="894"/>
+        <location filename="../screens/SettingsScreen.qml" line="900"/>
         <source>1 second (testing)</source>
         <translation>1 秒（测试）</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="896"/>
+        <location filename="../screens/SettingsScreen.qml" line="902"/>
         <source>1 minute</source>
         <translation>1 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="898"/>
+        <location filename="../screens/SettingsScreen.qml" line="904"/>
         <source>2 minutes</source>
         <translation>2 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="900"/>
+        <location filename="../screens/SettingsScreen.qml" line="906"/>
         <source>5 minutes</source>
         <translation>5 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="902"/>
+        <location filename="../screens/SettingsScreen.qml" line="908"/>
         <source>10 minutes</source>
         <translation>10 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="904"/>
+        <location filename="../screens/SettingsScreen.qml" line="910"/>
         <source>15 minutes</source>
         <translation>15 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="906"/>
+        <location filename="../screens/SettingsScreen.qml" line="912"/>
         <source>30 minutes</source>
         <translation>30 分钟</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="907"/>
+        <location filename="../screens/SettingsScreen.qml" line="913"/>
         <source>%1 seconds</source>
         <translation>%1 秒</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="917"/>
+        <location filename="../screens/SettingsScreen.qml" line="923"/>
         <source>PAL (50 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="919"/>
+        <location filename="../screens/SettingsScreen.qml" line="925"/>
         <source>480i (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="920"/>
+        <location filename="../screens/SettingsScreen.qml" line="926"/>
         <source>NTSC (60 Hz)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1905"/>
+        <location filename="../screens/SettingsScreen.qml" line="1911"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2210,13 +2242,13 @@ Français - Wilfried</source>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="102"/>
-        <location filename="../screens/SettingsScreen.qml" line="346"/>
+        <location filename="../screens/SettingsScreen.qml" line="352"/>
         <source>Display</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="108"/>
-        <location filename="../screens/SettingsScreen.qml" line="350"/>
+        <location filename="../screens/SettingsScreen.qml" line="356"/>
         <source>Controls</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2266,6 +2298,16 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="269"/>
+        <source>Get metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="280"/>
         <source>Show systems as a grid of covers, or as a list with details beside it.</source>
         <translation type="unfinished"></translation>
@@ -2286,92 +2328,107 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="324"/>
+        <location filename="../screens/SettingsScreen.qml" line="317"/>
+        <source>Documentation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="318"/>
+        <source>Shows a code you can scan to open the Zaparoo Frontend guide on your phone.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="330"/>
         <source>Uploads the log file and gives you a link to share when reporting a problem.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="843"/>
+        <location filename="../screens/SettingsScreen.qml" line="389"/>
+        <source>%1 imported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../screens/SettingsScreen.qml" line="849"/>
         <source>Zaparoo Dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="844"/>
+        <location filename="../screens/SettingsScreen.qml" line="850"/>
         <source>Zaparoo Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="845"/>
+        <location filename="../screens/SettingsScreen.qml" line="851"/>
         <source>Classic Purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="927"/>
+        <location filename="../screens/SettingsScreen.qml" line="933"/>
         <source>Image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="929"/>
+        <location filename="../screens/SettingsScreen.qml" line="935"/>
         <source>Thumbnail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="931"/>
+        <location filename="../screens/SettingsScreen.qml" line="937"/>
         <source>Box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="933"/>
+        <location filename="../screens/SettingsScreen.qml" line="939"/>
         <source>3D box art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="935"/>
+        <location filename="../screens/SettingsScreen.qml" line="941"/>
         <source>Screenshot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="937"/>
+        <location filename="../screens/SettingsScreen.qml" line="943"/>
         <source>Wheel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="939"/>
+        <location filename="../screens/SettingsScreen.qml" line="945"/>
         <source>Title screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="941"/>
+        <location filename="../screens/SettingsScreen.qml" line="947"/>
         <source>Map</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="943"/>
+        <location filename="../screens/SettingsScreen.qml" line="949"/>
         <source>Marquee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="945"/>
+        <location filename="../screens/SettingsScreen.qml" line="951"/>
         <source>Fan art</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="947"/>
+        <location filename="../screens/SettingsScreen.qml" line="953"/>
         <source>Box side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="949"/>
+        <location filename="../screens/SettingsScreen.qml" line="955"/>
         <source>Box back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="355"/>
+        <location filename="../screens/SettingsScreen.qml" line="361"/>
         <source>Settings</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1887"/>
+        <location filename="../screens/SettingsScreen.qml" line="1893"/>
         <source>No settings available on this platform</source>
         <translation>此平台上没有可用设置</translation>
     </message>
@@ -2410,9 +2467,33 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../components/StatusLine.qml" line="105"/>
+        <source>Importing paused: game running</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="106"/>
+        <source>Importing…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Import failed: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../components/StatusLine.qml" line="159"/>
+        <source>Imported %1 of %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Scraping…</source>
-        <translation type="unfinished">正在抓取…</translation>
+        <translation type="obsolete">正在抓取…</translation>
     </message>
     <message>
         <location filename="../components/StatusLine.qml" line="248"/>
@@ -2441,16 +2522,6 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../components/StatusLine.qml" line="105"/>
-        <source>Scraping paused: game running</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="106"/>
-        <source>Scraping: %1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>%1 files</source>
         <translation type="obsolete">%1 个文件</translation>
     </message>
@@ -2466,16 +2537,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../components/StatusLine.qml" line="148"/>
         <source>Indexing complete</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scraped %1 of %2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../components/StatusLine.qml" line="159"/>
-        <source>Scrape failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -2114,6 +2114,11 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../screens/SettingsScreen.qml" line="270"/>
+        <source>Imports artwork and details from files you already have. Zaparoo does not download them.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../screens/SettingsScreen.qml" line="279"/>
         <location filename="../screens/SettingsScreen.qml" line="1014"/>
         <source>Systems layout</source>
@@ -2300,11 +2305,6 @@ Français - Wilfried</source>
     <message>
         <location filename="../screens/SettingsScreen.qml" line="269"/>
         <source>Get metadata</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../screens/SettingsScreen.qml" line="270"/>
-        <source>Imports artwork, descriptions, and details from files you already have. Zaparoo does not download them.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/src/ui/translations/frontend_zh_CN.ts
+++ b/src/ui/translations/frontend_zh_CN.ts
@@ -2237,7 +2237,7 @@ Français - Wilfried</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1911"/>
+        <location filename="../screens/SettingsScreen.qml" line="1913"/>
         <source>Loading settings…</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2428,7 +2428,7 @@ Français - Wilfried</source>
         <translation>设置</translation>
     </message>
     <message>
-        <location filename="../screens/SettingsScreen.qml" line="1893"/>
+        <location filename="../screens/SettingsScreen.qml" line="1895"/>
         <source>No settings available on this platform</source>
         <translation>此平台上没有可用设置</translation>
     </message>

--- a/tests/ui/tst_context_menu.qml
+++ b/tests/ui/tst_context_menu.qml
@@ -267,8 +267,8 @@ TestCase {
         compare(viewport.contentY, 0, "wrapping to the first entry must scroll back to the top");
     }
 
-    // A menu within the documented 3-8 cap must render exactly as it did
-    // before `rowViewport` existed: unscrollable, contentY pinned at 0.
+    // A menu short enough to fit must render exactly as it did before
+    // `rowViewport` existed: unscrollable, contentY pinned at 0.
     function test_few_entries_never_scrolls(): void {
         menu.entries = _manyEntries(3);
         menu.currentIndex = 0;

--- a/tests/ui/tst_index_setup_modal.qml
+++ b/tests/ui/tst_index_setup_modal.qml
@@ -95,4 +95,14 @@ TestCase {
         modal.selectedSystemScope = "cat:Console";
         compare(modal._selectedSystemScopeName, qsTr("All %1 systems").arg("Console"));
     }
+
+    // The help bar describes the press, not the feature. Before this
+    // existed neither setup modal had a helpEntries branch at all, so the
+    // bar advertised the Settings screen's rows while a modal owned input.
+    function test_focused_action_label_tracks_the_focused_row(): void {
+        modal.currentIndex = modal._rowSystems;
+        compare(modal.focusedActionLabel, qsTr("Change"));
+        modal.currentIndex = modal._rowStart;
+        compare(modal.focusedActionLabel, qsTr("Start"));
+    }
 }

--- a/tests/ui/tst_list_picker_modal.qml
+++ b/tests/ui/tst_list_picker_modal.qml
@@ -64,6 +64,11 @@ TestCase {
     }
 
     function init(): void {
+        // The tier sweep below mutates the Sizing singleton; reset it here
+        // so it can't leak into this file's other tests or into whichever
+        // test file runs next in the same engine.
+        Sizing.crtNativePath = false;
+        Sizing.bitmapType = false;
         Sizing.screenWidth = testCase.width;
         Sizing.screenHeight = testCase.height;
         picker.open = false;
@@ -97,6 +102,113 @@ TestCase {
                 swatch: [Qt.rgba(0.1 * i, 0, 0, 1), Qt.rgba(0, 0.1 * i, 0, 1), Qt.rgba(0, 0, 0.1 * i, 1)]
             });
         return list;
+    }
+
+    // The panel is content-driven: whatever labels the caller passes, the
+    // widest one must render in full. Core's scraper list is data, not a
+    // fixed set -- "MiSTer docs databases" elided in the Source picker, and
+    // a picker that has to be re-tuned every time a scraper is added is the
+    // bug, not that one string. So assert the invariant over a range of
+    // label lengths and tiers instead of pinning a measurement.
+    //
+    // Clearance, not just `!truncated`: `_widestEntryLabelWidth` and each
+    // row's `_textWidth` apply the same `Sizing.stroke(2)` hinting slack, so
+    // they cancel. An exact fit passes `!truncated` wherever hinting rounds
+    // down and elides wherever it rounds up, which is how this shipped
+    // looking fine on one machine and broken on another.
+    function test_panel_fits_the_widest_label_whatever_it_is(): void {
+        const labels = ["gamelist.xml", "ScreenScraper", "MiSTer docs database", "MiSTer docs databases", "A considerably longer scraper name"];
+        const tiers = [
+            {
+                w: 1280,
+                h: 720,
+                crt: false
+            },
+            {
+                w: 640,
+                h: 480,
+                crt: false
+            },
+            {
+                w: 316,
+                h: 216,
+                crt: true
+            }
+        ];
+        for (let t = 0; t < tiers.length; t++) {
+            const tier = tiers[t];
+            for (let n = 2; n <= labels.length; n++) {
+                const entries = [];
+                for (let i = 0; i < n; i++)
+                    entries.push({
+                        id: "id-" + i,
+                        label: labels[i]
+                    });
+                picker.open = false;
+                Sizing.crtNativePath = tier.crt;
+                Sizing.bitmapType = tier.crt;
+                Sizing.screenWidth = tier.w;
+                Sizing.screenHeight = tier.h;
+                picker.entries = entries;
+                picker.open = true;
+                // Panel sizing is fixed at Font.Medium, the selected weight,
+                // so the selected row is the hard case for every entry.
+                for (let i = 0; i < n; i++) {
+                    picker.currentIndex = i;
+                    const where = tier.w + "x" + tier.h + " n=" + n + " row " + i + " (\"" + labels[i] + "\")";
+                    const row = findChild(picker, "listPickerRow-" + i);
+                    verify(row !== null, where + ": row not instantiated");
+                    const label = _centeredLabelOf(row);
+                    verify(label !== null, where + ": no centered label");
+                    compare(label.text, labels[i]);
+                    verify(!label.truncated, where + ": must not elide");
+                    verify(label._availableWidth >= label._textWidth + picker._labelClearance, where + ": fits with no clearance (available " + label._availableWidth + " vs text " + label._textWidth + ")");
+                }
+                picker.open = false;
+            }
+        }
+    }
+
+    // The app applies its resolution setting after startup, so the picker is
+    // routinely re-measured at a tier it wasn't built at. The panel binding
+    // has to follow `Sizing.fontBody` across that change, not stay pinned to
+    // the size it was constructed with.
+    function test_panel_remeasures_when_the_tier_changes_after_construction(): void {
+        const entries = [
+            {
+                id: "a",
+                label: "gamelist.xml"
+            },
+            {
+                id: "b",
+                label: "MiSTer docs databases"
+            }
+        ];
+        Sizing.screenWidth = 1920;
+        Sizing.screenHeight = 1080;
+        picker.entries = entries;
+        picker.open = true;
+        picker.currentIndex = 1;
+        const wide = picker._widestEntryLabelWidth;
+
+        Sizing.screenWidth = 640;
+        Sizing.screenHeight = 480;
+        verify(picker._widestEntryLabelWidth < wide, "panel measurement must shrink with the font tier, stayed at " + wide);
+
+        const row = findChild(picker, "listPickerRow-1");
+        const label = _centeredLabelOf(row);
+        verify(!label.truncated, "widest entry must not elide after a tier change");
+        verify(label._availableWidth >= label._textWidth + picker._labelClearance, "no clearance after a tier change (available " + label._availableWidth + " vs text " + label._textWidth + ")");
+    }
+
+    // `findChild` walks into the row's SelectionBar and metrics children
+    // too; the centered label is a direct child, so match it there.
+    function _centeredLabelOf(row) {
+        const kids = row.children;
+        for (let i = 0; i < kids.length; i++)
+            if (kids[i].objectName === "listPickerRowLabelCentered")
+                return kids[i];
+        return null;
     }
 
     function test_open_with_no_initial_id_starts_at_zero(): void {

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -1432,22 +1432,22 @@ TestCase {
 
     function test_context_menu_games_no_reader_omits_write_card(): void {
         const entries = main.buildContextMenuEntries("games", "media", true, false, false, "");
-        compare(_idsOf(entries), ["launch_game", "more_info", "toggle_favorite", "qr_code", "add_to_hub"], "Write to NFC token must be hidden when no reader is reported");
+        compare(_idsOf(entries), ["launch_game", "more_info", "toggle_favorite", "qr_code", "add_to_hub", "scrape_game"], "Write to NFC token must be hidden when no reader is reported");
     }
 
     function test_context_menu_games_with_reader_includes_write_card(): void {
         const entries = main.buildContextMenuEntries("games", "media", true, true, false, "");
-        compare(_idsOf(entries), ["launch_game", "more_info", "toggle_favorite", "write_card", "qr_code", "add_to_hub"]);
+        compare(_idsOf(entries), ["launch_game", "more_info", "toggle_favorite", "write_card", "qr_code", "add_to_hub", "scrape_game"]);
     }
 
     function test_context_menu_favorites_matches_games_media_entries(): void {
         const entries = main.buildContextMenuEntries("favorites", "", true, true, true, "", false, "");
-        compare(_idsOf(entries), ["launch_game", "more_info", "toggle_favorite", "write_card", "qr_code", "add_to_hub"]);
+        compare(_idsOf(entries), ["launch_game", "more_info", "toggle_favorite", "write_card", "qr_code", "add_to_hub", "scrape_game"]);
     }
 
     function test_context_menu_favorites_no_reader_omits_write_card(): void {
         const entries = main.buildContextMenuEntries("favorites", "", true, false, true, "", false, "");
-        compare(_idsOf(entries), ["launch_game", "more_info", "toggle_favorite", "qr_code", "add_to_hub"]);
+        compare(_idsOf(entries), ["launch_game", "more_info", "toggle_favorite", "qr_code", "add_to_hub", "scrape_game"]);
     }
 
     // Round 10: "Discover alt. versions" only appears when the row's own
@@ -1495,12 +1495,12 @@ TestCase {
     // tags (see the doc comment on RecentsModel in recents.rs).
     function test_context_menu_recents_includes_details_and_hub_shortcut(): void {
         const entries = main.buildContextMenuEntries("recents", "", false, false, false, "", false, "");
-        compare(_idsOf(entries), ["launch_game", "more_info", "qr_code", "add_to_hub"]);
+        compare(_idsOf(entries), ["launch_game", "more_info", "qr_code", "add_to_hub", "scrape_game"]);
     }
 
     function test_context_menu_recents_with_reader_includes_write_card(): void {
         const entries = main.buildContextMenuEntries("recents", "", false, true, false, "", false, "");
-        compare(_idsOf(entries), ["launch_game", "more_info", "write_card", "qr_code", "add_to_hub"]);
+        compare(_idsOf(entries), ["launch_game", "more_info", "write_card", "qr_code", "add_to_hub", "scrape_game"]);
     }
 
     function test_context_menu_games_favorite_label_toggles(): void {

--- a/tests/ui/tst_navigation.qml
+++ b/tests/ui/tst_navigation.qml
@@ -630,6 +630,42 @@ TestCase {
         compare(main.activeScreen, main.screenHub);
     }
 
+    // Settings > About > Documentation, end to end: the row's Accept has to
+    // reach `openDocumentationQrModal`, the QR has to actually generate for
+    // the docs URL (`size > 0` gates the open, so a generator failure would
+    // look exactly like a dead row), and the modal has to take the stack.
+    // tst_settings_field_control covers the screen's half of this in
+    // isolation; the dead branch that shipped was between the two.
+    function test_documentation_row_opens_the_qr_modal(): void {
+        main.activeScreen = main.screenSettings;
+        main.settingsScreen.optimisticLoading = false;
+        main.settingsScreen._switchPage(main.settingsScreen.pageSupportAbout);
+        const fields = main.settingsScreen.fields;
+        let idx = -1;
+        for (let i = 0; i < fields.length; i++) {
+            if (fields[i].id === "documentation") {
+                idx = i;
+                break;
+            }
+        }
+        verify(idx >= 0, "documentation field not found on the Support & About page");
+        main.settingsScreen.currentIndex = idx;
+
+        main.handleAction("accept");
+        // The dispatch is deferred behind the row's push-in cue.
+        tryCompare(main, "qrCodeModalVisible", true);
+        verify(Browse.QrCode.size > 0, "the docs URL must produce a QR matrix");
+        compare(main.qrCodeModalTitle, "Documentation");
+        compare(main.qrCodeModalUrlText, "zaparoo.org/docs/frontend");
+        compare(ScreenManager.topModal, main.modalQrCode);
+
+        main.handleAction("cancel");
+        compare(main.qrCodeModalVisible, false);
+        compare(ScreenManager.modalCount, 0);
+        main.settingsScreen._switchPage(main.settingsScreen.pageRoot);
+        main.activeScreen = main.screenHub;
+    }
+
     function test_settings_resolution_labels_explain_automatic_and_motion(): void {
         compare(main.settingsScreen._resolutionDisplay(""), "Automatic");
         compare(main.settingsScreen._resolutionDisplay("1280x720"), "1280 × 720");

--- a/tests/ui/tst_scrape_setup_modal.qml
+++ b/tests/ui/tst_scrape_setup_modal.qml
@@ -53,6 +53,10 @@ TestCase {
 
     function init(): void {
         modal.open = false;
+        // Reset before reopening: `initialSystemScope` seeds
+        // `selectedSystemScope` in onOpenChanged, so a test that sets it
+        // would otherwise carry its scope into every later test.
+        modal.initialSystemScope = "*";
         modal.open = true;
         pickerSpy.clear();
         systemScopePickerSpy.clear();
@@ -149,5 +153,47 @@ TestCase {
         compare(modal._selectedSystemScopeName, qsTr("All systems"));
         modal.selectedSystemScope = "cat:Console";
         compare(modal._selectedSystemScopeName, qsTr("All %1 systems").arg("Console"));
+    }
+
+    // Context-menu entries route through this modal pre-scoped, so the
+    // Systems row shows what is actually about to run rather than the
+    // caller quietly scraping wider than the user asked for.
+    function test_initial_scope_seeds_the_systems_row_on_open(): void {
+        modal.open = false;
+        modal.initialSystemScope = "Genesis";
+        modal.open = true;
+        compare(modal.selectedSystemScope, "Genesis");
+    }
+
+    // The Settings > Library entry point passes the all-systems sentinel;
+    // an empty string must not strand the modal on a blank scope.
+    function test_empty_initial_scope_falls_back_to_all_systems(): void {
+        modal.open = false;
+        modal.initialSystemScope = "";
+        modal.open = true;
+        compare(modal.selectedSystemScope, "*");
+    }
+
+    // Pre-scoping seeds the row but doesn't lock it: the user can still
+    // widen or narrow before starting.
+    function test_initial_scope_is_only_a_seed(): void {
+        modal.open = false;
+        modal.initialSystemScope = "Genesis";
+        modal.open = true;
+        modal.selectedSystemScope = "*";
+        compare(modal.selectedSystemScope, "*");
+    }
+
+    // The help bar describes the press, not the feature, so the accept
+    // verb tracks the focused row rather than repeating the title.
+    function test_focused_action_label_tracks_the_focused_row(): void {
+        modal.currentIndex = modal._rowScraper;
+        compare(modal.focusedActionLabel, qsTr("Change"));
+        modal.currentIndex = modal._rowSystems;
+        compare(modal.focusedActionLabel, qsTr("Change"));
+        modal.currentIndex = modal._rowToggle;
+        compare(modal.focusedActionLabel, qsTr("Toggle"));
+        modal.currentIndex = modal._rowStart;
+        compare(modal.focusedActionLabel, qsTr("Start"));
     }
 }

--- a/tests/ui/tst_screen_state_overlay.qml
+++ b/tests/ui/tst_screen_state_overlay.qml
@@ -94,4 +94,75 @@ TestCase {
         overlay.cueCenterY = windowSpace.height / 2 - screenContent.y;
         _verifyNear(_cueCenterInWindowSpace(), windowSpace.height / 2, "window-space match");
     }
+
+    // Returns the two stacked Texts in the Column: title, then detail.
+    function _stateTexts(): var {
+        const found = [];
+        for (let i = 0; i < overlay.children.length; ++i) {
+            const child = overlay.children[i];
+            for (let j = 0; j < child.children.length; ++j) {
+                const leaf = child.children[j];
+                if (leaf.wrapMode !== undefined && leaf.text !== undefined)
+                    found.push(leaf);
+            }
+        }
+        return found;
+    }
+
+    function _enterEmptyState(): void {
+        overlay.loading = false;
+        overlay.errorMessage = "";
+        overlay.count = 0;
+    }
+
+    // The empty state's second line only paints when the caller supplies
+    // one, so every existing single-line call site is unchanged.
+    function test_empty_detail_hidden_when_not_supplied(): void {
+        _enterEmptyState();
+        overlay.emptyText = "No games found yet";
+        overlay.emptyDetailText = "";
+        const texts = _stateTexts();
+        compare(texts.length, 2, "title and detail Texts both exist");
+        verify(texts[0].visible, "title paints in the empty state");
+        verify(!texts[1].visible, "detail stays hidden with no emptyDetailText");
+    }
+
+    // Carbon's empty-state anatomy: title plus a body naming the next
+    // step. `error` already had this; `empty` gained it for the Hub's
+    // indexing-aware copy.
+    function test_empty_detail_paints_when_supplied(): void {
+        _enterEmptyState();
+        overlay.emptyText = "Updating the media database";
+        overlay.emptyDetailText = "Your games appear here as Core finds them.";
+        const texts = _stateTexts();
+        verify(texts[0].visible);
+        compare(texts[0].text, "Updating the media database");
+        verify(texts[1].visible, "detail paints once emptyDetailText is set");
+        compare(texts[1].text, "Your games appear here as Core finds them.");
+    }
+
+    // The error state keeps its own detail line; `emptyDetailText` must
+    // not leak into it.
+    function test_error_detail_still_uses_error_text(): void {
+        overlay.loading = false;
+        overlay.count = 0;
+        overlay.emptyDetailText = "empty detail";
+        overlay.errorText = "Check Zaparoo Core and try again.";
+        overlay.errorMessage = "boom";
+        const texts = _stateTexts();
+        compare(texts[1].text, "Check Zaparoo Core and try again.");
+        overlay.errorMessage = "";
+    }
+
+    // Regression: the title had no width and no wrapMode, so a long
+    // string laid out at natural width and ran off a 240p frame instead
+    // of wrapping. Both lines now share the same measure.
+    function test_long_title_wraps_within_the_overlay(): void {
+        _enterEmptyState();
+        overlay.emptyText = "No systems available. Run Update media database from Settings.";
+        overlay.emptyDetailText = "";
+        const texts = _stateTexts();
+        verify(texts[0].width <= overlay.width, "title never exceeds the overlay width");
+        verify(texts[0].lineCount > 1, "a long title wraps rather than overflowing");
+    }
 }

--- a/tests/ui/tst_settings_field_control.qml
+++ b/tests/ui/tst_settings_field_control.qml
@@ -34,6 +34,7 @@ TestCase {
         compare(screen._fieldControl("showHidden"), "toggle");
         compare(screen._fieldControl("reduceMotion"), "toggle");
         compare(screen._fieldControl("aboutLicense"), "navigate");
+        compare(screen._fieldControl("documentation"), "navigate");
         compare(screen._fieldControl("crtCalibration"), "navigate");
         compare(screen._fieldControl("pageDisplayInterface"), "navigate");
         compare(screen._fieldControl("updateMediaDb"), "action");
@@ -41,6 +42,43 @@ TestCase {
         compare(screen._fieldControl("uploadLog"), "action");
         compare(screen._fieldControl("resolution"), "picker");
         compare(screen._fieldControl("colorScheme"), "picker");
+    }
+
+    // The Documentation row shipped with a `requestAccept("documentation")`
+    // handler in Main.qml but no branch in `fieldCommit.onDeferred` to emit
+    // it, so Accept fell through to `_openPickerForField`, which has no
+    // "documentation" case and returns silently. `focusedFieldIsAction`
+    // already listed the id, so the help bar promised "Open" on a row that
+    // did nothing. Drive the real Accept path rather than the signal
+    // directly — the dead branch was in the dispatch, not in the router.
+    function test_documentation_accept_emits_the_router_payload(): void {
+        screen._switchPage(screen.pageSupportAbout);
+        const fields = screen.fields;
+        let idx = -1;
+        for (let i = 0; i < fields.length; i++) {
+            if (fields[i].id === "documentation") {
+                idx = i;
+                break;
+            }
+        }
+        verify(idx >= 0, "documentation field not found on the Support & About page");
+        screen.currentIndex = idx;
+        compare(screen.focusedActionLabel, "Open");
+
+        acceptSpy.clear();
+        screen.handleAction("accept");
+        // The dispatch is deferred behind the row's push-in cue.
+        acceptSpy.wait();
+        compare(acceptSpy.count, 1);
+        compare(acceptSpy.signalArguments[0][0], "documentation");
+        screen._switchPage(screen.pageRoot);
+    }
+
+    SignalSpy {
+        id: acceptSpy
+
+        target: screen
+        signalName: "requestAccept"
     }
 
     // `colorScheme` is a picker (left/right is a no-op, Accept opens the

--- a/tests/ui/tst_status_line.qml
+++ b/tests/ui/tst_status_line.qml
@@ -348,7 +348,7 @@ TestCase {
             "mediaActivityEnabled": true
         });
         verify(line !== null);
-        compare(line._label, "Scraping: Super Nintendo");
+        compare(line._label, "Importing: Super Nintendo");
 
         const track = findChild(line, "statusLineTrack");
         verify(track !== null);
@@ -382,7 +382,7 @@ TestCase {
                 setup: function () {
                     Browse.MediaStatus.scraping = true;
                 },
-                expected: "Scraping…"
+                expected: "Importing…"
             }
         ];
     }
@@ -405,7 +405,7 @@ TestCase {
             "mediaActivityEnabled": true
         });
         verify(line !== null);
-        compare(line._label, "Scraping paused: game running");
+        compare(line._label, "Importing paused: game running");
     }
 
     // The track is the rightmost element and a short label shrink-wraps
@@ -504,7 +504,7 @@ TestCase {
         Browse.MediaStatus.scraping = true;
         Browse.MediaStatus.scraping = false;
 
-        compare(line._terminalMessage, "Scrape failed: disk full");
+        compare(line._terminalMessage, "Import failed: disk full");
     }
 
     function test_new_task_clears_a_pending_terminal_message(): void {


### PR DESCRIPTION
Stacked on #398. Review that one first; this PR's diff is only the commit on top.

Indexing is a true background process in Core, but the frontend never said so, and the one string that mentioned artwork was false.

- `SettingsScreen`'s "Scrape metadata" row claimed it "Downloads box art, descriptions, and tags". Core imports local files and downloads nothing. zaparoo.org's troubleshooting page has to state that three separate times, which is what leaving it unsaid here costs.
- Every metadata entry point now reads "Get metadata" and routes through the setup modal, pre-scoped. The system and category context entries previously bypassed the modal entirely with `scraper_id: "gamelist.xml"` and `force: false` hardcoded, so the user's source, scope and replace choices were silently ignored. Entry points stay source-agnostic because the mechanism is a property of the chosen source; the modal commits to it ("Start import") once one is picked, and the verb becomes conditional on the frontend when real network scrapers land.
- New game-level "Get metadata" entry on games, favorites and recents. A coverless game is the moment a user goes looking for artwork, and this is the menu they open. Core scrapes by system, not by game (`MediaScrapeParams` is `{ scraperId, systems, force }`), so it scopes to the containing system, and routing through the modal means that wider scope is visible in the Systems row rather than silent.
- The modal carries the prerequisite and a docs link, and Settings > About gained a Documentation row with a scannable code. A QR is unreadable at 240p over composite, so the URL leads and the code accelerates.
- `HubScreen`'s empty state always read "No systems available. Run Update media database from Settings." During a first index that is false and reads as a failure report. It now gates on `MediaStatus.indexing` and names the operation the Settings row uses, so the first thing a new user reads teaches the name of the thing they later go looking for.
- `ScreenStateOverlay`'s empty state gained the detail line its error state already had. Its title had no `width` or `wrapMode`, so the old 58-character string laid out at natural width and overflowed a 320px 240p frame instead of wrapping.
- `IndexSetupModal` and `ScrapeSetupModal` had no `helpEntries` branch, so the help bar advertised the Settings screen's rows while a modal owned input. Both now expose `focusedActionLabel`, and the bar describes the press rather than the feature.
- Dropped the 3-8 `ContextMenu` entry cap from docs and code. It was stale: `rowViewport` scrolls and `move()` wraps, so the last entry is one press up from the first. Fit at 240p is the real test, not a count.
- Removed `FirstRunIndexModal` residue from 17 catalogs and two stale comments; the component went in #377. Mock Core gained a `scrapers` handler, without which the Source picker is always empty off-device.

Follow-ups not in this PR: a Core request for `media.scrape` filtering by folder/file and by tag, and the frontend change to narrow the game entry to a single game once Core supports it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Get metadata” workflow with selectable sources and scoped imports from system, category, or game menus.
  * Added Documentation access with a QR code.
  * Added clearer media-database update and empty-state messaging.
  * Menus now support any number of entries, wrapping navigation and scrolling when needed.

* **Improvements**
  * Updated “scraping” terminology to “importing” throughout the interface.
  * Improved QR code, setup-modal guidance, empty-state layouts, and picker sizing.
  * Updated translations and licensing contact information across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->