### PR TITLE
chore(release): bump version to 1.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.22)
 
 project(
     zaparoo-frontend
-    VERSION 1.2.2
+    VERSION 1.3.0
     DESCRIPTION "Zaparoo Core frontend"
     HOMEPAGE_URL "https://zaparoo.org"
     LANGUAGES CXX

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "mock-core"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "futures-util",
  "serde",
@@ -1461,11 +1461,11 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zaparoo-build-info"
-version = "1.2.2"
+version = "1.3.0"
 
 [[package]]
 name = "zaparoo-core"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "dirs-next",
  "futures-util",
@@ -1486,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "zaparoo-frontend-rs"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
  "base64",
  "cxx",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -7,7 +7,7 @@ members = ["build-info", "frontend", "mock-core", "zaparoo-core"]
 resolver = "2"
 
 [workspace.package]
-version      = "1.2.2"
+version      = "1.3.0"
 edition      = "2021"
 rust-version = "1.97"
 license      = "LicenseRef-PolyForm-Noncommercial-1.0.0"


### PR DESCRIPTION
## Summary

- Bump CMake and Rust workspace versions from 1.2.2 to 1.3.0.
- Regenerate Cargo.lock for all workspace packages.

## Validation

- `just lint`
- `just test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the project version to 1.3.0 across supported build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->