### PR TITLE
fix(mister): rebalance image caches and prefer frontend as OOM victim

### DIFF
--- a/rust/frontend/src/media_image_cache.rs
+++ b/rust/frontend/src/media_image_cache.rs
@@ -63,15 +63,12 @@ const KEY_SEPARATOR: u8 = 0x1F;
 /// `system_id/path` pair (~64 B) → roughly 400 KiB worst-case.
 const NEGATIVE_MEMO_CAP: usize = 4096;
 
-/// Hard cap on cached image bytes. Sized to hold several pages of
-/// full-resolution tiles while leaving headroom for Core, the FPGA
-/// wrapper, and a loaded game core. On `MiSTer` (492 MiB total, no swap)
-/// measured free RAM with the frontend running was ~367 MiB, so 128 MiB
-/// leaves ~239 MiB for the rest of the system. When `max_cover_size` is
-/// set (resized covers average ~30 KB), this cap holds thousands of
-/// tiles rather than the ~110 full-resolution SNES covers that fit at
-/// 64 MiB.
-const CACHE_CAP_BYTES: usize = 128 * 1024 * 1024;
+/// Hard cap on encoded image bytes. This is one part of a process-wide image
+/// budget: decoded images and Qt Quick pixmaps have separate caps. `MiSTer` has
+/// 492 MiB total and no swap, so this cache must leave enough headroom for
+/// those caches, Core, Main, and transient image decoding. At roughly 30 KiB
+/// per resized cover, 64 MiB still retains more than 2,000 thumbnails.
+const CACHE_CAP_BYTES: usize = 64 * 1024 * 1024;
 /// Core's `localPath` response is a resized thumbnail, never an arbitrary
 /// source image. Bound one file well below total cache capacity so a corrupt,
 /// replaced, or remote-host path cannot allocate `MiSTer`'s remaining RAM.
@@ -825,10 +822,9 @@ impl CacheState {
     /// `BTreeMap`'s first element is its smallest key, i.e. the oldest
     /// `last_used`). Replaces an old O(N) linear scan over `map` per
     /// evicted entry — fine at the "a few hundred entries" the cache was
-    /// originally sized for, but the cap comment on `CACHE_CAP_BYTES`
-    /// says 128 MiB holds "thousands of tiles" once `max_cover_size` is
-    /// set, and `get_bytes` takes the cache's write lock too, so every
-    /// cover paint was serialising against an eviction pass whose cost
+    /// originally sized for, but resized covers let the bounded cache hold
+    /// thousands of tiles. Since `get_bytes` takes the cache's write lock too,
+    /// every cover paint was serialising against an eviction pass whose cost
     /// scaled with total cache size once the cache was actually full.
     fn evict_until_fits(&mut self, cap_bytes: usize) {
         while self.total_bytes > cap_bytes {

--- a/rust/frontend/src/mister_runtime.rs
+++ b/rust/frontend/src/mister_runtime.rs
@@ -586,6 +586,23 @@ fn acquire_resource_lease() {
 }
 
 #[cfg(any(zaparoo_runtime = "mister", test))]
+fn set_oom_score_adj(path: &std::path::Path) -> std::io::Result<()> {
+    std::fs::write(path, b"500")
+}
+
+#[cfg(zaparoo_runtime = "mister")]
+fn prefer_frontend_as_oom_victim() {
+    // Frontend is supervised by Main and restarts with empty caches; Core owns
+    // device services and durable operations. Prefer sacrificing frontend
+    // under MiSTer's swap-free memory pressure instead of silently losing Core.
+    let path = std::path::Path::new("/proc/self/oom_score_adj");
+    match set_oom_score_adj(path) {
+        Ok(()) => tracing::info!("set frontend OOM priority above Core"),
+        Err(error) => tracing::warn!("failed to set frontend OOM priority: {error}"),
+    }
+}
+
+#[cfg(any(zaparoo_runtime = "mister", test))]
 fn core_service_start_command() -> std::process::Command {
     let mut command = std::process::Command::new("/usr/bin/taskset");
     command.args([
@@ -605,6 +622,7 @@ pub fn ensure_core_service_running() {
     #[cfg(zaparoo_runtime = "mister")]
     {
         use tracing::{info, warn};
+        prefer_frontend_as_oom_victim();
         acquire_resource_lease();
         info!("spawning core service wrapper with CPU affinity 0-1");
         if let Err(e) = core_service_start_command().spawn() {
@@ -615,10 +633,16 @@ pub fn ensure_core_service_running() {
 
 #[cfg(test)]
 mod tests {
+    #![allow(
+        clippy::expect_used,
+        clippy::unwrap_used,
+        reason = "tests should fail-fast on unexpected errors"
+    )]
+
     use super::{
         automatic_render_size, configured_render_size_supported, core_service_start_command,
         debounce_output_change, infer_full_size_from_half, parse_fb_mode, parse_virtual_size,
-        scale_probe_verified, selectable_render_sizes, vmode_resolution_command,
+        scale_probe_verified, selectable_render_sizes, set_oom_score_adj, vmode_resolution_command,
         vmode_result_accepted, vmode_result_timed_out, vmode_scale_command, VmodeOutcome,
     };
 
@@ -792,6 +816,13 @@ mod tests {
         ));
         assert!(!vmode_result_accepted(Some(2), b"", b""));
         assert!(!vmode_result_accepted(None, b"", b"terminated"));
+    }
+
+    #[test]
+    fn writes_frontend_oom_score_adjustment() {
+        let file = tempfile::NamedTempFile::new().expect("create score file");
+        set_oom_score_adj(file.path()).expect("write score");
+        assert_eq!(std::fs::read_to_string(file.path()).unwrap(), "500");
     }
 
     #[test]

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -151,31 +151,14 @@ int main(int argc, char* argv[]) // NOLINT
             Qt::HighDpiScaleFactorRoundingPolicy::Floor);
     }
 
-    // Qt Quick's own decoded-pixmap cache (QQuickPixmapStore) has no
-    // documented default cap tuned for this app, and every cover `Image`
-    // in Tile.qml deliberately leaves `cache: true` (see that file's
-    // doc comment -- a constant `sourceSize` needs the pixmap cache so a
-    // reload short-circuits to it instead of re-decoding). That cache
-    // sits on top of, not instead of, the Rust-side media_image_cache's
-    // own 128 MiB encoded-bytes budget: a decoded RGBA cover is several
-    // times its encoded size, so an unbounded pixmap cache can make the
-    // real image-memory ceiling far exceed what CACHE_CAP_BYTES's own
-    // sizing math assumed (see that constant's doc comment -- it was
-    // sized as if it were the only image-memory consumer). On MiSTer's
-    // swap-free ~492 MiB this reads as a gradual system-wide slowdown
-    // (page cache eviction), not an OOM, which is easy to miss without
-    // an explicit cap to point at. 32 MiB is a conservative starting
-    // point -- room for a full grid page or two of decoded tiles without
-    // competing heavily with the encoded-bytes budget or the rest of
-    // what MiSTer needs (Core, the FPGA wrapper, the active core); tune
-    // with a real long-session capture (ZAPAROO_DEBUG=1) rather than
-    // guessing further from here. QML_PIXMAP_CACHE_LIMIT is in
-    // kilobytes and must be set before the QML engine's first image
-    // decode, so this has to happen this early, ahead of both
-    // QGuiApplication and QQmlApplicationEngine construction.
+    // QQuickPixmapStore retains decoded images independently of both media
+    // image caches. Keep its Qt 6.7 default explicit: raising this to 32 MiB
+    // can exhaust MiSTer's swap-free 492 MiB when the other caches fill and
+    // make Core a kernel OOM victim. QML_PIXMAP_CACHE_LIMIT is in KiB and must be
+    // set before the first image decode. Preserve an operator override.
     if (qEnvironmentVariableIsEmpty("QML_PIXMAP_CACHE_LIMIT"))
     {
-        qputenv("QML_PIXMAP_CACHE_LIMIT", QByteArrayLiteral("32768"));
+        qputenv("QML_PIXMAP_CACHE_LIMIT", QByteArrayLiteral("2048"));
     }
 
     QGuiApplication::setApplicationName("Zaparoo Frontend");

--- a/src/app/media_image_provider.cpp
+++ b/src/app/media_image_provider.cpp
@@ -326,11 +326,11 @@ void MediaImageResponse::run()
     emit finished();
 }
 
-// 64 MB cap: a scaled 374×512 ARGB grid cover is ~765 KB, so this holds ~85
-// decoded covers — most of a large system's worth — while leaving SD page
-// cache room inside MiSTer's measured ~307 MB available. Tune after re-measuring
-// against a real browse session.
-static constexpr int kDecodedCacheMaxBytes = 64 * 1024 * 1024;
+// Decoded images share MiSTer's memory budget with the encoded-byte cache and
+// Qt Quick's pixmap cache. A scaled 374×512 ARGB cover is about 765 KiB, so
+// 32 MiB retains one full grid page while preserving headroom for Core, Main,
+// and transient decode copies on the swap-free 492 MiB system.
+static constexpr int kDecodedCacheMaxBytes = 32 * 1024 * 1024;
 
 MediaImageProvider::MediaImageProvider() : m_decodedCache(kDecodedCacheMaxBytes)
 {


### PR DESCRIPTION
- Lower the encoded-bytes image cache cap from 128 MiB to 64 MiB and the decoded-image cache from 64 MiB to 32 MiB. Together with Qt Quick's pixmap cache these previously assumed each was the only image-memory consumer, which could exhaust MiSTer's swap-free 492 MiB once the caches filled.
- Set `QML_PIXMAP_CACHE_LIMIT` to Qt's 2 MiB default instead of 32 MiB. An operator override in the environment is still honored.
- Write 500 to `/proc/self/oom_score_adj` on MiSTer before starting Core. The frontend is supervised by Main and restarts with empty caches, so under memory pressure the kernel now reclaims it rather than Core.
- Add a unit test for the OOM score write and refresh the cache sizing comments to describe the shared budget.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Reduced image and pixmap cache limits to lower overall memory usage.
  - Updated cache behavior to support efficient handling of resized cover images.
  - Adjusted MiSTer runtime memory pressure handling so the frontend is more likely to be selected for termination when system memory is critically low.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->