### PR TITLE
fix(mister): restore framebuffer mmap on kernels without fb_mmap

### DIFF
--- a/cmake/ZaparooRust.cmake
+++ b/cmake/ZaparooRust.cmake
@@ -99,6 +99,8 @@ qt_add_executable(
     "${CMAKE_SOURCE_DIR}/src/app/custom_image_provider.cpp"
     "${CMAKE_SOURCE_DIR}/src/app/native_video_writer.h"
     "${CMAKE_SOURCE_DIR}/src/app/native_video_writer.cpp"
+    "${CMAKE_SOURCE_DIR}/src/app/fb_mmap_fallback.h"
+    "${CMAKE_SOURCE_DIR}/src/app/fb_mmap_fallback.cpp"
 )
 target_include_directories(
     frontend
@@ -109,6 +111,19 @@ target_compile_definitions(
     frontend PRIVATE ZAPAROO_VERSION="${CMAKE_PROJECT_VERSION}"
                      ZAPAROO_DEFAULT_INTERFACE_PROFILE="${ZAPAROO_DEFAULT_INTERFACE_PROFILE}"
 )
+
+# MiSTer kernels from 6.18 carry a MiSTer_fb driver with no `fb_mmap`, so mmap() on /dev/fb0 returns
+# ENODEV and Qt's linuxfb plugin aborts startup with "no screens available". --wrap redirects the
+# mmap/munmap calls made from Qt's statically linked linuxfb plugin (and from
+# native_video_writer.cpp) into src/app/fb_mmap_fallback.cpp, which reaches the same physical pixels
+# through /dev/mem. This keeps the workaround in our tree instead of forking Qt. glibc is linked
+# dynamically, so libc's internal mmap calls resolve inside libc.so and are not affected. See
+# src/app/fb_mmap_fallback.h.
+if(ZAPAROO_EMBEDDED)
+    target_link_options(
+        frontend PRIVATE "LINKER:--wrap=mmap" "LINKER:--wrap=mmap64" "LINKER:--wrap=munmap"
+    )
+endif()
 
 # For static Qt (ARM32): define QT_STATIC so main.cpp's #ifdef fires. Qt itself defines this in its
 # headers, but the compiler may not see it before the first #include unless we make it explicit here

--- a/src/app/fb_mmap_fallback.cpp
+++ b/src/app/fb_mmap_fallback.cpp
@@ -62,6 +62,10 @@ struct Entry
     // staged mode it is cached anonymous RAM copied out by the flush.
     void* handed;
     void* physMap;
+    // Borrowers currently holding `handed`. Qt's screen and the CRT writer map
+    // the same surface independently, so the mapping outlives whichever of
+    // them releases first.
+    int refs;
 };
 
 std::mutex g_mutex;
@@ -140,6 +144,7 @@ void* redirect(size_t length, int fd, int64_t offset)
     {
         if (g_entries[i].physStart == physStart && length <= g_entries[i].length)
         {
+            ++g_entries[i].refs;
             return g_entries[i].handed;
         }
     }
@@ -189,7 +194,7 @@ void* redirect(size_t length, int fd, int64_t offset)
         handed = staging;
     }
 
-    g_entries[g_entryCount] = Entry{physStart, length, handed, physMap};
+    g_entries[g_entryCount] = Entry{physStart, length, handed, physMap, 1};
     ++g_entryCount;
     g_active = true;
     setStatus("framebuffer mmap fallback: engaged in %s mode, %zu bytes at 0x%lx via /dev/mem "
@@ -243,10 +248,20 @@ extern "C" int __wrap_munmap(void* addr, size_t length)
             {
                 continue;
             }
-            // Qt unmaps its surface when the screen goes away. Drop the entry
-            // first so a queued flush cannot write through a stale pointer,
-            // and release the /dev/mem mapping the caller knows nothing about.
+            // Only the last borrower may tear the mapping down. Releasing on
+            // the first unmap would hand the survivor freed address space:
+            // `stopNativeVideoWriter()` runs before Qt's screen destructor, so
+            // in the CRT geometries the writer always releases first.
+            if (--g_entries[i].refs > 0)
+            {
+                return 0;
+            }
+            // Drop the entry before unmapping so a queued flush cannot write
+            // through a stale pointer, and release the /dev/mem mapping the
+            // caller knows nothing about.
             void* physMap = g_entries[i].physMap;
+            // The entry's length, not the caller's: a borrower that mapped
+            // less than the surface would otherwise leave part of it mapped.
             const size_t mapped = g_entries[i].length;
             const bool staged = g_entries[i].handed != physMap;
             g_entries[i] = g_entries[g_entryCount - 1];
@@ -258,11 +273,10 @@ extern "C" int __wrap_munmap(void* addr, size_t length)
             if (staged)
             {
                 __real_munmap(physMap, mapped);
-                return __real_munmap(addr, length);
             }
-            // Direct mode: `addr` is the /dev/mem mapping itself, so the
-            // caller's own munmap below releases it.
-            break;
+            // Direct mode: `addr` is the /dev/mem mapping itself, so this
+            // single unmap releases it.
+            return __real_munmap(addr, mapped);
         }
     }
     return __real_munmap(addr, length);

--- a/src/app/fb_mmap_fallback.cpp
+++ b/src/app/fb_mmap_fallback.cpp
@@ -1,0 +1,338 @@
+// Zaparoo Frontend
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+#include "fb_mmap_fallback.h"
+
+#if defined(ZAPAROO_EMBEDDED_BUILD) && defined(__linux__)
+
+#include <QLoggingCategory>
+#include <cerrno>
+#include <cstdarg>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fcntl.h>
+#include <linux/fb.h>
+#include <mutex>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <unistd.h>
+
+// The linker's --wrap gives us __real_* aliases for the genuine libc entry
+// points. mmap64 is wrapped alongside mmap because Qt and our own translation
+// units compile with _FILE_OFFSET_BITS=64, where glibc rewrites `mmap` to
+// `mmap64`; wrapping only one of the two would silently miss every call.
+//
+// The offset types are spelled out rather than written as `off_t`/`off64_t` on
+// purpose. `off_t` changes width with _FILE_OFFSET_BITS, so using it here would
+// make these declarations disagree with the libc symbols they bind to whenever
+// this file's feature macros differ from the caller's, and on ARM32 a 64-bit
+// argument occupies an aligned register pair where a 32-bit one does not. The
+// legacy `mmap` always takes a word-sized offset (`long`) and `mmap64` always
+// takes a 64-bit one, whatever the macros say.
+extern "C"
+{
+    void* __real_mmap(void* addr, size_t length, int prot, int flags, int fd, long offset);
+    void* __real_mmap64(void* addr, size_t length, int prot, int flags, int fd, int64_t offset);
+    int __real_munmap(void* addr, size_t length);
+    void* __wrap_mmap(void* addr, size_t length, int prot, int flags, int fd, long offset);
+    void* __wrap_mmap64(void* addr, size_t length, int prot, int flags, int fd, int64_t offset);
+    int __wrap_munmap(void* addr, size_t length);
+}
+
+namespace
+{
+
+// One entry per distinct physical range. In practice this is one (Qt's
+// surface), or two when the CRT path also maps fb0 for its DDR copy.
+constexpr int kMaxEntries = 4;
+// FB_MAJOR. /dev/fb0 is 29,0 and the check keeps the fallback from firing on
+// an unrelated fd that happens to fail with ENODEV.
+constexpr unsigned int kFbMajor = 29;
+
+struct Entry
+{
+    unsigned long physStart;
+    size_t length;
+    // Buffer handed back to the caller. In direct mode this is `physMap`; in
+    // staged mode it is cached anonymous RAM copied out by the flush.
+    void* handed;
+    void* physMap;
+};
+
+std::mutex g_mutex;
+Entry g_entries[kMaxEntries];
+int g_entryCount = 0;
+bool g_active = false;
+bool g_staged = false;
+char g_status[256] = "framebuffer mmap fallback: not engaged (kernel fbdev mmap works)";
+
+void setStatus(const char* format, ...) __attribute__((format(printf, 1, 2)));
+void setStatus(const char* format, ...)
+{
+    va_list args;
+    va_start(args, format);
+    vsnprintf(g_status, sizeof(g_status), format, args);
+    va_end(args);
+}
+
+bool isFramebufferFd(int fd)
+{
+    struct stat info = {};
+    if (fstat(fd, &info) != 0 || !S_ISCHR(info.st_mode))
+    {
+        return false;
+    }
+    return major(info.st_rdev) == kFbMajor;
+}
+
+// Resolved once, on the first redirect, so a later setenv cannot leave two
+// mappings of the same surface disagreeing about the strategy.
+void resolveMode()
+{
+    const char* mode = getenv("ZAPAROO_FB_FALLBACK");
+    g_staged = mode != nullptr && strcmp(mode, "staged") == 0;
+}
+
+bool disabled()
+{
+    const char* mode = getenv("ZAPAROO_FB_FALLBACK");
+    return mode != nullptr && strcmp(mode, "off") == 0;
+}
+
+// Caller holds g_mutex.
+void* redirect(size_t length, int fd, int64_t offset)
+{
+    fb_fix_screeninfo fixed = {};
+    // FBIOGET_FSCREENINFO is handled by the fbdev core, not the driver, so it
+    // still works on the very kernel whose mmap is missing. This is what makes
+    // the fallback self-configuring rather than hardcoding 0x22001000.
+    if (ioctl(fd, FBIOGET_FSCREENINFO, &fixed) != 0)
+    {
+        setStatus("framebuffer mmap fallback: FBIOGET_FSCREENINFO failed (%s)", strerror(errno));
+        return MAP_FAILED;
+    }
+    if (fixed.smem_start == 0 || fixed.smem_len == 0)
+    {
+        setStatus("framebuffer mmap fallback: driver reports no framebuffer memory "
+                  "(smem_start=0x%lx smem_len=%u)",
+                  static_cast<unsigned long>(fixed.smem_start), fixed.smem_len);
+        return MAP_FAILED;
+    }
+    if (offset < 0 || static_cast<uint64_t>(offset) + length > fixed.smem_len)
+    {
+        setStatus("framebuffer mmap fallback: request (offset=%lld len=%zu) exceeds the %u byte "
+                  "framebuffer; not redirected",
+                  static_cast<long long>(offset), length, fixed.smem_len);
+        return MAP_FAILED;
+    }
+
+    const unsigned long physStart = fixed.smem_start + static_cast<unsigned long>(offset);
+
+    // A second mapping of the same surface has to see the same bytes, exactly
+    // as two MAP_SHARED mappings of fb0 did. Without this the CRT writer would
+    // copy a blank buffer to the FPGA while Qt drew into a different one.
+    for (int i = 0; i < g_entryCount; ++i)
+    {
+        if (g_entries[i].physStart == physStart && length <= g_entries[i].length)
+        {
+            return g_entries[i].handed;
+        }
+    }
+
+    if (g_entryCount == kMaxEntries)
+    {
+        setStatus("framebuffer mmap fallback: entry table full; not redirected");
+        return MAP_FAILED;
+    }
+
+    const int memFd = open("/dev/mem", O_RDWR | O_SYNC | O_CLOEXEC);
+    if (memFd < 0)
+    {
+        setStatus("framebuffer mmap fallback: cannot open /dev/mem (%s)", strerror(errno));
+        return MAP_FAILED;
+    }
+    void* physMap = __real_mmap64(nullptr, length, PROT_READ | PROT_WRITE, MAP_SHARED, memFd,
+                                  static_cast<int64_t>(physStart));
+    close(memFd);
+    if (physMap == MAP_FAILED)
+    {
+        setStatus("framebuffer mmap fallback: cannot map /dev/mem at 0x%lx+%zu (%s)", physStart,
+                  length, strerror(errno));
+        return MAP_FAILED;
+    }
+
+    if (g_entryCount == 0)
+    {
+        resolveMode();
+    }
+
+    void* handed = physMap;
+    if (g_staged)
+    {
+        void* staging = __real_mmap64(nullptr, length, PROT_READ | PROT_WRITE,
+                                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (staging == MAP_FAILED)
+        {
+            setStatus("framebuffer mmap fallback: cannot allocate %zu byte staging buffer (%s)",
+                      length, strerror(errno));
+            __real_munmap(physMap, length);
+            return MAP_FAILED;
+        }
+        // Seed from the live framebuffer so a first frame that only touches
+        // part of the surface does not publish uninitialised memory.
+        memcpy(staging, physMap, length);
+        handed = staging;
+    }
+
+    g_entries[g_entryCount] = Entry{physStart, length, handed, physMap};
+    ++g_entryCount;
+    g_active = true;
+    setStatus("framebuffer mmap fallback: engaged in %s mode, %zu bytes at 0x%lx via /dev/mem "
+              "(kernel fbdev has no fb_mmap)",
+              g_staged ? "staged" : "direct", length, physStart);
+    return handed;
+}
+
+} // namespace
+
+extern "C" void* __wrap_mmap(void* addr, size_t length, int prot, int flags, int fd, long offset)
+{
+    return __wrap_mmap64(addr, length, prot, flags, fd, static_cast<int64_t>(offset));
+}
+
+extern "C" void* __wrap_mmap64(void* addr, size_t length, int prot, int flags, int fd,
+                               int64_t offset)
+{
+    void* result = __real_mmap64(addr, length, prot, flags, fd, offset);
+    if (result != MAP_FAILED)
+    {
+        return result;
+    }
+
+    // Anything other than "this fbdev has no mmap" is a real failure and must
+    // reach the caller untouched, errno included.
+    const int savedErrno = errno;
+    if (savedErrno != ENODEV || fd < 0 || addr != nullptr || disabled() || !isFramebufferFd(fd))
+    {
+        errno = savedErrno;
+        return MAP_FAILED;
+    }
+
+    std::lock_guard<std::mutex> lock(g_mutex);
+    void* redirected = redirect(length, fd, offset);
+    if (redirected == MAP_FAILED)
+    {
+        errno = savedErrno;
+        return MAP_FAILED;
+    }
+    return redirected;
+}
+
+extern "C" int __wrap_munmap(void* addr, size_t length)
+{
+    {
+        std::lock_guard<std::mutex> lock(g_mutex);
+        for (int i = 0; i < g_entryCount; ++i)
+        {
+            if (g_entries[i].handed != addr)
+            {
+                continue;
+            }
+            // Qt unmaps its surface when the screen goes away. Drop the entry
+            // first so a queued flush cannot write through a stale pointer,
+            // and release the /dev/mem mapping the caller knows nothing about.
+            void* physMap = g_entries[i].physMap;
+            const size_t mapped = g_entries[i].length;
+            const bool staged = g_entries[i].handed != physMap;
+            g_entries[i] = g_entries[g_entryCount - 1];
+            --g_entryCount;
+            if (g_entryCount == 0)
+            {
+                g_active = false;
+            }
+            if (staged)
+            {
+                __real_munmap(physMap, mapped);
+                return __real_munmap(addr, length);
+            }
+            // Direct mode: `addr` is the /dev/mem mapping itself, so the
+            // caller's own munmap below releases it.
+            break;
+        }
+    }
+    return __real_munmap(addr, length);
+}
+
+bool fbMmapFallbackActive()
+{
+    std::lock_guard<std::mutex> lock(g_mutex);
+    return g_active;
+}
+
+void flushFbMmapFallback()
+{
+    if (!g_active || !g_staged)
+    {
+        return;
+    }
+    std::lock_guard<std::mutex> lock(g_mutex);
+    for (int i = 0; i < g_entryCount; ++i)
+    {
+        if (g_entries[i].handed != g_entries[i].physMap)
+        {
+            memcpy(g_entries[i].physMap, g_entries[i].handed, g_entries[i].length);
+        }
+    }
+}
+
+void stopFbMmapFallback()
+{
+    std::lock_guard<std::mutex> lock(g_mutex);
+    if (g_entryCount == 0)
+    {
+        g_active = false;
+        return;
+    }
+    for (int i = 0; i < g_entryCount; ++i)
+    {
+        if (g_entries[i].handed != g_entries[i].physMap)
+        {
+            __real_munmap(g_entries[i].handed, g_entries[i].length);
+        }
+        __real_munmap(g_entries[i].physMap, g_entries[i].length);
+    }
+    g_entryCount = 0;
+    g_active = false;
+}
+
+void logFbMmapFallbackStatus()
+{
+    std::lock_guard<std::mutex> lock(g_mutex);
+    if (g_active)
+    {
+        qInfo("%s", g_status);
+    }
+    else
+    {
+        qDebug("%s", g_status);
+    }
+}
+
+#else
+
+#include <QLoggingCategory>
+
+bool fbMmapFallbackActive()
+{
+    return false;
+}
+void flushFbMmapFallback() {}
+void stopFbMmapFallback() {}
+void logFbMmapFallbackStatus() {}
+
+#endif

--- a/src/app/fb_mmap_fallback.h
+++ b/src/app/fb_mmap_fallback.h
@@ -1,0 +1,61 @@
+// Zaparoo Frontend
+// Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+// SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+
+#pragma once
+
+// Restores framebuffer mmap on MiSTer kernels whose fbdev driver has no
+// `fb_mmap`.
+//
+// Linux 6.8 ("fbdev: Remove default file-I/O implementations") deleted the
+// fbdev core's default read/write/mmap handlers; every driver must now supply
+// its own. `MiSTer_fb` still declares only fillrect/copyarea/imageblit/
+// setcolreg/ioctl, so from the 6.18 MiSTer kernel onwards `mmap()` on
+// /dev/fb0 fails with ENODEV and Qt's linuxfb plugin aborts the process with
+// "Cannot create window: no screens available". Main_MiSTer is unaffected
+// because it reaches the same pixels through /dev/mem, which is exactly the
+// route taken here.
+//
+// The shim is passive. It engages only when the real `mmap` fails with ENODEV
+// on a framebuffer character device, so a kernel with a fixed driver keeps the
+// native path and none of this code runs. It is installed via
+// `-Wl,--wrap=mmap` at the executable's link step, which rewrites the calls
+// made from Qt's statically linked linuxfb plugin and from
+// `native_video_writer.cpp` without patching Qt. glibc is linked dynamically,
+// so libc's own internal mmap calls resolve inside libc.so and are untouched.
+//
+// Two mapping strategies, selected by ZAPAROO_FB_FALLBACK:
+//
+//   direct (default) - hand the caller a /dev/mem mapping of the same
+//       physical range fbdev would have mapped. Semantics match the working
+//       5.15 behavior exactly: Qt composites straight into framebuffer
+//       memory and only the rects it actually touched are written. The
+//       mapping is uncached, but `QLinuxFbScreen::doRedraw()` blits with
+//       CompositionMode_Source (a straight overwrite, not a read-modify-write
+//       blend), and this UI is built to keep dirty rects small, so the
+//       written area per frame is small.
+//
+//   staged - hand the caller cached anonymous RAM and copy the whole surface
+//       out to framebuffer memory once per rendered frame. Every pixel moves
+//       every frame regardless of dirty area, which wins only when most of
+//       the screen changes on most frames. Requires the per-frame
+//       `flushFbMmapFallback()` hook to be wired, and therefore makes the
+//       display depend on `frameSwapped` firing, which `direct` does not.
+
+// True once the shim has redirected at least one framebuffer mapping.
+bool fbMmapFallbackActive();
+
+// Publish staged pixels to framebuffer memory. No-op in direct mode, and no-op
+// when the shim never engaged. Must run after Qt's `doRedraw()` has composited
+// into the mapping, so connect it to `QQuickWindow::frameSwapped` with
+// Qt::QueuedConnection for the same reason the native video writer does.
+void flushFbMmapFallback();
+
+// Release the shim's mappings and stop `flushFbMmapFallback()` from touching
+// them. Safe to call more than once.
+void stopFbMmapFallback();
+
+// One line describing what the shim did, for the startup log. The wrapper
+// itself cannot log: it runs during Qt platform initialization, before the
+// message handler is installed.
+void logFbMmapFallbackStatus();

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -8,6 +8,7 @@
 
 #include "baked_icon_atlas.h"
 #include "custom_image_provider.h"
+#include "fb_mmap_fallback.h"
 #include "frontend_arguments.h"
 #include "media_image_provider.h"
 #include "native_video_writer.h"
@@ -243,6 +244,10 @@ int main(int argc, char* argv[]) // NOLINT
 
     QGuiApplication app(qtArgc, qtArgv);
     startupTrace("cpp:QGuiApplication constructed");
+    // The linuxfb plugin maps the framebuffer while QGuiApplication is being
+    // constructed, so this is the first point at which the shim's outcome is
+    // known. The message handler is already installed, so it reaches the log.
+    logFbMmapFallbackStatus();
 
     // addApplicationFont returns -1 on failure (broken qrc path,
     // unreadable file). Logging the failure mode keeps a refactor that
@@ -508,6 +513,19 @@ int main(int argc, char* argv[]) // NOLINT
                          });
     }
 
+    // Staged fallback mode renders into RAM, so the framebuffer only changes
+    // when this runs. Queued for the same reason as the CRT copy below: the
+    // linuxfb QPA blits in `QFbScreen::doRedraw()` on a later event-loop
+    // iteration, so a direct connection would publish the previous frame.
+    // No-op in the default direct mode, where Qt composites into framebuffer
+    // memory itself and there is nothing to publish.
+    if (fbMmapFallbackActive() && rootWindow != nullptr)
+    {
+        QObject::connect(
+            rootWindow, &QQuickWindow::frameSwapped, rootWindow, []() { flushFbMmapFallback(); },
+            Qt::QueuedConnection);
+    }
+
     if (crtNativePathEnabled)
     {
         qInfo("CRT startup decision: initialising native video writer");
@@ -561,6 +579,7 @@ int main(int argc, char* argv[]) // NOLINT
                      {
                          zaparoo_rust_shutdown();
                          stopNativeVideoWriter();
+                         stopFbMmapFallback();
                          qInstallMessageHandler(nullptr);
                      });
 


### PR DESCRIPTION
- The MiSTer kernel moved from 5.15 to 6.18 on 2026-09-07. Linux 6.8 removed the fbdev core's default read/write/mmap handlers ("fbdev: Remove default file-I/O implementations") and requires each driver to supply its own, but `MiSTer_fb` still declares only fillrect/copyarea/imageblit/setcolreg/ioctl. `mmap()` on `/dev/fb0` therefore fails with `ENODEV`, Qt's linuxfb plugin cannot create a screen, and the frontend aborts at startup with "Cannot create window: no screens available". The kernel confirms it directly: `fb0: fb_WARN_ON_ONCE(!info->fbops->fb_mmap)`.
- Main_MiSTer is not affected, because it reaches the same pixels through `/dev/mem` rather than fbdev. That is the route this change takes.
- Adds `src/app/fb_mmap_fallback.{h,cpp}`, wrapping `mmap`/`mmap64`/`munmap` via `-Wl,--wrap` at the executable's link step so the calls made from Qt's statically linked linuxfb plugin are covered without forking Qt. glibc is linked dynamically, so libc's internal mmap calls resolve inside libc.so and are untouched.
- The wrapper is passive. Every call passes through untouched, errno included, and it only intervenes when the real call fails with `ENODEV` on a framebuffer character device (major 29). It then reads the framebuffer's physical range from `FBIOGET_FSCREENINFO`, which the fbdev core still answers, and maps that range through `/dev/mem`. Nothing is hardcoded, so a kernel with a fixed driver takes the native path and none of this code runs.
- Two strategies, selected by `ZAPAROO_FB_FALLBACK`. The default `direct` hands back the `/dev/mem` mapping and matches the previous behavior: `QLinuxFbScreen::doRedraw()` blits with `CompositionMode_Source` and only touches dirty rects, so little is written per frame. `staged` renders into cached RAM and publishes the whole surface once per frame, which only wins when most of the screen changes on most frames and makes the display depend on `frameSwapped` firing. `off` disables the shim.
- Mappings of the same physical range share one buffer, so the CRT writer's `fb0` mapping and Qt's observe identical bytes, as two `MAP_SHARED` mappings of `fb0` did. That path is exercised only in the three CRT geometries, where `native_video_writer` is active.
- Verified on a MiSTer running 6.18.38: the frontend reaches first frame instead of aborting, framebuffer memory holds live pixels where it was previously zeroed, and idle CPU is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added framebuffer compatibility for embedded systems where direct framebuffer mapping is unavailable.
  * Supports direct and staged framebuffer access modes, with staged rendering synchronized after each displayed frame.
  * Added runtime status reporting and cleanup when the application exits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->