### PR TITLE
feat(): Build commands that works on my machine

### DIFF
--- a/Dockerfile.slint-arm32
+++ b/Dockerfile.slint-arm32
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1.6
+# Zaparoo Frontend
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+# SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+#
+# Persistent ARM32 Slint toolchain for MiSTer. This image intentionally does
+# not copy application source: rebuild it only when this toolchain changes.
+
+ARG CROSS_IMAGE=ghcr.io/cross-rs/armv7-unknown-linux-musleabihf:main
+FROM ${CROSS_IMAGE} AS toolchain
+
+WORKDIR /src
+
+# Slint's compiler needs fontconfig. Keep Rust independent from Cross's
+# rolling toolchain so this repo always builds with its pinned Rust version.
+RUN apt-get update && apt-get install --assume-yes --no-install-recommends \
+        ca-certificates \
+        curl \
+        libfontconfig1-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Keep the Rust version explicit: Cross's `main` image changes independently
+# from this repository, while the workspace is pinned to Rust 1.97.0.
+ENV CARGO_HOME=/opt/cargo
+ENV RUSTUP_HOME=/opt/rustup
+ENV PATH=/opt/cargo/bin:${PATH}
+
+RUN mkdir -p "$CARGO_HOME" "$RUSTUP_HOME" && \
+    chmod -R a+rwx "$CARGO_HOME" "$RUSTUP_HOME" && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+        sh -s -- -y --no-modify-path --profile minimal --default-toolchain 1.97.0 && \
+    rustup target add armv7-unknown-linux-musleabihf

--- a/docs/building.md
+++ b/docs/building.md
@@ -161,6 +161,42 @@ file output/frontend
 # Should report: ELF 32-bit LSB executable, ARM, EABI5 ...
 ```
 
+## Slint builds (macOS and MiSTer)
+
+The experimental Slint frontend has two explicit build commands:
+
+```bash
+just slint-macos    # native macOS release binary
+just slint-mister   # static-musl ARM32 MiSTer binary, via Docker
+```
+
+Both use the Rust version in `rust-toolchain.toml` (`1.97.0`). Install Rustup
+once rather than relying on Homebrew's system Cargo:
+
+```bash
+brew install rustup
+```
+
+The build commands detect Homebrew's keg-only Rustup installation. On other
+platforms, install Rustup with the standard installer.
+
+The MiSTer command also needs Docker Desktop and Cross. `cross` is a small
+host-side Docker launcher; the compiler and Rust dependencies run inside its
+container:
+
+```bash
+cargo install cross
+```
+
+Outputs are `rust/target/release/frontend-slint` (macOS) and
+`rust/target/armv7-unknown-linux-musleabihf/release/frontend-slint` (MiSTer).
+`just slint-arm32` remains as an alias for `just slint-mister`.
+
+On Apple Silicon, the MiSTer command uses Docker's `linux/amd64` emulation:
+Cross's ARM32-musl build image is amd64-only. Override only when using a
+compatible custom image, for example
+`CROSS_DOCKER_PLATFORM=linux/amd64 just slint-mister`.
+
 ## ARM64 cross-build
 
 The ARM64 target mirrors the MiSTer Docker flow but uses a separate Qt +

--- a/docs/building.md
+++ b/docs/building.md
@@ -170,8 +170,8 @@ just slint-macos    # native macOS release binary
 just slint-mister   # static-musl ARM32 MiSTer binary, via Docker
 ```
 
-Both use the Rust version in `rust-toolchain.toml` (`1.97.0`). Install Rustup
-once rather than relying on Homebrew's system Cargo:
+The macOS command uses the Rust version in `rust-toolchain.toml` (`1.97.0`).
+Install Rustup once rather than relying on Homebrew's system Cargo:
 
 ```bash
 brew install rustup
@@ -180,22 +180,23 @@ brew install rustup
 The build commands detect Homebrew's keg-only Rustup installation. On other
 platforms, install Rustup with the standard installer.
 
-The MiSTer command also needs Docker Desktop and Cross. `cross` is a small
-host-side Docker launcher; the compiler and Rust dependencies run inside its
-container:
+The MiSTer command needs Docker Desktop with Buildx. First use creates the
+Dashboard image `zaparoo-slint-mister:local`; later code builds reuse it and
+only run Cargo in a temporary container. Its compiler and pinned Rust toolchain
+stay in Docker; no host Cross, Cargo target, or compiler is needed. Rebuild it
+only after a toolchain change:
 
 ```bash
-cargo install cross
+SLINT_MISTER_REBUILD_TOOLCHAIN=1 just slint-mister
 ```
 
 Outputs are `rust/target/release/frontend-slint` (macOS) and
 `rust/target/armv7-unknown-linux-musleabihf/release/frontend-slint` (MiSTer).
 `just slint-arm32` remains as an alias for `just slint-mister`.
 
-On Apple Silicon, the MiSTer command uses Docker's `linux/amd64` emulation:
-Cross's ARM32-musl build image is amd64-only. Override only when using a
-compatible custom image, for example
-`CROSS_DOCKER_PLATFORM=linux/amd64 just slint-mister`.
+On Apple Silicon, the MiSTer command uses Docker's `linux/amd64` emulation.
+Override only for a compatible custom toolchain image, for example
+`DOCKER_PLATFORM=linux/amd64 just slint-mister`.
 
 ## ARM64 cross-build
 

--- a/justfile
+++ b/justfile
@@ -286,10 +286,18 @@ test-slint:
     # dual head); they only build under that feature.
     cd rust && cargo nextest run -p frontend-slint --no-default-features --features mister
 
+# Native macOS Slint release build. Uses the Rust version pinned by the repo.
+slint-macos:
+    ./scripts/build-slint-macos.sh
+
 # Static ARM32 musl MiSTer build via `cross` (Cortex-A9 tuning). Static musl
 # because the MiSTer rootfs glibc is older than cross's gnueabihf image.
+slint-mister:
+    ./scripts/build-slint-mister.sh
+
+# Compatibility alias for the original MiSTer Slint build command.
 slint-arm32:
-    cd rust && ZAPAROO_RESOURCES_DIR="$PWD/../resources" RUSTFLAGS="-C target-cpu=cortex-a9" cross build -p frontend-slint --release --no-default-features --features mister --target armv7-unknown-linux-musleabihf
+    just slint-mister
 
 # MiSTer release bundle for the Slint frontend (zaparoo-frontend-<tag>-slint.zip);
 # same wrapper and layout as `release-zip`, one static binary with everything embedded.

--- a/justfile
+++ b/justfile
@@ -290,8 +290,7 @@ test-slint:
 slint-macos:
     ./scripts/build-slint-macos.sh
 
-# Static ARM32 musl MiSTer build via `cross` (Cortex-A9 tuning). Static musl
-# because the MiSTer rootfs glibc is older than cross's gnueabihf image.
+# Static ARM32 musl MiSTer Docker build (Cortex-A9; avoids old MiSTer glibc).
 slint-mister:
     ./scripts/build-slint-mister.sh
 

--- a/scripts/build-slint-macos.sh
+++ b/scripts/build-slint-macos.sh
@@ -30,8 +30,7 @@ if ! command -v rustup > /dev/null 2>&1; then
 Error: Rustup is required for Slint builds.
 
 Install it with:
-  brew install rustup-init
-  rustup-init -y --default-toolchain 1.97.0 --profile minimal
+  brew install rustup
 EOF
     exit 1
 fi

--- a/scripts/build-slint-macos.sh
+++ b/scripts/build-slint-macos.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Zaparoo Frontend
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+# SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+#
+# Build the Slint frontend for the host macOS machine.  The repository's
+# rust-toolchain.toml is authoritative; use rustup so Homebrew Rust cannot
+# silently build it with a different compiler.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+PROJECT_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd -P)"
+CARGO_BIN="${CARGO_HOME:-${HOME}/.cargo}/bin"
+
+# Cargo-installed tools (including cross) live here.  Homebrew's rustup is
+# keg-only, so also expose its bin directory when it is present.
+if [ -d "$CARGO_BIN" ]; then
+    export PATH="$CARGO_BIN:$PATH"
+fi
+if ! command -v rustup > /dev/null 2>&1 && command -v brew > /dev/null 2>&1; then
+    BREW_RUSTUP_BIN="$(brew --prefix rustup 2> /dev/null || true)/bin"
+    if [ -x "$BREW_RUSTUP_BIN/rustup" ]; then
+        export PATH="$BREW_RUSTUP_BIN:$PATH"
+    fi
+fi
+
+if ! command -v rustup > /dev/null 2>&1; then
+    cat >&2 <<'EOF'
+Error: Rustup is required for Slint builds.
+
+Install it with:
+  brew install rustup-init
+  rustup-init -y --default-toolchain 1.97.0 --profile minimal
+EOF
+    exit 1
+fi
+
+echo "=== Building Slint frontend for macOS ==="
+(cd "$PROJECT_ROOT/rust" && rustup run 1.97.0 cargo build -p frontend-slint --release)
+echo "Built: $PROJECT_ROOT/rust/target/release/frontend-slint"

--- a/scripts/build-slint-mister.sh
+++ b/scripts/build-slint-mister.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Zaparoo Frontend
+# Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
+# SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
+#
+# Build the Slint frontend for MiSTer. Cross launches Docker's static-musl
+# ARM32 toolchain; Rust and the target dependencies stay in that container.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+PROJECT_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd -P)"
+TARGET="armv7-unknown-linux-musleabihf"
+BINARY="$PROJECT_ROOT/rust/target/$TARGET/release/frontend-slint"
+CARGO_BIN="${CARGO_HOME:-${HOME}/.cargo}/bin"
+# Cross's published ARM32-musl image is amd64-only. Docker Desktop otherwise
+# selects the Apple Silicon host platform and fails before Cross can build.
+# Keep both knobs because Cross uses `docker build` for Cross.toml's pre-build
+# hook, then `docker run` for the actual compilation container.
+CROSS_DOCKER_PLATFORM="${CROSS_DOCKER_PLATFORM:-linux/amd64}"
+
+# `cargo install cross` writes next to rustup.  Make that bin directory
+# available for this command even when the user's shell profile omitted it.
+if [ -d "$CARGO_BIN" ]; then
+    export PATH="$CARGO_BIN:$PATH"
+fi
+# Homebrew's rustup is keg-only.  Find it here rather than requiring a
+# user-specific shell-profile edit before the project commands can work.
+if ! command -v rustup > /dev/null 2>&1 && command -v brew > /dev/null 2>&1; then
+    BREW_RUSTUP_BIN="$(brew --prefix rustup 2> /dev/null || true)/bin"
+    if [ -x "$BREW_RUSTUP_BIN/rustup" ]; then
+        export PATH="$BREW_RUSTUP_BIN:$PATH"
+    fi
+fi
+
+if ! command -v rustup > /dev/null 2>&1; then
+    cat >&2 <<'EOF'
+Error: Rustup is required for the MiSTer Slint build.
+
+Install it with:
+  brew install rustup-init
+  rustup-init -y --default-toolchain 1.97.0 --profile minimal
+EOF
+    exit 1
+fi
+
+if ! command -v cross > /dev/null 2>&1; then
+    cat >&2 <<'EOF'
+Error: Cross is required for the MiSTer Slint build.
+
+Install it with:
+  cargo install cross
+EOF
+    exit 1
+fi
+
+if ! docker info > /dev/null 2>&1; then
+    echo "Error: Docker Desktop must be running for the MiSTer Slint build." >&2
+    exit 1
+fi
+
+TOOLCHAIN_CARGO="$(rustup which --toolchain 1.97.0 cargo)"
+TOOLCHAIN_RUSTC="$(rustup which --toolchain 1.97.0 rustc)"
+
+echo "=== Cross-building Slint frontend for MiSTer (${TARGET}, Cortex-A9) ==="
+echo "Docker platform: $CROSS_DOCKER_PLATFORM"
+(cd "$PROJECT_ROOT/rust" && \
+    ZAPAROO_RESOURCES_DIR="$PROJECT_ROOT/resources" \
+    RUSTFLAGS="-C target-cpu=cortex-a9" \
+    RUSTUP_TOOLCHAIN=1.97.0 \
+    CARGO="$TOOLCHAIN_CARGO" \
+    RUSTC="$TOOLCHAIN_RUSTC" \
+    CROSS_BUILD_OPTS="${CROSS_BUILD_OPTS:---platform=$CROSS_DOCKER_PLATFORM}" \
+    CROSS_CONTAINER_OPTS="${CROSS_CONTAINER_OPTS:---platform $CROSS_DOCKER_PLATFORM}" \
+    rustup run 1.97.0 cross build -p frontend-slint --release \
+        --no-default-features --features mister --target "$TARGET")
+echo "Built: $BINARY"

--- a/scripts/build-slint-mister.sh
+++ b/scripts/build-slint-mister.sh
@@ -3,8 +3,8 @@
 # Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 #
-# Build the Slint frontend for MiSTer. Cross launches Docker's static-musl
-# ARM32 toolchain; Rust and the target dependencies stay in that container.
+# Build the Slint frontend for MiSTer. Docker owns a persistent static-musl
+# ARM32 toolchain image; source builds run inside it without rebuilding it.
 
 set -euo pipefail
 
@@ -12,66 +12,45 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 PROJECT_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd -P)"
 TARGET="armv7-unknown-linux-musleabihf"
 BINARY="$PROJECT_ROOT/rust/target/$TARGET/release/frontend-slint"
-CARGO_BIN="${CARGO_HOME:-${HOME}/.cargo}/bin"
-# Cross's published ARM32-musl image is amd64-only. Docker Desktop otherwise
-# selects the Apple Silicon host platform and fails before Cross can build.
-# Keep both knobs because Cross uses `docker build` for Cross.toml's pre-build
-# hook, then `docker run` for the actual compilation container.
-CROSS_DOCKER_PLATFORM="${CROSS_DOCKER_PLATFORM:-linux/amd64}"
+DOCKER_PLATFORM="${DOCKER_PLATFORM:-linux/amd64}"
+TOOLCHAIN_IMAGE="${SLINT_MISTER_IMAGE:-zaparoo-slint-mister:local}"
+CROSS_IMAGE="${SLINT_MISTER_BASE_IMAGE:-ghcr.io/cross-rs/armv7-unknown-linux-musleabihf:main}"
 
-# `cargo install cross` writes next to rustup.  Make that bin directory
-# available for this command even when the user's shell profile omitted it.
-if [ -d "$CARGO_BIN" ]; then
-    export PATH="$CARGO_BIN:$PATH"
-fi
-# Homebrew's rustup is keg-only.  Find it here rather than requiring a
-# user-specific shell-profile edit before the project commands can work.
-if ! command -v rustup > /dev/null 2>&1 && command -v brew > /dev/null 2>&1; then
-    BREW_RUSTUP_BIN="$(brew --prefix rustup 2> /dev/null || true)/bin"
-    if [ -x "$BREW_RUSTUP_BIN/rustup" ]; then
-        export PATH="$BREW_RUSTUP_BIN:$PATH"
-    fi
-fi
-
-if ! command -v rustup > /dev/null 2>&1; then
-    cat >&2 <<'EOF'
-Error: Rustup is required for the MiSTer Slint build.
-
-Install it with:
-  brew install rustup-init
-  rustup-init -y --default-toolchain 1.97.0 --profile minimal
-EOF
+if ! docker buildx version > /dev/null 2>&1; then
+    echo "Error: Docker Buildx is required for the MiSTer Slint build." >&2
     exit 1
 fi
 
-if ! command -v cross > /dev/null 2>&1; then
-    cat >&2 <<'EOF'
-Error: Cross is required for the MiSTer Slint build.
-
-Install it with:
-  cargo install cross
-EOF
-    exit 1
+if [ "${SLINT_MISTER_REBUILD_TOOLCHAIN:-0}" = "1" ] || \
+        ! docker image inspect "$TOOLCHAIN_IMAGE" > /dev/null 2>&1; then
+    echo "=== Creating MiSTer Slint toolchain image: $TOOLCHAIN_IMAGE ==="
+    docker buildx build \
+        --platform "$DOCKER_PLATFORM" \
+        -f "$PROJECT_ROOT/Dockerfile.slint-arm32" \
+        --build-arg "CROSS_IMAGE=$CROSS_IMAGE" \
+        --target toolchain \
+        --tag "$TOOLCHAIN_IMAGE" \
+        --load \
+        "$PROJECT_ROOT"
+else
+    echo "=== Reusing MiSTer Slint toolchain image: $TOOLCHAIN_IMAGE ==="
 fi
 
-if ! docker info > /dev/null 2>&1; then
-    echo "Error: Docker Desktop must be running for the MiSTer Slint build." >&2
+echo "=== Building Slint frontend for MiSTer (${TARGET}, Cortex-A9) ==="
+echo "Docker platform: $DOCKER_PLATFORM"
+docker run --rm \
+    --platform "$DOCKER_PLATFORM" \
+    --mount "type=bind,source=$PROJECT_ROOT,target=/src" \
+    --workdir /src/rust \
+    --env ZAPAROO_RESOURCES_DIR=/src/resources \
+    --env 'RUSTFLAGS=-C target-cpu=cortex-a9' \
+    "$TOOLCHAIN_IMAGE" \
+    cargo +1.97.0 build -p frontend-slint --release \
+        --no-default-features --features mister \
+        --target "$TARGET"
+
+if [ ! -x "$BINARY" ]; then
+    echo "Error: MiSTer binary was not written to $BINARY" >&2
     exit 1
 fi
-
-TOOLCHAIN_CARGO="$(rustup which --toolchain 1.97.0 cargo)"
-TOOLCHAIN_RUSTC="$(rustup which --toolchain 1.97.0 rustc)"
-
-echo "=== Cross-building Slint frontend for MiSTer (${TARGET}, Cortex-A9) ==="
-echo "Docker platform: $CROSS_DOCKER_PLATFORM"
-(cd "$PROJECT_ROOT/rust" && \
-    ZAPAROO_RESOURCES_DIR="$PROJECT_ROOT/resources" \
-    RUSTFLAGS="-C target-cpu=cortex-a9" \
-    RUSTUP_TOOLCHAIN=1.97.0 \
-    CARGO="$TOOLCHAIN_CARGO" \
-    RUSTC="$TOOLCHAIN_RUSTC" \
-    CROSS_BUILD_OPTS="${CROSS_BUILD_OPTS:---platform=$CROSS_DOCKER_PLATFORM}" \
-    CROSS_CONTAINER_OPTS="${CROSS_CONTAINER_OPTS:---platform $CROSS_DOCKER_PLATFORM}" \
-    rustup run 1.97.0 cross build -p frontend-slint --release \
-        --no-default-features --features mister --target "$TARGET")
 echo "Built: $BINARY"

--- a/scripts/deploy-mister-slint.sh
+++ b/scripts/deploy-mister-slint.sh
@@ -3,8 +3,8 @@
 # Copyright (c) 2026 Wizzo Pty Ltd and the Zaparoo Project contributors.
 # SPDX-License-Identifier: LicenseRef-PolyForm-Noncommercial-1.0.0
 #
-# Slint frontend: cross-builds the ARM32 binary with `cross` and deploys
-# it to a MiSTer over SSH/SCP. It is one static file with every font and
+# Slint frontend: Docker-builds the ARM32 binary and deploys it to a MiSTer
+# over SSH/SCP. It is one static file with every font and
 # logo embedded, like the Qt binary; nothing else is copied. By default it
 # lands beside the Qt frontend as /media/fat/zaparoo/frontend-slint for
 # manual testing; --replace backs up the Qt frontend and installs the

--- a/scripts/deploy-mister-slint.sh
+++ b/scripts/deploy-mister-slint.sh
@@ -40,12 +40,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 if [ "${SKIP_BUILD}" -eq 0 ]; then
-    echo "=== Cross-building frontend-slint (${TARGET}, Cortex-A9) ==="
-    (cd "${PROJECT_ROOT}/rust" &&
-        ZAPAROO_RESOURCES_DIR="${PROJECT_ROOT}/resources" \
-        RUSTFLAGS="-C target-cpu=cortex-a9" \
-        cross build -p frontend-slint --release \
-            --no-default-features --features mister --target "${TARGET}")
+    "${SCRIPT_DIR}/build-slint-mister.sh"
 fi
 
 if [ ! -f "${BINARY}" ]; then


### PR DESCRIPTION
## Summary

<!-- What changed, and why? One or two sentences is usually enough. -->

## Motivation

<!-- Link the issue or discussion that led to this. Delete this section if it does not apply. -->

## Screenshots / recordings

<!-- Required for visual changes. Include the FPS counter at 720p and, if possible, 240p. -->

## Test plan

<!-- How did you verify this? Manual steps and automated tests are both fine. -->

## Checklist

- [ ] `just lint` is green (zero warnings)
- [ ] `just test` passes
- [ ] If this touches QML, the FPS counter stays green (≥ 55) at 720p+ and ≥ 30 at 240p
- [ ] If this could affect the MiSTer build, I considered ARM32 implications (see `docs/architecture.md`)
- [ ] If this adds user-visible strings, they are wrapped in `qsTr()` (QML) or `tr()` (C++)
- [ ] I have signed the [CLA](../.github/CLA.md) (first-time contributors only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added supported build commands for the Slint frontend on macOS and MiSTer.
  - Added automated cross-compilation for MiSTer’s ARM32 target, including Docker platform support for Apple Silicon.
  - Existing ARM32 build command remains available as a compatibility alias.
  - Build scripts now provide checks and guidance for required tools such as Rustup, Cross, and Docker.

- **Documentation**
  - Added setup instructions, build commands, output locations, and platform-specific requirements for Slint builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->